### PR TITLE
Fix spaced duplicate punctuation (GPT-5.1 suggestion)

### DIFF
--- a/leo.py
+++ b/leo.py
@@ -591,6 +591,8 @@ def fix_punctuation(text: str) -> str:
     text = re.sub(r",\.", ".", text)  # ",." → "."
     text = re.sub(r",;", ";", text)   # ",;" → ";"
     text = re.sub(r"\.,", ".", text)  # ".," → "."
+    # Collapse spaced duplicates: ". ." → ".", "? ?" → "?", "! !" → "!"
+    text = re.sub(r"([.!?])\s+\1", r"\1", text)
 
     # 4) Normalize weird dashes and em-dashes
     text = re.sub(r"\s*—\s*—\s*—\s*", " — ", text)  # " — — — " → " — "

--- a/neoleo.py
+++ b/neoleo.py
@@ -463,6 +463,8 @@ def fix_punctuation(text: str) -> str:
     text = re.sub(r",\.", ".", text)  # ",." → "."
     text = re.sub(r",;", ";", text)   # ",;" → ";"
     text = re.sub(r"\.,", ".", text)  # ".," → "."
+    # Collapse spaced duplicates: ". ." → ".", "? ?" → "?", "! !" → "!"
+    text = re.sub(r"([.!?])\s+\1", r"\1", text)
 
     # 4) Normalize weird dashes and em-dashes
     text = re.sub(r"\s*—\s*—\s*—\s*", " — ", text)  # " — — — " → " — "


### PR DESCRIPTION
Added regex to collapse spaced duplicate punctuation marks:
- ". ." → "."
- "? ?" → "?"
- "! !" → "!"

Pattern: ([.!?])\s+\1 → \1

Fixes artifacts like "honesty. . ThemeLayer" → "honesty. ThemeLayer" All 34 tests passing.

Credit: GPT-5.1 code review suggestion