### PR TITLE
Add wounded overthinking + pulse-aware ring weighting

### DIFF
--- a/leo.py
+++ b/leo.py
@@ -1853,6 +1853,8 @@ class LeoField:
                     generate_fn=self._overthinking_generate,
                     observe_fn=self._overthinking_observe,
                     pulse=pulse_snapshot,
+                    trauma_state=self._trauma_state if hasattr(self, '_trauma_state') else None,
+                    bootstrap=EMBEDDED_BOOTSTRAP,
                     config=OverthinkingConfig() if OverthinkingConfig else None,
                 )
 


### PR DESCRIPTION
Wounded overthinking integration:
- Ring 1 drifts toward bootstrap when trauma.level > 0.5
- Lower temp (0.85), higher semantic weight (0.65)
- Pulls internal thoughts back to origin when Leo is hurt
- Added _random_bootstrap_fragment() to extract origin fragments

Pulse-aware ring weighting:
- Ring 0: stabilize when entropy > 0.7 (temp → 0.7)
- Ring 1: thematic pull when arousal > 0.6 (semantic → 0.6)
- Ring 2: creativity boost when novelty > 0.7 (temp → 1.4)
- Rings now adapt to Leo's situational state

Trauma helpers:
- Added get_top_trauma_tokens() for debug/inspection
- Shows most wounded words with their weights

Integration:
- leo.py passes trauma_state + EMBEDDED_BOOTSTRAP to overthinking
- Backwards compatible - works without trauma module
- All 101 tests passing