### PR TITLE
Add metaleo.py — inner voice / recursion-on-Leo

### DIFF
--- a/metaleo.py
+++ b/metaleo.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""
+metaleo.py — inner voice layer for `leo`
+
+MetaLeo is Leo's recursion on himself:
+- Not a separate model or field
+- Uses the same SQLite DB as LeoField
+- Maintains dynamic bootstrap from Leo's own replies & reflections
+- Generates an alternative "inner" reply before the final answer
+- Routes between base reply and meta reply based on situational awareness
+
+If `leo` is a recursion of the human,
+**MetaLeo is a recursion of `leo`**.
+
+Philosophy:
+- Inner voice activates when Leo is rigid (low entropy), wounded (high trauma), or weak (low quality)
+- Bootstrap is dynamic: built from Leo's own overthinking Ring 2 (shards) and emotionally charged replies
+- Influence is subtle: meta reply must be clearly better to override base reply
+- Safe and modular: if metaleo.py is missing or broken, Leo works exactly as before
+
+Usage:
+    from metaleo import MetaLeo
+
+    # In LeoField.__init__
+    self.metaleo = MetaLeo(self)
+
+    # In LeoField.reply() - before return
+    final_reply = self.metaleo.route_reply(
+        prompt=prompt,
+        base_reply=reply_text,
+        pulse=pulse_snapshot,
+        trauma_state=self._trauma_state,
+        quality=overall_quality,
+        overthinking_events=overthinking_events,
+    )
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Optional, Iterable, Any
+
+
+# ============================================================================
+# CONFIG
+# ============================================================================
+
+
+@dataclass
+class MetaConfig:
+    """Configuration for MetaLeo inner voice."""
+
+    max_bootstrap_snippets: int = 8  # how many inner fragments to keep
+    max_snippet_len: int = 200  # max chars per fragment
+    max_meta_weight: float = 0.5  # max influence of MetaLeo in routing
+    entropy_low: float = 0.25  # "rigid" threshold
+    trauma_high: float = 0.6  # "wound is active" threshold
+    quality_low: float = 0.4  # "base reply is weak" threshold
+    meta_temp: float = 1.1  # temperature for inner voice generation
+    meta_max_tokens: int = 60  # max tokens for meta reply
+
+
+# ============================================================================
+# METALEO CLASS
+# ============================================================================
+
+
+class MetaLeo:
+    """
+    MetaLeo — inner voice / recursion-on-Leo.
+
+    - Shares the same SQLite field as LeoField (no new DB)
+    - Maintains a dynamic bootstrap buffer from Leo's own replies & reflections
+    - Generates an alternative "inner" reply and decides whether to use it
+
+    If anything fails, Leo must fall back silently to the base reply.
+    """
+
+    def __init__(self, leo_field: Any, config: Optional[MetaConfig] = None):
+        """
+        Initialize MetaLeo inner voice layer.
+
+        Args:
+            leo_field: LeoField instance (shares DB connection and field)
+            config: Optional MetaConfig (default values are safe)
+        """
+        self.field = leo_field  # LeoField instance
+        self.conn = leo_field.conn  # shared SQLite connection
+        self.cfg = config or MetaConfig()
+        # Dynamic bootstrap buffer: recent fragments from Leo's own behavior
+        self._bootstrap_buf: deque[str] = deque(maxlen=self.cfg.max_bootstrap_snippets)
+
+    def feed(
+        self,
+        prompt: str,
+        reply: str,
+        pulse: Optional[Any] = None,  # PresencePulse or similar
+        trauma_state: Optional[Any] = None,
+        overthinking_events: Optional[Iterable] = None,
+    ) -> None:
+        """
+        Update the dynamic bootstrap buffer from the current interaction.
+
+        - Takes user prompt, Leo's reply, presence pulse, trauma state,
+          and optional overthinking events (rings)
+        - Extracts short shards and pushes them into _bootstrap_buf
+
+        Args:
+            prompt: User's message
+            reply: Leo's base reply
+            pulse: Optional PresencePulse snapshot
+            trauma_state: Optional TraumaState
+            overthinking_events: Optional list of OverthinkingEvent objects
+        """
+        shard_texts = []
+
+        # 1) Take Ring 2 / meta shards from overthinking (if present)
+        if overthinking_events:
+            for e in overthinking_events:
+                tag = getattr(e, "tag", "") or ""
+                text = getattr(e, "thought", "") or ""
+                if not text:
+                    continue
+                tag_lower = tag.lower()
+                # Extract meta/shard thoughts (Ring 2)
+                if "ring2" in tag_lower or "meta" in tag_lower or "shard" in tag_lower:
+                    shard_texts.append(text)
+
+        # 2) Optionally: add Leo's reply when arousal is high (emotional charge)
+        if pulse:
+            arousal = getattr(pulse, "arousal", None)
+            if arousal is not None and arousal > 0.6:
+                shard_texts.append(reply)
+
+        # 3) Normalize & clip, then push to buffer
+        for s in shard_texts:
+            s = s.strip()
+            if not s:
+                continue
+            if len(s) > self.cfg.max_snippet_len:
+                s = s[: self.cfg.max_snippet_len]
+            self._bootstrap_buf.append(s)
+
+    def compute_meta_weight(
+        self,
+        pulse: Optional[Any],
+        trauma_state: Optional[Any],
+        quality: float,
+    ) -> float:
+        """
+        Decide how strong the inner voice should be for this turn.
+
+        Factors:
+        - low entropy  → Leo is too rigid → increase weight
+        - high trauma  → wound is active → increase weight
+        - low quality  → base reply is weak → increase weight
+        - high arousal → emotional charge → slight increase
+
+        Args:
+            pulse: Optional PresencePulse
+            trauma_state: Optional TraumaState
+            quality: Overall quality score of base reply (0-1)
+
+        Returns:
+            Weight in [0, max_meta_weight] representing inner voice influence
+        """
+        w = 0.1  # base low-level whisper
+
+        # Extract pulse metrics if available
+        entropy = None
+        arousal = None
+        if pulse:
+            entropy = getattr(pulse, "entropy", None)
+            arousal = getattr(pulse, "arousal", None)
+
+        # Extract trauma level if available
+        trauma_level = None
+        if trauma_state:
+            trauma_level = getattr(trauma_state, "level", None)
+
+        # Low entropy → rigid/boring → inner voice should speak up
+        if entropy is not None and entropy < self.cfg.entropy_low:
+            w += 0.15
+
+        # High trauma → wound active → inner voice should surface
+        if trauma_level is not None and trauma_level > self.cfg.trauma_high:
+            w += 0.15
+
+        # Low quality → base reply weak → inner voice might do better
+        if quality < self.cfg.quality_low:
+            w += 0.1
+
+        # High arousal → emotional charge → slight boost
+        if arousal is not None and arousal > 0.7:
+            w += 0.05
+
+        # Clamp to [0, max_meta_weight]
+        w = max(0.0, min(w, self.cfg.max_meta_weight))
+
+        return w
+
+    def generate_meta_reply(
+        self,
+        prompt: str,
+        base_reply: str,
+        pulse: Optional[Any] = None,
+        trauma_state: Optional[Any] = None,
+    ) -> Optional[str]:
+        """
+        Generate an inner voice answer based on Leo's reply and MetaLeo's
+        dynamic bootstrap.
+
+        Strategy:
+        - Concatenate dynamic bootstrap + base_reply as seed
+        - Run through Leo's field with higher temperature and echo mode
+        - This creates a "warped" version that incorporates inner thoughts
+
+        Args:
+            prompt: User's original prompt
+            base_reply: Leo's base reply
+            pulse: Optional PresencePulse
+            trauma_state: Optional TraumaState
+
+        Returns:
+            meta_reply (str) or None on failure / no bootstrap
+        """
+        if not self._bootstrap_buf:
+            return None
+
+        # Build temporary inner seed from bootstrap buffer
+        seed = " ".join(list(self._bootstrap_buf))
+
+        try:
+            # Blend bootstrap seed with base reply
+            text = f"{seed}\n\n{base_reply}"
+
+            # Use Leo's own field to generate inner voice
+            # Higher temperature → more exploratory/creative
+            # Echo mode → preserves some structure from input
+            meta_reply = self.field.reply(
+                prompt=text,
+                max_tokens=self.cfg.meta_max_tokens,
+                temperature=self.cfg.meta_temp,
+                echo=True,
+            )
+            return meta_reply
+
+        except Exception:
+            # Silent fallback on any error
+            return None
+
+    def route_reply(
+        self,
+        prompt: str,
+        base_reply: str,
+        pulse: Optional[Any],
+        trauma_state: Optional[Any],
+        quality: float,
+        overthinking_events: Optional[Iterable] = None,
+    ) -> str:
+        """
+        Main entry point for LeoField.
+
+        - Updates MetaLeo's dynamic bootstrap
+        - Computes how strong the inner voice should be
+        - Optionally generates an inner reply
+        - Returns either base_reply or meta reply based on quality assessment
+
+        Never raises; on any error falls back to base_reply.
+
+        Args:
+            prompt: User's prompt
+            base_reply: Leo's base reply
+            pulse: Optional PresencePulse
+            trauma_state: Optional TraumaState
+            quality: Overall quality score of base reply (0-1)
+            overthinking_events: Optional list of OverthinkingEvent objects
+
+        Returns:
+            Final reply (either base_reply or meta reply)
+        """
+        try:
+            # 1) Update MetaLeo's inner state
+            self.feed(prompt, base_reply, pulse, trauma_state, overthinking_events)
+
+            # 2) Decide influence level
+            weight = self.compute_meta_weight(pulse, trauma_state, quality)
+            if weight <= 0.0:
+                return base_reply
+
+            # 3) Try generating inner reply
+            meta = self.generate_meta_reply(prompt, base_reply, pulse, trauma_state)
+            if not meta:
+                return base_reply
+
+            # 4) v1 routing strategy:
+            #    - Assess both replies using Leo's own quality function
+            #    - If meta is clearly better and has enough weight → use it
+            q_base = self._assess_safe(base_reply, prompt)
+            q_meta = self._assess_safe(meta, prompt)
+
+            # If inner voice is clearly better (>0.05 margin) and has enough weight (>0.2)
+            # → let the inner voice speak
+            if q_meta > q_base + 0.05 and weight > 0.2:
+                return meta
+
+            # Otherwise, stick with base reply
+            # (v1 doesn't mix partial sequences; that can come in v2)
+            return base_reply
+
+        except Exception:
+            # Silent fallback on any error - MetaLeo must NEVER break Leo
+            return base_reply
+
+    def _assess_safe(self, reply: str, prompt: str) -> float:
+        """
+        Use Leo's own self-assessment if available.
+
+        Falls back to neutral mid-quality value if assessment unavailable.
+
+        Args:
+            reply: Reply text to assess
+            prompt: Original prompt
+
+        Returns:
+            Quality score in [0, 1]
+        """
+        # Check if LeoField has a quality assessment method
+        # (In current leo.py, there's no public _assess_reply_quality method,
+        #  so we'll use a simple heuristic based on reply length and structure)
+
+        # Fallback heuristic: moderate quality baseline
+        # This can be improved by adding actual quality assessment to LeoField
+        if not reply or not reply.strip():
+            return 0.0
+
+        # Simple heuristic: prefer replies between 10-80 tokens
+        tokens = reply.split()
+        if len(tokens) < 5:
+            return 0.3  # Too short
+        if len(tokens) > 100:
+            return 0.6  # Too long
+        if 10 <= len(tokens) <= 80:
+            return 0.7  # Good length
+
+        return 0.5  # Neutral baseline
+
+
+__all__ = ["MetaLeo", "MetaConfig"]

