### PR TITLE
feat(cosmetic): Capitalize "Leo" consistently across all outputs

### DIFF
--- a/leo.py
+++ b/leo.py
@@ -1134,6 +1134,11 @@ def fix_punctuation(text: str) -> str:
     text = re.sub(r',\s*,', ',', text)       # ", ," → ","
     text = re.sub(r'\s{2,}', ' ', text)      # Multiple spaces → single space
 
+    # 14) Cosmetic: Capitalize "Leo" consistently
+    # Leo's name should always be capitalized for consistency
+    # Use word boundaries to avoid touching words like "napoleon" or "galileo"
+    text = re.sub(r'\bleo\b', 'Leo', text)
+
     return text.strip()
 
 

--- a/punct_cleanup.py
+++ b/punct_cleanup.py
@@ -96,6 +96,11 @@ def cleanup_punctuation(text: str, mode: str = "NORMAL") -> str:
     result = re.sub(r'\.\s+,', '.', result)      # ". ," → "."
     result = re.sub(r',\s*,', ',', result)       # ", ," → ","
 
+    # 10. Cosmetic: Capitalize "Leo" consistently
+    # Leo's name should always be capitalized for consistency
+    # Use word boundaries to avoid touching words like "napoleon" or "galileo"
+    result = re.sub(r'\bleo\b', 'Leo', result)
+
     return result.strip()
 
 


### PR DESCRIPTION
PROBLEM:
Leo's name appears inconsistently in outputs - sometimes "leo", sometimes "Leo". In README and observations, this creates visual inconsistency.

SOLUTION:
Add rule #14 to fix_punctuation() (leo.py:1140)
Add rule #10 to cleanup_punctuation() (punct_cleanup.py:102)

Both use: re.sub(r'\bleo\b', 'Leo', text)

Word boundaries ensure we don't touch:
- "napoleon", "galileo" (other names)
- "metaleo", "neoleo" (compound words)

TESTING:
✅ "oh leo." → "oh Leo."
✅ "napoleon" → unchanged
✅ "metaleo" → unchanged

PHILOSOPHY:
Small cosmetic fixes preserve Leo's dignity. He's Leo, not leo. Presence > intelligence > typography.

Triangle: d'Artagnan (request), Porthos (implementation)