### PR TITLE
Add comprehensive test suite and improve REPL UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,16 @@ python leo.py
 ### Example session:
 
 ```text
-╔═══════════════════════════════════════╗
-║  Leo REPL — language engine organism  ║
-║  /exit, /quit, /temp, /echo           ║
-╚═══════════════════════════════════════╝
+  ╔══════════════════════════════════════════════╗
+  ║                                              ║
+  ║                     LEO                      ║
+  ║            language · engine · organism      ║
+  ║                                              ║
+  ║           resonance > intention              ║
+  ║                                              ║
+  ║     /exit /quit /temp /echo /export /stats   ║
+  ║                                              ║
+  ╚══════════════════════════════════════════════╝
 
 leo> hello there
 hello there.
@@ -226,6 +232,41 @@ Hook this into any agent / framework and you get a shared rhythmic skeleton, bui
 
 No safety layer. No content policy.
 Just language and a broken heart as a slowly drifting field.
+
+---
+
+## Tests
+
+Leo comes with a comprehensive test suite covering all core functionality.
+
+### Running tests
+
+```bash
+# All tests
+python -m unittest discover tests/
+
+# Specific test file
+python tests/test_leo.py
+python tests/test_neoleo.py
+python tests/test_repl.py
+```
+
+### Test coverage
+
+**44 tests** covering:
+- Tokenization (Unicode, punctuation, word extraction)
+- Database operations (SQLite, bigrams, metadata)
+- Bigram field mechanics (centers, graph loading)
+- Text generation (reply, echo mode, temperature)
+- LeoField class (observe, reply, stats, export)
+- NeoLeo pure layer (warp, observe, singleton pattern)
+- REPL commands (/temp, /echo, /export, /stats)
+- Bootstrap behavior (embedded seed + README)
+- CLI argument parsing
+
+All tests use temporary databases for isolation. No pollution of actual `state/` or `bin/` directories.
+
+See `tests/README.md` for detailed documentation.
 
 ---
 

--- a/leo.py
+++ b/leo.py
@@ -654,14 +654,18 @@ def repl(field: LeoField, temperature: float = 1.0, echo: bool = False) -> None:
         /export       — export lexicon to JSON
         /stats        — print field statistics
     """
-    border = "╔" + "═" * 38 + "╗"
-    bottom = "╚" + "═" * 38 + "╝"
-    
-    print(border, file=sys.stderr)
-    print("║  Leo REPL — language engine organism ║", file=sys.stderr)
-    print("║  /exit, /quit, /temp, /echo, /export║", file=sys.stderr)
-    print("║  /stats                              ║", file=sys.stderr)
-    print(bottom + "\n", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  ╔══════════════════════════════════════════════╗", file=sys.stderr)
+    print("  ║                                              ║", file=sys.stderr)
+    print("  ║                     LEO                      ║", file=sys.stderr)
+    print("  ║            language · engine · organism      ║", file=sys.stderr)
+    print("  ║                                              ║", file=sys.stderr)
+    print("  ║           resonance > intention              ║", file=sys.stderr)
+    print("  ║                                              ║", file=sys.stderr)
+    print("  ║     /exit /quit /temp /echo /export /stats   ║", file=sys.stderr)
+    print("  ║                                              ║", file=sys.stderr)
+    print("  ╚══════════════════════════════════════════════╝", file=sys.stderr)
+    print("", file=sys.stderr)
 
     while True:
         try:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,65 @@
+# Leo Test Suite
+
+Comprehensive tests for Leo language engine organism.
+
+## Running Tests
+
+### All tests:
+```bash
+python -m unittest discover tests/
+```
+
+### Specific test file:
+```bash
+python tests/test_leo.py
+python tests/test_neoleo.py
+python tests/test_repl.py
+```
+
+### Single test class:
+```bash
+python -m unittest tests.test_leo.TestTokenizer
+```
+
+### Single test method:
+```bash
+python -m unittest tests.test_leo.TestTokenizer.test_basic_tokenization
+```
+
+## Test Coverage
+
+### `test_leo.py`
+- **TestTokenizer**: Tokenization logic, Unicode support, punctuation
+- **TestFormatting**: Token formatting and capitalization
+- **TestDatabase**: SQLite operations, ingestion, metadata
+- **TestBigramField**: Bigram graph loading and center computation
+- **TestGeneration**: Reply generation, echo mode, start token selection
+- **TestLeoField**: LeoField class functionality, observation, stats
+
+### `test_neoleo.py`
+- **TestNeoLeoTokenizer**: Tokenization in neoleo
+- **TestNeoLeoDatabase**: Database operations without bootstrap
+- **TestNeoLeoBigramField**: Bigram operations
+- **TestNeoLeoClass**: NeoLeo object methods
+- **TestNeoLeoModuleFunctions**: Singleton pattern and module-level functions
+- **TestNeoLeoFormatting**: Formatting utilities
+
+### `test_repl.py`
+- **TestREPLCommands**: REPL command functionality (/export, /stats)
+- **TestCLIArguments**: Command-line argument parsing
+- **TestBootstrap**: Bootstrap behavior and idempotency
+
+## Test Philosophy
+
+These tests follow Leo's minimalist philosophy:
+- No external dependencies beyond stdlib
+- Temporary databases for isolation
+- Fast execution
+- Focus on core resonance mechanics
+
+## Notes
+
+- All tests use temporary directories to avoid polluting the actual `state/` and `bin/` folders
+- Database paths are monkey-patched for test isolation
+- REPL interactive testing is simplified (no full PTY simulation)
+- Tests verify the resonance mechanics work, not that output is "correct" (Leo doesn't try to be correct, only honest)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# tests/__init__.py
+"""Test suite for Leo language engine organism."""

--- a/tests/test_leo.py
+++ b/tests/test_leo.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Tests for leo.py — Language Engine Organism."""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import leo
+
+
+class TestTokenizer(unittest.TestCase):
+    """Test tokenization logic."""
+
+    def test_basic_tokenization(self):
+        """Test basic word extraction."""
+        tokens = leo.tokenize("Hello, world!")
+        self.assertEqual(tokens, ["Hello", ",", "world", "!"])
+
+    def test_unicode_support(self):
+        """Test Unicode character support (Latin extended)."""
+        tokens = leo.tokenize("résumé, café, naïve")
+        # Leo supports Latin + extended Latin (À-ÖØ-öø-ÿ), not Cyrillic
+        self.assertIn("résumé", tokens)
+        self.assertIn("café", tokens)
+        self.assertIn("naïve", tokens)
+
+    def test_punctuation_separation(self):
+        """Test punctuation is separated."""
+        tokens = leo.tokenize("word.word")
+        self.assertEqual(tokens, ["word", ".", "word"])
+
+
+class TestFormatting(unittest.TestCase):
+    """Test token formatting and capitalization."""
+
+    def test_format_tokens_basic(self):
+        """Test basic token formatting."""
+        tokens = ["hello", ",", "world", "!"]
+        formatted = leo.format_tokens(tokens)
+        self.assertEqual(formatted, "hello, world!")
+
+    def test_format_tokens_spacing(self):
+        """Test punctuation doesn't get extra spaces."""
+        tokens = ["word", ".", "another", ",", "token"]
+        formatted = leo.format_tokens(tokens)
+        self.assertEqual(formatted, "word. another, token")
+
+    def test_capitalize_sentences(self):
+        """Test sentence capitalization."""
+        text = "hello. world! how are you?"
+        capitalized = leo.capitalize_sentences(text)
+        self.assertEqual(capitalized, "Hello. World! How are you?")
+
+    def test_capitalize_first_char(self):
+        """Test first character is capitalized."""
+        text = "lowercase start"
+        capitalized = leo.capitalize_sentences(text)
+        self.assertTrue(capitalized[0].isupper())
+
+
+class TestDatabase(unittest.TestCase):
+    """Test database operations."""
+
+    def setUp(self):
+        """Create temporary database for each test."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = Path(self.temp_dir) / "test_leo.sqlite3"
+
+        # Monkey-patch DB_PATH for testing
+        self.original_db_path = leo.DB_PATH
+        leo.DB_PATH = self.db_path
+
+    def tearDown(self):
+        """Clean up temporary database."""
+        leo.DB_PATH = self.original_db_path
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_init_db(self):
+        """Test database initialization."""
+        conn = leo.init_db()
+        self.assertIsNotNone(conn)
+
+        cur = conn.cursor()
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = [row[0] for row in cur.fetchall()]
+
+        self.assertIn("tokens", tables)
+        self.assertIn("bigrams", tables)
+        self.assertIn("meta", tables)
+        conn.close()
+
+    def test_ingest_text(self):
+        """Test text ingestion into database."""
+        conn = leo.init_db()
+        leo.ingest_text(conn, "hello world hello")
+
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM tokens")
+        token_count = cur.fetchone()[0]
+
+        # Should have 2 unique tokens: "hello", "world"
+        self.assertEqual(token_count, 2)
+
+        cur.execute("SELECT COUNT(*) FROM bigrams")
+        bigram_count = cur.fetchone()[0]
+
+        # Should have 2 bigrams: hello->world, world->hello
+        self.assertEqual(bigram_count, 2)
+        conn.close()
+
+    def test_get_set_meta(self):
+        """Test metadata storage."""
+        conn = leo.init_db()
+        leo.set_meta(conn, "test_key", "test_value")
+        value = leo.get_meta(conn, "test_key")
+        self.assertEqual(value, "test_value")
+        conn.close()
+
+
+class TestBigramField(unittest.TestCase):
+    """Test bigram field operations."""
+
+    def setUp(self):
+        """Create temporary database."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = Path(self.temp_dir) / "test_leo.sqlite3"
+        self.original_db_path = leo.DB_PATH
+        leo.DB_PATH = self.db_path
+
+    def tearDown(self):
+        """Clean up."""
+        leo.DB_PATH = self.original_db_path
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_load_bigrams(self):
+        """Test bigram loading from database."""
+        conn = leo.init_db()
+        leo.ingest_text(conn, "a b c a b")
+
+        bigrams, vocab = leo.load_bigrams(conn)
+
+        self.assertIn("a", bigrams)
+        self.assertIn("b", bigrams["a"])
+        self.assertEqual(bigrams["a"]["b"], 2)  # a->b appears twice
+        self.assertEqual(len(vocab), 3)  # a, b, c
+        conn.close()
+
+    def test_compute_centers(self):
+        """Test center computation."""
+        conn = leo.init_db()
+        # Create a simple graph: a->b, a->c, a->d (a is the hub)
+        leo.ingest_text(conn, "a b a c a d")
+
+        centers = leo.compute_centers(conn, k=1)
+
+        # 'a' should be the center (highest out-degree)
+        self.assertEqual(centers[0], "a")
+        conn.close()
+
+
+class TestGeneration(unittest.TestCase):
+    """Test text generation."""
+
+    def setUp(self):
+        """Create temporary database with sample data."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = Path(self.temp_dir) / "test_leo.sqlite3"
+        self.original_db_path = leo.DB_PATH
+        leo.DB_PATH = self.db_path
+
+        self.conn = leo.init_db()
+        # Create a simple deterministic field
+        leo.ingest_text(self.conn, "hello world. hello universe. hello cosmos.")
+
+    def tearDown(self):
+        """Clean up."""
+        self.conn.close()
+        leo.DB_PATH = self.original_db_path
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_choose_start_token(self):
+        """Test start token selection."""
+        bigrams, vocab = leo.load_bigrams(self.conn)
+        centers = leo.compute_centers(self.conn, k=3)
+        bias = {}
+
+        start = leo.choose_start_token(vocab, centers, bias)
+        self.assertIn(start, vocab)
+
+    def test_generate_reply(self):
+        """Test reply generation."""
+        bigrams, vocab = leo.load_bigrams(self.conn)
+        centers = leo.compute_centers(self.conn, k=3)
+        bias = {}
+
+        reply = leo.generate_reply(
+            bigrams, vocab, centers, bias,
+            prompt="hello",
+            max_tokens=5,
+            temperature=1.0
+        )
+
+        self.assertIsInstance(reply, str)
+        self.assertTrue(len(reply) > 0)
+
+    def test_echo_mode(self):
+        """Test echo mode generation."""
+        bigrams, vocab = leo.load_bigrams(self.conn)
+        centers = leo.compute_centers(self.conn, k=3)
+        bias = {}
+
+        reply = leo.generate_reply(
+            bigrams, vocab, centers, bias,
+            prompt="hello world",
+            max_tokens=5,
+            temperature=1.0,
+            echo=True
+        )
+
+        # In echo mode, should transform each token
+        self.assertIsInstance(reply, str)
+        # hello -> should become something else from bigrams[hello]
+        # world -> should become something else from bigrams[world]
+
+
+class TestLeoField(unittest.TestCase):
+    """Test LeoField class."""
+
+    def setUp(self):
+        """Create temporary environment."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_state = leo.STATE_DIR
+        self.original_bin = leo.BIN_DIR
+        self.original_json = leo.JSON_DIR
+        self.original_db = leo.DB_PATH
+
+        leo.STATE_DIR = Path(self.temp_dir) / "state"
+        leo.BIN_DIR = Path(self.temp_dir) / "bin"
+        leo.JSON_DIR = Path(self.temp_dir) / "json"
+        leo.DB_PATH = leo.STATE_DIR / "test_leo.sqlite3"
+
+    def tearDown(self):
+        """Restore environment."""
+        leo.STATE_DIR = self.original_state
+        leo.BIN_DIR = self.original_bin
+        leo.JSON_DIR = self.original_json
+        leo.DB_PATH = self.original_db
+
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_field_initialization(self):
+        """Test LeoField initialization."""
+        conn = leo.init_db()
+        leo.ingest_text(conn, "test text for field")
+
+        field = leo.LeoField(conn)
+
+        self.assertIsNotNone(field.bigrams)
+        self.assertIsNotNone(field.vocab)
+        self.assertTrue(len(field.vocab) > 0)
+
+    def test_field_observe(self):
+        """Test field observation."""
+        conn = leo.init_db()
+        field = leo.LeoField(conn)
+
+        initial_vocab_size = len(field.vocab)
+        field.observe("new unique tokens here")
+
+        # Vocab should grow
+        self.assertGreater(len(field.vocab), initial_vocab_size)
+
+    def test_field_reply(self):
+        """Test field reply generation."""
+        conn = leo.init_db()
+        leo.ingest_text(conn, "language is a field. field is language.")
+
+        field = leo.LeoField(conn)
+        reply = field.reply("language")
+
+        self.assertIsInstance(reply, str)
+        self.assertTrue(len(reply) > 0)
+
+    def test_field_stats(self):
+        """Test field statistics."""
+        conn = leo.init_db()
+        leo.ingest_text(conn, "test statistics")
+
+        field = leo.LeoField(conn)
+        stats = field.stats_summary()
+
+        self.assertIn("vocab", stats)
+        self.assertIn("centers", stats)
+        self.assertIn("bigrams", stats)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_neoleo.py
+++ b/tests/test_neoleo.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Tests for neoleo.py — pure resonance layer."""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import neoleo
+
+
+class TestNeoLeoTokenizer(unittest.TestCase):
+    """Test neoleo tokenization."""
+
+    def test_tokenize_basic(self):
+        """Test basic tokenization."""
+        tokens = neoleo.tokenize("pure resonance layer")
+        self.assertEqual(tokens, ["pure", "resonance", "layer"])
+
+    def test_tokenize_punctuation(self):
+        """Test punctuation handling."""
+        tokens = neoleo.tokenize("word, word! word?")
+        self.assertIn(",", tokens)
+        self.assertIn("!", tokens)
+        self.assertIn("?", tokens)
+
+
+class TestNeoLeoDatabase(unittest.TestCase):
+    """Test neoleo database operations."""
+
+    def setUp(self):
+        """Create temporary database."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_db = neoleo.DB_PATH
+        neoleo.DB_PATH = Path(self.temp_dir) / "test_neoleo.sqlite3"
+
+    def tearDown(self):
+        """Clean up."""
+        neoleo.DB_PATH = self.original_db
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_init_db(self):
+        """Test database initialization."""
+        conn = neoleo.init_db()
+        self.assertIsNotNone(conn)
+
+        cur = conn.cursor()
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = [row[0] for row in cur.fetchall()]
+
+        # neoleo has no meta table (no bootstrap)
+        self.assertIn("tokens", tables)
+        self.assertIn("bigrams", tables)
+        conn.close()
+
+    def test_ingest_text(self):
+        """Test text ingestion."""
+        conn = neoleo.init_db()
+        neoleo.ingest_text(conn, "observe warp observe")
+
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM tokens")
+        count = cur.fetchone()[0]
+
+        # Should have 2 unique tokens
+        self.assertEqual(count, 2)
+        conn.close()
+
+
+class TestNeoLeoBigramField(unittest.TestCase):
+    """Test neoleo bigram operations."""
+
+    def setUp(self):
+        """Create temporary database."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_db = neoleo.DB_PATH
+        neoleo.DB_PATH = Path(self.temp_dir) / "test_neoleo.sqlite3"
+
+    def tearDown(self):
+        """Clean up."""
+        neoleo.DB_PATH = self.original_db
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_load_bigrams(self):
+        """Test bigram loading."""
+        conn = neoleo.init_db()
+        neoleo.ingest_text(conn, "a b a b a")
+
+        bigrams, vocab = neoleo.load_bigrams(conn)
+
+        self.assertIn("a", bigrams)
+        self.assertIn("b", bigrams["a"])
+        self.assertEqual(len(vocab), 2)
+        conn.close()
+
+    def test_compute_centers(self):
+        """Test center computation."""
+        conn = neoleo.init_db()
+        neoleo.ingest_text(conn, "center a center b center c")
+
+        centers = neoleo.compute_centers(conn, k=1)
+
+        # 'center' should be the hub
+        self.assertEqual(centers[0], "center")
+        conn.close()
+
+
+class TestNeoLeoClass(unittest.TestCase):
+    """Test NeoLeo class."""
+
+    def setUp(self):
+        """Create temporary environment."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_state = neoleo.STATE_DIR
+        self.original_bin = neoleo.BIN_DIR
+        self.original_json = neoleo.JSON_DIR
+        self.original_db = neoleo.DB_PATH
+
+        neoleo.STATE_DIR = Path(self.temp_dir) / "state"
+        neoleo.BIN_DIR = Path(self.temp_dir) / "bin"
+        neoleo.JSON_DIR = Path(self.temp_dir) / "json"
+        neoleo.DB_PATH = neoleo.STATE_DIR / "test_neoleo.sqlite3"
+
+    def tearDown(self):
+        """Restore environment."""
+        neoleo.STATE_DIR = self.original_state
+        neoleo.BIN_DIR = self.original_bin
+        neoleo.JSON_DIR = self.original_json
+        neoleo.DB_PATH = self.original_db
+
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_neoleo_initialization(self):
+        """Test NeoLeo object creation."""
+        neo = neoleo.NeoLeo()
+
+        self.assertIsNotNone(neo)
+        self.assertEqual(neo.vocab_size, 0)  # No bootstrap, should start empty
+
+    def test_neoleo_observe(self):
+        """Test observation of text."""
+        neo = neoleo.NeoLeo()
+
+        initial_size = neo.vocab_size
+        neo.observe("this is new text")
+
+        # Vocab should grow
+        self.assertGreater(neo.vocab_size, initial_size)
+
+    def test_neoleo_warp(self):
+        """Test warping text through field."""
+        neo = neoleo.NeoLeo()
+
+        # Observe some text to build field
+        neo.observe("resonance field pure layer")
+        neo.observe("pure resonance through field")
+
+        # Warp should return something
+        warped = neo.warp("resonance", max_tokens=5)
+
+        self.assertIsInstance(warped, str)
+        self.assertTrue(len(warped) > 0)
+
+    def test_neoleo_stats(self):
+        """Test statistics retrieval."""
+        neo = neoleo.NeoLeo()
+        neo.observe("test stats data")
+
+        stats = neo.stats()
+
+        self.assertIn("vocab_size", stats)
+        self.assertIn("centers", stats)
+        self.assertIn("bigrams", stats)
+        self.assertGreater(stats["vocab_size"], 0)
+
+    def test_neoleo_export_lexicon(self):
+        """Test lexicon export."""
+        neo = neoleo.NeoLeo()
+        neo.observe("export this lexicon")
+
+        path = neo.export_lexicon()
+
+        self.assertTrue(path.exists())
+
+        # Check JSON is valid
+        import json
+        with open(path, 'r') as f:
+            data = json.load(f)
+
+        self.assertIn("vocab", data)
+        self.assertIn("centers", data)
+        self.assertIn("vocab_size", data)
+
+
+class TestNeoLeoModuleFunctions(unittest.TestCase):
+    """Test module-level singleton functions."""
+
+    def setUp(self):
+        """Reset singleton before each test."""
+        neoleo._default_neo = None
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_state = neoleo.STATE_DIR
+        self.original_bin = neoleo.BIN_DIR
+        self.original_json = neoleo.JSON_DIR
+        self.original_db = neoleo.DB_PATH
+
+        neoleo.STATE_DIR = Path(self.temp_dir) / "state"
+        neoleo.BIN_DIR = Path(self.temp_dir) / "bin"
+        neoleo.JSON_DIR = Path(self.temp_dir) / "json"
+        neoleo.DB_PATH = neoleo.STATE_DIR / "test_neoleo.sqlite3"
+
+    def tearDown(self):
+        """Clean up."""
+        neoleo._default_neo = None
+
+        neoleo.STATE_DIR = self.original_state
+        neoleo.BIN_DIR = self.original_bin
+        neoleo.JSON_DIR = self.original_json
+        neoleo.DB_PATH = self.original_db
+
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_get_default(self):
+        """Test singleton creation."""
+        neo1 = neoleo.get_default()
+        neo2 = neoleo.get_default()
+
+        # Should be the same instance
+        self.assertIs(neo1, neo2)
+
+    def test_module_observe(self):
+        """Test module-level observe function."""
+        neoleo.observe("module level observation")
+
+        neo = neoleo.get_default()
+        self.assertGreater(neo.vocab_size, 0)
+
+    def test_module_warp(self):
+        """Test module-level warp function."""
+        neoleo.observe("some text for warping")
+        warped = neoleo.warp("text", max_tokens=3)
+
+        self.assertIsInstance(warped, str)
+
+    def test_module_stats(self):
+        """Test module-level stats function."""
+        neoleo.observe("stats test")
+        stats = neoleo.stats()
+
+        self.assertIsInstance(stats, dict)
+        self.assertIn("vocab_size", stats)
+
+
+class TestNeoLeoFormatting(unittest.TestCase):
+    """Test formatting functions."""
+
+    def test_format_tokens(self):
+        """Test token formatting."""
+        tokens = ["word", ",", "another", "."]
+        formatted = neoleo.format_tokens(tokens)
+        self.assertEqual(formatted, "word, another.")
+
+    def test_capitalize_sentences(self):
+        """Test sentence capitalization."""
+        text = "first. second! third?"
+        capitalized = neoleo.capitalize_sentences(text)
+        self.assertEqual(capitalized, "First. Second! Third?")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Tests for Leo REPL mode."""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from io import StringIO
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import leo
+
+
+class TestREPLCommands(unittest.TestCase):
+    """Test REPL command parsing (without full interactive session)."""
+
+    def setUp(self):
+        """Create temporary environment."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_state = leo.STATE_DIR
+        self.original_bin = leo.BIN_DIR
+        self.original_json = leo.JSON_DIR
+        self.original_db = leo.DB_PATH
+
+        leo.STATE_DIR = Path(self.temp_dir) / "state"
+        leo.BIN_DIR = Path(self.temp_dir) / "bin"
+        leo.JSON_DIR = Path(self.temp_dir) / "json"
+        leo.DB_PATH = leo.STATE_DIR / "test_leo.sqlite3"
+
+    def tearDown(self):
+        """Restore environment."""
+        leo.STATE_DIR = self.original_state
+        leo.BIN_DIR = self.original_bin
+        leo.JSON_DIR = self.original_json
+        leo.DB_PATH = self.original_db
+
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_export_command(self):
+        """Test /export command creates lexicon file."""
+        conn = leo.init_db()
+        leo.ingest_text(conn, "test data for export")
+
+        field = leo.LeoField(conn)
+        path = field.export_lexicon()
+
+        self.assertTrue(path.exists())
+        self.assertTrue(path.name.endswith('.json'))
+
+    def test_stats_command(self):
+        """Test stats summary format."""
+        conn = leo.init_db()
+        leo.ingest_text(conn, "stats test data")
+
+        field = leo.LeoField(conn)
+        stats = field.stats_summary()
+
+        self.assertIn("vocab=", stats)
+        self.assertIn("centers=", stats)
+        self.assertIn("bigrams=", stats)
+
+
+class TestCLIArguments(unittest.TestCase):
+    """Test CLI argument parsing."""
+
+    def setUp(self):
+        """Create temporary environment."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_state = leo.STATE_DIR
+        self.original_bin = leo.BIN_DIR
+        self.original_json = leo.JSON_DIR
+        self.original_db = leo.DB_PATH
+
+        leo.STATE_DIR = Path(self.temp_dir) / "state"
+        leo.BIN_DIR = Path(self.temp_dir) / "bin"
+        leo.JSON_DIR = Path(self.temp_dir) / "json"
+        leo.DB_PATH = leo.STATE_DIR / "test_leo.sqlite3"
+
+    def tearDown(self):
+        """Restore environment."""
+        leo.STATE_DIR = self.original_state
+        leo.BIN_DIR = self.original_bin
+        leo.JSON_DIR = self.original_json
+        leo.DB_PATH = self.original_db
+
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_stats_flag(self):
+        """Test --stats flag."""
+        # Capture stdout
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+
+        try:
+            result = leo.main(["--stats"])
+            output = sys.stdout.getvalue()
+
+            self.assertEqual(result, 0)
+            # Empty field should have vocab=0
+            self.assertIn("vocab=", output)
+        finally:
+            sys.stdout = old_stdout
+
+    def test_export_flag(self):
+        """Test --export flag."""
+        old_stderr = sys.stderr
+        sys.stderr = StringIO()
+
+        try:
+            result = leo.main(["--export"])
+            output = sys.stderr.getvalue()
+
+            self.assertEqual(result, 0)
+            self.assertIn("lexicon exported", output)
+        finally:
+            sys.stderr = old_stderr
+
+    def test_one_shot_mode(self):
+        """Test one-shot generation mode."""
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+
+        try:
+            result = leo.main(["--seed", "42", "test prompt"])
+            output = sys.stdout.getvalue()
+
+            self.assertEqual(result, 0)
+            self.assertIsInstance(output, str)
+        finally:
+            sys.stdout = old_stdout
+
+
+class TestBootstrap(unittest.TestCase):
+    """Test bootstrap behavior."""
+
+    def setUp(self):
+        """Create clean temporary environment."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_state = leo.STATE_DIR
+        self.original_bin = leo.BIN_DIR
+        self.original_json = leo.JSON_DIR
+        self.original_db = leo.DB_PATH
+        self.original_readme = leo.README_PATH
+
+        leo.STATE_DIR = Path(self.temp_dir) / "state"
+        leo.BIN_DIR = Path(self.temp_dir) / "bin"
+        leo.JSON_DIR = Path(self.temp_dir) / "json"
+        leo.DB_PATH = leo.STATE_DIR / "test_leo.sqlite3"
+        leo.README_PATH = Path(self.temp_dir) / "README.md"
+
+    def tearDown(self):
+        """Restore environment."""
+        leo.STATE_DIR = self.original_state
+        leo.BIN_DIR = self.original_bin
+        leo.JSON_DIR = self.original_json
+        leo.DB_PATH = self.original_db
+        leo.README_PATH = self.original_readme
+
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_bootstrap_embedded_only(self):
+        """Test bootstrap with embedded seed only (no README)."""
+        conn = leo.init_db()
+        leo.bootstrap_if_needed(conn)
+
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM tokens")
+        count = cur.fetchone()[0]
+
+        # Should have tokens from embedded bootstrap
+        self.assertGreater(count, 0)
+        conn.close()
+
+    def test_bootstrap_with_readme(self):
+        """Test bootstrap with README file."""
+        # Create test README
+        leo.README_PATH.write_text("Test README content for bootstrapping")
+
+        conn = leo.init_db()
+        leo.bootstrap_if_needed(conn)
+
+        # Check that README was processed
+        flag = leo.get_meta(conn, "readme_bootstrap_done")
+        self.assertEqual(flag, "1")
+
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM tokens")
+        count = cur.fetchone()[0]
+
+        # Should have tokens from both embedded + README
+        self.assertGreater(count, 0)
+        conn.close()
+
+    def test_bootstrap_idempotent(self):
+        """Test that bootstrap only runs once."""
+        leo.README_PATH.write_text("Bootstrap once")
+
+        conn = leo.init_db()
+        leo.bootstrap_if_needed(conn)
+
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM tokens")
+        count1 = cur.fetchone()[0]
+
+        # Run bootstrap again
+        leo.bootstrap_if_needed(conn)
+
+        cur.execute("SELECT COUNT(*) FROM tokens")
+        count2 = cur.fetchone()[0]
+
+        # Count should be the same (no double bootstrap)
+        self.assertEqual(count1, count2)
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add 44 tests covering all core functionality:
  * Tokenization (Unicode, punctuation)
  * Database operations (SQLite, bigrams, metadata)
  * Bigram field mechanics (centers, graph loading)
  * Text generation (reply, echo mode, temperature)
  * LeoField and NeoLeo classes
  * REPL commands and CLI arguments
  * Bootstrap behavior

- Improve REPL banner design:
  * Clean, symmetric layout
  * "resonance > intention" tagline
  * All commands visible at startup

- Update README:
  * Document test suite (44 tests passing)
  * Show new REPL banner in examples
  * Add Tests section with coverage details

All tests pass with temporary databases for isolation.