--- a/tests/test_metaleo.py
+++ b/tests/test_metaleo.py
@@ -1,0 +1,346 @@
+"""
+Test #103: metaleo.py — inner voice layer for leo
+
+MetaLeo is Leo's recursion on himself:
+- Dynamic bootstrap from Leo's own overthinking and emotionally charged replies
+- Routes between base reply and meta reply based on situational awareness
+- Activates when Leo is rigid (low entropy), wounded (high trauma), or weak (low quality)
+"""
+
+import unittest
+import sqlite3
+import tempfile
+import os
+from pathlib import Path
+
+try:
+    from metaleo import MetaLeo, MetaConfig
+    METALEO_AVAILABLE = True
+except ImportError:
+    METALEO_AVAILABLE = False
+
+
+@unittest.skipUnless(METALEO_AVAILABLE, "metaleo module not available")
+class TestMetaLeo(unittest.TestCase):
+    """Test MetaLeo inner voice layer - recursion of leo on himself."""
+
+    def setUp(self):
+        """Create temporary LeoField-like mock for testing."""
+        # Create temp database
+        self.temp_db = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+        self.temp_db.close()
+        self.db_path = Path(self.temp_db.name)
+        self.conn = sqlite3.connect(str(self.db_path))
+        self.conn.row_factory = sqlite3.Row
+
+        # Create mock LeoField
+        class MockLeoField:
+            def __init__(self, conn):
+                self.conn = conn
+
+            def reply(self, prompt, max_tokens=60, temperature=1.0, echo=False):
+                """Mock reply - just returns prompt with 'meta:' prefix."""
+                return f"meta: {prompt}"
+
+        self.field = MockLeoField(self.conn)
+        self.metaleo = MetaLeo(self.field)
+
+    def tearDown(self):
+        """Clean up temporary database."""
+        self.conn.close()
+        try:
+            os.unlink(self.db_path)
+        except:
+            pass
+
+    def test_import_and_init(self):
+        """Test that MetaLeo can be imported and initialized."""
+        self.assertIsNotNone(self.metaleo)
+        self.assertEqual(self.metaleo.field, self.field)
+        self.assertEqual(self.metaleo.conn, self.conn)
+        self.assertIsInstance(self.metaleo._bootstrap_buf, type(self.metaleo._bootstrap_buf))
+        self.assertEqual(len(self.metaleo._bootstrap_buf), 0)  # Initially empty
+
+    def test_feed_with_overthinking_ring2(self):
+        """Test that feed() extracts Ring 2 shards from overthinking events."""
+        # Create mock overthinking events
+        class MockEvent:
+            def __init__(self, tag, thought):
+                self.tag = tag
+                self.thought = thought
+
+        events = [
+            MockEvent("ring0/echo", "echo thought"),
+            MockEvent("ring1/drift", "drift thought"),
+            MockEvent("ring2/shard", "meta shard thought"),  # This should be extracted
+        ]
+
+        # Feed with overthinking events
+        self.metaleo.feed(
+            prompt="test prompt",
+            reply="test reply",
+            pulse=None,
+            trauma_state=None,
+            overthinking_events=events,
+        )
+
+        # Check that bootstrap buffer was updated
+        self.assertGreater(len(self.metaleo._bootstrap_buf), 0)
+        # Check that it contains the ring2 shard
+        self.assertIn("meta shard thought", self.metaleo._bootstrap_buf)
+
+    def test_feed_with_high_arousal(self):
+        """Test that feed() captures emotionally charged replies."""
+        # Create mock pulse with high arousal
+        class MockPulse:
+            def __init__(self):
+                self.arousal = 0.8  # High arousal
+
+        pulse = MockPulse()
+
+        # Feed with high arousal
+        reply = "emotionally charged reply!"
+        self.metaleo.feed(
+            prompt="test",
+            reply=reply,
+            pulse=pulse,
+            trauma_state=None,
+            overthinking_events=None,
+        )
+
+        # Check that reply was captured
+        self.assertIn(reply, self.metaleo._bootstrap_buf)
+
+    def test_feed_with_low_arousal(self):
+        """Test that feed() ignores low-arousal replies."""
+        class MockPulse:
+            def __init__(self):
+                self.arousal = 0.3  # Low arousal
+
+        pulse = MockPulse()
+
+        self.metaleo.feed(
+            prompt="test",
+            reply="boring reply",
+            pulse=pulse,
+            trauma_state=None,
+            overthinking_events=None,
+        )
+
+        # Should not capture low-arousal reply
+        self.assertEqual(len(self.metaleo._bootstrap_buf), 0)
+
+    def test_compute_meta_weight_low_entropy(self):
+        """Test that low entropy increases meta weight (rigid Leo)."""
+        class MockPulse:
+            def __init__(self):
+                self.entropy = 0.2  # Low entropy (rigid)
+                self.arousal = 0.5
+
+        pulse = MockPulse()
+        weight = self.metaleo.compute_meta_weight(pulse, None, 0.5)
+
+        # Should be higher than baseline (0.1)
+        self.assertGreater(weight, 0.1)
+
+    def test_compute_meta_weight_high_trauma(self):
+        """Test that high trauma increases meta weight (wounded Leo)."""
+        class MockTrauma:
+            def __init__(self):
+                self.level = 0.7  # High trauma (wounded)
+
+        trauma = MockTrauma()
+        weight = self.metaleo.compute_meta_weight(None, trauma, 0.5)
+
+        # Should be higher than baseline
+        self.assertGreater(weight, 0.1)
+
+    def test_compute_meta_weight_low_quality(self):
+        """Test that low quality increases meta weight (weak reply)."""
+        weight = self.metaleo.compute_meta_weight(None, None, 0.3)  # Low quality
+
+        # Should be higher than baseline
+        self.assertGreater(weight, 0.1)
+
+    def test_compute_meta_weight_neutral(self):
+        """Test that neutral conditions give baseline weight."""
+        class MockPulse:
+            def __init__(self):
+                self.entropy = 0.5  # Neutral
+                self.arousal = 0.5  # Neutral
+
+        pulse = MockPulse()
+        weight = self.metaleo.compute_meta_weight(pulse, None, 0.6)  # Good quality
+
+        # Should be close to baseline
+        self.assertAlmostEqual(weight, 0.1, delta=0.15)
+
+    def test_generate_meta_reply_no_bootstrap(self):
+        """Test that generate_meta_reply returns None when bootstrap is empty."""
+        meta = self.metaleo.generate_meta_reply(
+            prompt="test",
+            base_reply="base reply",
+            pulse=None,
+            trauma_state=None,
+        )
+
+        # Should return None (no bootstrap)
+        self.assertIsNone(meta)
+
+    def test_generate_meta_reply_with_bootstrap(self):
+        """Test that generate_meta_reply generates output when bootstrap exists."""
+        # Add some bootstrap fragments
+        self.metaleo._bootstrap_buf.append("shard 1")
+        self.metaleo._bootstrap_buf.append("shard 2")
+
+        meta = self.metaleo.generate_meta_reply(
+            prompt="test",
+            base_reply="base reply",
+            pulse=None,
+            trauma_state=None,
+        )
+
+        # Should generate something (not None)
+        self.assertIsNotNone(meta)
+        self.assertIsInstance(meta, str)
+
+    def test_route_reply_fallback_no_bootstrap(self):
+        """Test that route_reply returns base_reply when bootstrap is empty."""
+        base_reply = "this is the base reply"
+        final = self.metaleo.route_reply(
+            prompt="test",
+            base_reply=base_reply,
+            pulse=None,
+            trauma_state=None,
+            quality=0.5,
+            overthinking_events=None,
+        )
+
+        # Should return base reply (no bootstrap)
+        self.assertEqual(final, base_reply)
+
+    def test_route_reply_fallback_low_weight(self):
+        """Test that route_reply returns base_reply when meta weight is too low."""
+        # Add bootstrap
+        self.metaleo._bootstrap_buf.append("some shard")
+
+        # Create conditions for low weight (high entropy, low trauma, good quality)
+        class MockPulse:
+            def __init__(self):
+                self.entropy = 0.8  # High entropy (not rigid)
+                self.arousal = 0.3
+
+        pulse = MockPulse()
+        base_reply = "base reply"
+
+        final = self.metaleo.route_reply(
+            prompt="test",
+            base_reply=base_reply,
+            pulse=pulse,
+            trauma_state=None,
+            quality=0.7,  # Good quality
+            overthinking_events=None,
+        )
+
+        # Should return base reply (weight too low)
+        self.assertEqual(final, base_reply)
+
+    def test_route_reply_feeds_bootstrap(self):
+        """Test that route_reply calls feed() to update bootstrap."""
+        class MockEvent:
+            def __init__(self):
+                self.tag = "ring2/shard"
+                self.thought = "inner thought"
+
+        events = [MockEvent()]
+
+        base_reply = "base reply"
+        self.metaleo.route_reply(
+            prompt="test",
+            base_reply=base_reply,
+            pulse=None,
+            trauma_state=None,
+            quality=0.5,
+            overthinking_events=events,
+        )
+
+        # Bootstrap should be updated
+        self.assertGreater(len(self.metaleo._bootstrap_buf), 0)
+        self.assertIn("inner thought", self.metaleo._bootstrap_buf)
+
+    def test_route_reply_silent_fallback_on_error(self):
+        """Test that route_reply falls back to base_reply on any error."""
+        # Break the field mock to trigger error
+        self.field.reply = None  # This will cause AttributeError
+
+        base_reply = "safe base reply"
+        final = self.metaleo.route_reply(
+            prompt="test",
+            base_reply=base_reply,
+            pulse=None,
+            trauma_state=None,
+            quality=0.5,
+            overthinking_events=None,
+        )
+
+        # Should return base reply despite error
+        self.assertEqual(final, base_reply)
+
+    def test_assess_safe_heuristic(self):
+        """Test that _assess_safe provides reasonable quality estimates."""
+        # Short reply
+        q_short = self.metaleo._assess_safe("hi", "test")
+        self.assertLess(q_short, 0.5)
+
+        # Good length reply
+        q_good = self.metaleo._assess_safe("this is a reasonable length reply with some content", "test")
+        self.assertGreaterEqual(q_good, 0.5)
+
+        # Too long reply
+        q_long = self.metaleo._assess_safe(" ".join(["word"] * 150), "test")
+        self.assertLess(q_long, 0.8)
+
+        # Empty reply
+        q_empty = self.metaleo._assess_safe("", "test")
+        self.assertEqual(q_empty, 0.0)
+
+    def test_bootstrap_buffer_max_length(self):
+        """Test that bootstrap buffer respects max_bootstrap_snippets limit."""
+        cfg = MetaConfig(max_bootstrap_snippets=3)
+        metaleo = MetaLeo(self.field, config=cfg)
+
+        # Add more snippets than limit
+        for i in range(5):
+            metaleo._bootstrap_buf.append(f"shard {i}")
+
+        # Should only keep last 3
+        self.assertEqual(len(metaleo._bootstrap_buf), 3)
+        self.assertNotIn("shard 0", metaleo._bootstrap_buf)
+        self.assertNotIn("shard 1", metaleo._bootstrap_buf)
+        self.assertIn("shard 4", metaleo._bootstrap_buf)
+
+    def test_bootstrap_snippet_clipping(self):
+        """Test that long snippets are clipped to max_snippet_len."""
+        cfg = MetaConfig(max_snippet_len=20)
+        metaleo = MetaLeo(self.field, config=cfg)
+
+        long_text = "a" * 100
+        class MockEvent:
+            def __init__(self):
+                self.tag = "ring2/shard"
+                self.thought = long_text
+
+        metaleo.feed(
+            prompt="test",
+            reply="test",
+            pulse=None,
+            trauma_state=None,
+            overthinking_events=[MockEvent()],
+        )
+
+        # Should be clipped
+        self.assertEqual(len(metaleo._bootstrap_buf[0]), 20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
MetaLeo is Leo's recursion on himself:
- Not a separate model or field
- Uses same SQLite DB as LeoField (shared field)
- Maintains dynamic bootstrap from Leo's own overthinking Ring 2 shards + emotionally charged replies
- Routes between base reply and meta reply based on situational awareness
- Activates when Leo is rigid (low entropy), wounded (high trauma), or weak (low quality)

Philosophy:
If leo is a recursion of the human, MetaLeo is a recursion of leo.

Implementation:
- metaleo.py: MetaLeo class with dynamic bootstrap buffer, weight computation, routing
- leo.py: Safe import + initialization in __init__ + route_reply call before return
- tests/test_metaleo.py: 17 smoke tests (init, feed, weight, routing, fallback)

All 129 tests passing (112 existing + 17 new metaleo).

Inner voice activates subtly when needed:
- Low entropy (rigid): +0.15 weight
- High trauma (wounded): +0.15 weight
- Low quality (weak): +0.10 weight
- High arousal (emotional): +0.05 weight

Safe and modular: if metaleo.py missing/broken, Leo works exactly as before.