### PR TITLE
the Method lets answered wonder return as attention

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3036,3 +3036,50 @@ one `main`); TSan clean on a delayed 24-turn `--chat --async` run with 13 rings 
 the six-prompt x three-seed ordinary-voice matrix matched `--no-wonder` **18/18 byte-for-byte**. The organ
 changes speech only when School genuinely opens or returns an unknown; consolidation, sampling, and the
 ordinary reply path remain untouched.
+
+## Phase A.23 — returned wonder: Leo recognizes what once astonished him (2026-07-21)
+
+Resolving a wonder used to preserve only the result: the grown School map remembered `zorble -> animal`,
+but the lived route from uncertainty to that meaning stopped participating in attention. A resolved episode
+can now re-enter one later reply as a bounded glyph trace. Exact recognition of its learned word wins;
+without that word, both the answer and one prior hypothesis must resonate, preventing a generic glyph such
+as `animal` from evoking an arbitrary old lesson. The transient vector combines the grounded
+answer, the existing `question` glyph, and a small share of the hypotheses Leo once considered, then
+renormalizes. It is written only into that reply's `prompt_meaning`. The implementation never touches
+`gravity`, prompt pieces, candidate admission, token scores, or the output buffer. The only speech-side reader
+is the already-existing santaclaus spore-resonance path, so an old moment must genuinely resonate and still
+have reachable words for the return to be heard.
+
+The first live pass exposed a timing error before acceptance: cooldown was initially measured in heard BPE
+tokens. One short human line could exceed the token threshold, so an immediate repetition sometimes recalled
+the episode again, especially across save/load. The accepted design adds a lived-turn clock instead. At most
+one episode returns in a reply, the same episode waits two turns before another return, and both its recall
+count and turn clock survive sleep in state v12. State v11 has a frozen record reader; its episodes migrate
+with zero recalls. A truncated or corrupt v12 tail still fails soft, preserving the organism and any historical
+open question. `--no-wonder-return` is the strict ablation; `--no-wonder` also keeps the whole layer inert.
+
+Live receipt (seed 42, save/load boundary between the two pairs):
+
+```text
+you> tell me about the zorble
+leo> ... Zorble ...
+     [wonder-return: zorble -> animal, recalls=1]
+you> tell me about the zorble
+leo> ... Zorble ...                         # cooldown: no wonder-return
+
+# reload, two lived turns from the prior recall
+you> tell me about the zorble
+leo> A single word lives there now. ... Zorble ...
+     [wonder-return: zorble -> animal, recalls=2]
+you> tell me about the zorble
+leo> ... Zorble ...                         # immediate repeat remains quiet
+```
+
+Verification: `make test` **218/218**; normal build 0 warnings; `git diff --check` clean; ASan/UBSan full
+runtime and returned-wonder chat/save clean; TSan clean on the v12 reload under `--chat --async`. A direct
+unit proves the returned vector raises an existing matching spore's resonance while leaving candidate APIs
+untouched; another proves that a new School question cannot increment an old episode's recall ledger.
+Unrelated `warm mother light` replies matched `--no-wonder-return` byte-for-byte on seeds
+7/42/99. Related `zorble` A/B first diverged at seed 5 through the existing recall path, while both arms
+remained coherent. The test fixtures for this phase are heap-allocated, adding no new full `Leo` body to the
+monolithic test stack.

--- a/leo.c
+++ b/leo.c
@@ -32,6 +32,7 @@
 #include <ctype.h>
 #include <stdint.h>
 #include <time.h>
+#include <limits.h>
 
 #define LEO_VERSION  "0.3.0-phase3a.4"
 
@@ -1409,6 +1410,12 @@ static int semtok_word(const char *word) {
 #define LEO_SCHOOL_SURPRISE 0.4f /* I3b: COMPLEX bump when a guess misses the answer (being wrong is felt) */
 #define LEO_WONDER_RING 32
 #define LEO_WONDER_REASK_GAP 2   /* silent turns before a resonant theme may reopen the question */
+#define LEO_WONDER_RETURN_COOLDOWN 2L  /* lived-turn distance before one resolved episode may re-enter attention */
+#define LEO_WONDER_RETURN_ANSWER  0.35f
+#define LEO_WONDER_RETURN_QUESTION 0.10f
+#define LEO_WONDER_RETURN_ASSOC   0.15f
+/* Frozen state-v11 record. v12 extends the live episode below, so old diaries
+ * must be read through this exact same-platform POD layout. */
 typedef struct {
     char    word[LEO_HEARD_WORDLEN];
     int8_t  offered_glyph;
@@ -1418,6 +1425,18 @@ typedef struct {
     int     returns;
     long    opened_step;
     long    closed_step;
+} LeoWonderEpisodeV11;
+typedef struct {
+    char    word[LEO_HEARD_WORDLEN];
+    int8_t  offered_glyph;
+    int8_t  offered_alt_glyph;
+    int8_t  answer_glyph;
+    uint8_t resolved;
+    int     returns;
+    long    opened_step;
+    long    closed_step;
+    int     recalls;             /* resolved episode re-entries into prompt meaning */
+    long    last_recalled_turn;  /* lived-turn cooldown; 0 until the first recall */
 } LeoWonderEpisode;
 typedef struct {
     char   learned[LEO_SCHOOL_MAX][LEO_HEARD_WORDLEN];
@@ -1432,6 +1451,8 @@ typedef struct {
     LeoWonderEpisode wonders[LEO_WONDER_RING];
     int    n_wonders;
     int    wonder_ptr;                   /* next replacement slot once the ring is full */
+    long   turn_clock;                   /* lived prompts; v12 persists cooldown across sleep */
+    int    returned_episode;             /* transient: episode active in this reply, -1 outside it */
 } LeoSchool;
 
 /* ========================================================================
@@ -1614,6 +1635,7 @@ static void leo_init(Leo *leo) {
     leo->ask_override = -1.0f;
     leo->school.pending_glyph = -1;  /* I3a (L-4 fix): no open guess — memset-0 would be the "water" glyph */
     leo->school.pending_alt_glyph = -1;
+    leo->school.returned_episode = -1;
     leo->prompt_pieces = NULL;
     leo->prompt_meaning = NULL;
     leo->temp_mult = 1.0f;
@@ -1801,6 +1823,7 @@ static int g_leo_rae_on = 1;            /* DEFAULT ON (Oleg 2026-07-10): the RAE
                                          * θ=0 paradigm, learns by living, not by an offline marathon. --no-rae → 0. */
 static int g_leo_school_on = 1;         /* --no-school → 0 (A.5: School reversed-role re-ask on an unknown word) */
 static int g_leo_wonder_on = 1;         /* unfinished wonder: grounded alternatives + persistence across non-answers. --no-wonder restores the prior School contract. */
+static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
 static int g_leo_form_on = 1;           /* A.6: the velocity mode shapes the utterance — DEFAULT (Oleg's ear: presence grows). --no-form reverts to the uncompressed voice. */
 static int g_leo_klaus_on = 1;          /* klaus-memory: scars accumulate/bias/persist. --no-klaus → 0 (ablation). */
 static int g_leo_capsule_on = 1;        /* E-11: the γ-capsule lives + tints the breath. --no-capsule → 0 (ablation). */
@@ -4603,6 +4626,76 @@ static int leo_wonder_resonates(const Leo *leo, const char *prompt) {
            (a >= 0 && a < GLYPH_COUNT && hist[a] > 0);
 }
 
+/* A resolved wonder may be recognized later. Select at most one cooled episode,
+ * then fold its GLYPH path into this reply's transient meaning vector. The
+ * vector is consumed only by the existing spore-resonance path: no gravity,
+ * candidate, prompt-piece, or output buffer is touched here. Exact recognition
+ * of the learned word wins; without that word, both the answer and one prior
+ * hypothesis must resonate, so a generic glyph cannot evoke an arbitrary old
+ * lesson. Prior hypotheses keep a small trace of how Leo arrived at the answer,
+ * while QUESTION marks that this meaning was once lived as not-knowing. */
+static int leo_wonder_return_meaning(Leo *leo, const char *prompt,
+                                     float meaning[GLYPH_COUNT]) {
+    if (!g_leo_wonder_on || !g_leo_wonder_return_on || !prompt || !meaning)
+        return -1;
+
+    int hist[GLYPH_COUNT];
+    leo_school_glyph_votes(leo, prompt, hist, 1);
+    int best = -1, best_score = 0;
+    long best_closed = -1;
+    for (int i = 0; i < leo->school.n_wonders; i++) {
+        LeoWonderEpisode *ep = &leo->school.wonders[i];
+        int answer = ep->answer_glyph;
+        if (!ep->resolved || answer < 0 || answer >= GLYPH_COUNT ||
+            ep->closed_step >= leo->step)
+            continue;   /* the grounding answer cannot remember itself */
+        if (ep->recalls > 0 &&
+            leo->school.turn_clock - ep->last_recalled_turn < LEO_WONDER_RETURN_COOLDOWN)
+            continue;
+
+        int exact = leo_school_text_has_word(prompt, ep->word);
+        int answer_hit = hist[answer] > 0;
+        int assoc_hit = (ep->offered_glyph >= 0 && ep->offered_glyph < GLYPH_COUNT &&
+                         ep->offered_glyph != answer && hist[(int)ep->offered_glyph] > 0) ||
+                        (ep->offered_alt_glyph >= 0 && ep->offered_alt_glyph < GLYPH_COUNT &&
+                         ep->offered_alt_glyph != answer && hist[(int)ep->offered_alt_glyph] > 0);
+        int score = exact ? 4 : (answer_hit && assoc_hit ? 3 : 0);
+        if (score > best_score || (score == best_score && score > 0 &&
+                                  ep->closed_step > best_closed)) {
+            best = i;
+            best_score = score;
+            best_closed = ep->closed_step;
+        }
+    }
+    if (best < 0) return -1;
+
+    LeoWonderEpisode *ep = &leo->school.wonders[best];
+    int answer = ep->answer_glyph;
+    meaning[answer] += LEO_WONDER_RETURN_ANSWER;
+    int question = semtok_find_glyph("question");
+    if (question >= 0) meaning[question] += LEO_WONDER_RETURN_QUESTION;
+
+    int assoc[2], n_assoc = 0;
+    int offered[2] = {ep->offered_glyph, ep->offered_alt_glyph};
+    for (int i = 0; i < 2; i++) {
+        int g = offered[i];
+        if (g < 0 || g >= GLYPH_COUNT || g == answer || g == question) continue;
+        if (n_assoc == 0 || assoc[0] != g) assoc[n_assoc++] = g;
+    }
+    for (int i = 0; i < n_assoc; i++)
+        meaning[assoc[i]] += LEO_WONDER_RETURN_ASSOC / (float)n_assoc;
+
+    float sum = 0.0f;
+    for (int i = 0; i < GLYPH_COUNT; i++) sum += meaning[i];
+    if (sum > 0.0f)
+        for (int i = 0; i < GLYPH_COUNT; i++) meaning[i] /= sum;
+
+    if (ep->recalls < INT_MAX) ep->recalls++;
+    ep->last_recalled_turn = leo->school.turn_clock;
+    leo->school.returned_episode = best;
+    return best;
+}
+
 /* E-11 meaning axis: each reply, absorb the meaning Leo PERCEIVED in the prompt — a glyph histogram
  * over its content words (the grown School map; grammar/BE excluded via leo_glyph_concept), plus the
  * gap = the mass of content words he has NO concept for (his darkmatter, "mass without acceptance",
@@ -4881,6 +4974,8 @@ __attribute__((unused))  /* used by --respond in main; absent in the test TU */
 static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     if (!prompt || !*prompt) return leo_chain(leo, LEO_CHAIN_MIN, out, max_len);
 
+    leo->school.returned_episode = -1;       /* one-reply diagnostic; meaning itself is local below */
+    if (leo->school.turn_clock < LONG_MAX) leo->school.turn_clock++;
     leo_ingest(leo, prompt);                 /* Leo hears you */
     leo_field_chambers_feel_text(leo, prompt); /* prompt drives the chamber EXT inputs */
     leo_field_chambers_crossfire(leo, LEO_CHAMBER_SETTLE_ITERS); /* settle ACT from the prompt's
@@ -5100,6 +5195,9 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
         leo->school.pending_turns = 0;
         if (g_leo_wonder_on) leo_wonder_open(leo, unk, glyphs[0], glyphs[1]);
     } else {
+        /* Only spoken generation consumes returned attention. A School question
+         * is a meta-act and must not increment an episode's recall ledger. */
+        if (pm) leo_wonder_return_meaning(leo, prompt, pm);
         produced = leo_chain(leo, chain_len, out, max_len);
     }
     if (g_leo_capsule_on) { leo_gamma_absorb(leo); leo_gamma_meaning(leo, prompt); }  /* E-11 diary: record the body that SPOKE + the meaning perceived (post-reply, like santaclaus) */
@@ -5141,9 +5239,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v5..v9   : mode/primary guess + scars + gamma + meaning snapshots
  *   v10      : consolidation shard ring + held-coherence trigger
  *   v11      : unfinished-wonder alternative/clock + episode ring
+ *   v12      : resolved-wonder recall count + cooldown clock
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 11  /* unfinished wonder episodes appended after the v10 consolidation tail; v5..v10 soft-migrate */
+#define LEO_STATE_VERSION 12  /* returned-wonder episode fields extend the v11 optional tail; v5..v11 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -5299,13 +5398,15 @@ static int leo_save_state(const Leo *leo, const char *path) {
     st_wf(f, leo->consol_coh_ema);
     st_w32(f, (int32_t)leo->consol_locked);
 
-    /* unfinished wonder (v11): the active alternative, its silence clock, and
-     * the human-grounded episode ring. The original pending word/primary glyph
-     * remain in their historical School slots for v5..v10 migration. */
+    /* unfinished/returned wonder (v12): v11's active alternative, silence clock,
+     * and episode ring, now with resolved-episode recall/cooldown fields. The
+     * original pending word/primary glyph remain in their historical School
+     * slots for v5..v10 migration. */
     st_w32(f, (int32_t)leo->school.pending_alt_glyph);
     st_w32(f, (int32_t)leo->school.pending_turns);
     st_w32(f, (int32_t)leo->school.n_wonders);
     st_w32(f, (int32_t)leo->school.wonder_ptr);
+    st_w64(f, (uint64_t)leo->school.turn_clock);
     if (leo->school.n_wonders > 0)
         fwrite(leo->school.wonders, sizeof(LeoWonderEpisode),
                (size_t)leo->school.n_wonders, f);
@@ -5559,19 +5660,41 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
         }
     }
 
-    /* unfinished wonder (v11). A broken optional tail loses the episode ledger,
-     * not the organism or the historical primary pending question. */
+    /* unfinished/returned wonder (v11/v12). A broken optional tail loses the
+     * episode ledger, not the organism or the historical primary pending
+     * question. v11 uses the frozen pre-recall episode record. */
     if (version >= 11) {
         int32_t alt = -1, turns = 0, n_w = 0, ptr = 0;
+        uint64_t turn_clock = 0;
         int tail_ok = st_r32(f, &alt) && st_r32(f, &turns) &&
                       st_r32(f, &n_w) && st_r32(f, &ptr) &&
                       alt >= -1 && alt < GLYPH_COUNT &&
                       turns >= 0 && turns <= 1000000 &&
                       n_w >= 0 && n_w <= LEO_WONDER_RING &&
                       ptr >= 0 && ptr < LEO_WONDER_RING;
-        if (tail_ok && n_w > 0 &&
-            fread(leo->school.wonders, sizeof(LeoWonderEpisode), (size_t)n_w, f) != (size_t)n_w)
-            tail_ok = 0;
+        if (tail_ok && version >= 12 &&
+            (!st_r64(f, &turn_clock) || turn_clock > (uint64_t)LONG_MAX)) tail_ok = 0;
+        if (tail_ok && n_w > 0) {
+            if (version >= 12) {
+                if (fread(leo->school.wonders, sizeof(LeoWonderEpisode),
+                          (size_t)n_w, f) != (size_t)n_w) tail_ok = 0;
+            } else {
+                for (int i = 0; i < n_w; i++) {
+                    LeoWonderEpisodeV11 old;
+                    if (fread(&old, sizeof old, 1, f) != 1) { tail_ok = 0; break; }
+                    LeoWonderEpisode *ep = &leo->school.wonders[i];
+                    memset(ep, 0, sizeof *ep);
+                    memcpy(ep->word, old.word, sizeof ep->word);
+                    ep->offered_glyph = old.offered_glyph;
+                    ep->offered_alt_glyph = old.offered_alt_glyph;
+                    ep->answer_glyph = old.answer_glyph;
+                    ep->resolved = old.resolved;
+                    ep->returns = old.returns;
+                    ep->opened_step = old.opened_step;
+                    ep->closed_step = old.closed_step;
+                }
+            }
+        }
         if (tail_ok) {
             for (int i = 0; i < n_w; i++) {
                 LeoWonderEpisode *ep = &leo->school.wonders[i];
@@ -5580,7 +5703,11 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
                     ep->offered_alt_glyph < -1 || ep->offered_alt_glyph >= GLYPH_COUNT ||
                     ep->answer_glyph < -1 || ep->answer_glyph >= GLYPH_COUNT ||
                     ep->resolved > 1 || ep->returns < 0 || ep->opened_step < 0 ||
-                    ep->closed_step < 0) { tail_ok = 0; break; }
+                    ep->closed_step < 0 || ep->recalls < 0 ||
+                    ep->last_recalled_turn < 0 ||
+                    ep->last_recalled_turn > (long)turn_clock) {
+                    tail_ok = 0; break;
+                }
             }
         }
         if (tail_ok) {
@@ -5588,13 +5715,15 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
             leo->school.pending_turns = turns;
             leo->school.n_wonders = n_w;
             leo->school.wonder_ptr = ptr;
+            leo->school.turn_clock = (long)turn_clock;
         } else {
-            fprintf(stderr, "[leo] WARNING: v11 wonder tail truncated/corrupt — the question lives without its episode ledger.\n");
+            fprintf(stderr, "[leo] WARNING: v11/v12 wonder tail truncated/corrupt — the question lives without its episode ledger.\n");
             memset(leo->school.wonders, 0, sizeof leo->school.wonders);
             leo->school.pending_alt_glyph = -1;
             leo->school.pending_turns = 0;
             leo->school.n_wonders = 0;
             leo->school.wonder_ptr = 0;
+            leo->school.turn_clock = 0;
         }
     }
 
@@ -5886,6 +6015,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-rae")) g_leo_rae_on = 0;
         else if (!strcmp(argv[i], "--no-school")) g_leo_school_on = 0;
         else if (!strcmp(argv[i], "--no-wonder")) g_leo_wonder_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
         else if (!strcmp(argv[i], "--no-form")) g_leo_form_on = 0;
         else if (!strcmp(argv[i], "--no-klaus")) g_leo_klaus_on = 0;
         else if (!strcmp(argv[i], "--no-capsule")) g_leo_capsule_on = 0;
@@ -6141,6 +6271,11 @@ int main(int argc, char **argv) {
             if (g_leo_wonder_on && leo.school.pending[0])
                 printf("     [wonder: %s open, silence=%d, episodes=%d]\n",
                        leo.school.pending, leo.school.pending_turns, leo.school.n_wonders);
+            if (g_leo_wonder_return_on && leo.school.returned_episode >= 0) {
+                const LeoWonderEpisode *ep = &leo.school.wonders[leo.school.returned_episode];
+                printf("     [wonder-return: %s -> %s, recalls=%d]\n",
+                       ep->word, GLYPH_NAMES[(int)ep->answer_glyph], ep->recalls);
+            }
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */
                 printf("     [async: rings lived=%ld]\n", async.rings_done);
                 pthread_rwlock_unlock(&async.field_lock);

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -1121,26 +1121,50 @@ int main(void) {
               w.school.pending_turns == 0 && w.school.wonders[0].returns == 1,
               "wonder: resonant water returns the unfinished question after silence");
 
-        const char *open = "/tmp/leo_wonder_open_v11.state";
+        const char *open = "/tmp/leo_wonder_open_v12.state";
         const char *old = "/tmp/leo_wonder_open_v10.state";
+        const char *compat = "/tmp/leo_wonder_open_v11.state";
         const char *cut = "/tmp/leo_wonder_open_cut.state";
         const char *bad = "/tmp/leo_wonder_open_bad.state";
-        int saved = leo_save_state(&w, open), built_old = 0, built_cut = 0, built_bad = 0;
+        int saved = leo_save_state(&w, open), built_old = 0, built_compat = 0,
+            built_cut = 0, built_bad = 0;
         FILE *fi = fopen(open, "rb");
         if (fi) {
             fseek(fi, 0, SEEK_END); long sz = ftell(fi); fseek(fi, 0, SEEK_SET);
             unsigned char *bytes = malloc(sz > 0 ? (size_t)sz : 1);
             if (bytes && sz > 0 && (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
-                long v11tail = (long)(4 * sizeof(int32_t) + sizeof(LeoWonderEpisode));
-                if (sz > v11tail) {
+                long v12tail = (long)(4 * sizeof(int32_t) + sizeof(uint64_t) +
+                                      sizeof(LeoWonderEpisode));
+                if (sz > v12tail) {
+                    long tail_start = sz - v12tail;
                     uint32_t ten = 10; memcpy(bytes + 4, &ten, sizeof ten);
                     FILE *fo = fopen(old, "wb");
-                    if (fo) { built_old = (long)fwrite(bytes, 1, (size_t)(sz - v11tail), fo) == sz - v11tail; fclose(fo); }
+                    if (fo) { built_old = (long)fwrite(bytes, 1, (size_t)tail_start, fo) == tail_start; fclose(fo); }
+
                     uint32_t eleven = 11; memcpy(bytes + 4, &eleven, sizeof eleven);
+                    LeoWonderEpisode *cur = &w.school.wonders[0];
+                    LeoWonderEpisodeV11 oldep = {0};
+                    memcpy(oldep.word, cur->word, sizeof oldep.word);
+                    oldep.offered_glyph = cur->offered_glyph;
+                    oldep.offered_alt_glyph = cur->offered_alt_glyph;
+                    oldep.answer_glyph = cur->answer_glyph;
+                    oldep.resolved = cur->resolved;
+                    oldep.returns = cur->returns;
+                    oldep.opened_step = cur->opened_step;
+                    oldep.closed_step = cur->closed_step;
+                    fo = fopen(compat, "wb");
+                    if (fo) {
+                        long prefix = tail_start + (long)(4 * sizeof(int32_t));
+                        built_compat = (long)fwrite(bytes, 1, (size_t)prefix, fo) == prefix &&
+                                       fwrite(&oldep, sizeof oldep, 1, fo) == 1;
+                        fclose(fo);
+                    }
+
+                    uint32_t twelve = 12; memcpy(bytes + 4, &twelve, sizeof twelve);
                     fo = fopen(cut, "wb");
                     if (fo) { built_cut = (long)fwrite(bytes, 1, (size_t)(sz - 4), fo) == sz - 4; fclose(fo); }
                     int32_t too_many = LEO_WONDER_RING + 1;
-                    memcpy(bytes + sz - v11tail + 2 * sizeof(int32_t), &too_many, sizeof too_many);
+                    memcpy(bytes + tail_start + 2 * sizeof(int32_t), &too_many, sizeof too_many);
                     fo = fopen(bad, "wb");
                     if (fo) { built_bad = (long)fwrite(bytes, 1, (size_t)sz, fo) == sz; fclose(fo); }
                 }
@@ -1158,15 +1182,21 @@ int main(void) {
               !strcmp(oldw.school.wonders[0].word, "zorble"),
               "wonder: the first lived v10 turn materializes its surviving question");
         Leo cutw; leo_init(&cutw);
+        int loaded_compat = built_compat && leo_load_state(&cutw, compat);
+        CHECK(loaded_compat && cutw.school.n_wonders == 1 &&
+              cutw.school.wonders[0].recalls == 0 &&
+              cutw.school.wonders[0].last_recalled_turn == 0,
+              "wonder: a v11 episode migrates with returned-wonder fields clean");
+        leo_free(&cutw); leo_init(&cutw);
         int loaded_cut = built_cut && leo_load_state(&cutw, cut);
         CHECK(loaded_cut && !strcmp(cutw.school.pending, "zorble") &&
               cutw.school.pending_alt_glyph == -1 && cutw.school.n_wonders == 0,
-              "wonder: a truncated v11 ledger fails soft; the question still lives");
+              "wonder: a truncated v12 ledger fails soft; the question still lives");
         Leo badw; leo_init(&badw);
         int loaded_bad = built_bad && leo_load_state(&badw, bad);
         CHECK(loaded_bad && !strcmp(badw.school.pending, "zorble") &&
               badw.school.pending_alt_glyph == -1 && badw.school.n_wonders == 0,
-              "wonder: an impossible v11 episode count fails soft; the question still lives");
+              "wonder: an impossible v12 episode count fails soft; the question still lives");
 
         Leo slept; leo_init(&slept);
         int loaded = saved && leo_load_state(&slept, open);
@@ -1185,7 +1215,7 @@ int main(void) {
               "wonder: the resolved human-grounded episode survives another sleep");
 
         leo_free(&w); leo_free(&oldw); leo_free(&cutw); leo_free(&badw); leo_free(&slept); leo_free(&woke);
-        remove(open); remove(old); remove(cut); remove(bad);
+        remove(open); remove(old); remove(compat); remove(cut); remove(bad);
         g_leo_school_on = prev_school; g_leo_wonder_on = prev_wonder;
     }
 
@@ -1204,6 +1234,104 @@ int main(void) {
               "wonder: --no-wonder is the pre-wonder one-turn School contract");
         leo_free(&ab);
         g_leo_school_on = prev_school; g_leo_wonder_on = prev_wonder;
+    }
+
+    /* W-4: a resolved question later returns as glyph attention, not text. The
+     * answer, the route Leo once considered, and QUESTION blend into exactly one
+     * reply's meaning vector; the existing spore-resonance channel is the only
+     * speech-side reader. Cooldown and --no-wonder-return bound the effect. */
+    {
+        Leo *wr = malloc(sizeof *wr), *woke = malloc(sizeof *woke);
+        CHECK(wr && woke, "wonder-return: heap fixtures allocated (no new Leo on test stack)");
+        if (wr && woke) {
+            int prev_school = g_leo_school_on;
+            int prev_wonder = g_leo_wonder_on;
+            int prev_return = g_leo_wonder_return_on;
+            int prev_capsule = g_leo_capsule_on;
+            g_leo_school_on = 1; g_leo_wonder_on = 1;
+            g_leo_wonder_return_on = 1; g_leo_capsule_on = 1;
+            leo_init(wr); leo_init(woke);
+            int water = semtok_word("water"), animal = semtok_word("animal");
+            int question = semtok_find_glyph("question");
+            leo_school_learn(wr, "zorble", animal);
+            LeoWonderEpisode *ep = leo_wonder_open(wr, "zorble", water, animal);
+            ep->resolved = 1; ep->answer_glyph = (int8_t)animal;
+            ep->closed_step = ++wr->step;
+            wr->step++;
+            wr->school.turn_clock = 1;
+
+            float base[GLYPH_COUNT], remembered[GLYPH_COUNT];
+            leo_glyph_hist(wr, "tell me about zorble", base);
+            memcpy(remembered, base, sizeof base);
+            int idx = leo_wonder_return_meaning(wr, "tell me about zorble", remembered);
+            float sum = 0.0f; for (int i = 0; i < GLYPH_COUNT; i++) sum += remembered[i];
+            CHECK(idx == 0 && ep->recalls == 1 && ep->last_recalled_turn == wr->school.turn_clock &&
+                  wr->school.returned_episode == 0,
+                  "wonder-return: the learned word recognizes its resolved episode");
+            CHECK(remembered[water] > base[water] && remembered[question] > base[question] &&
+                  fabsf(sum - 1.0f) < 1e-5f,
+                  "wonder-return: answer path + QUESTION enter normalized glyph attention only");
+
+            LeoSpore trace = {0};
+            trace.meaning_snap[water] = 0.7f;
+            trace.meaning_snap[question] = 0.3f;
+            wr->prompt_meaning = base;
+            float before = leo_spore_resonance(wr, &trace);
+            wr->prompt_meaning = remembered;
+            float after = leo_spore_resonance(wr, &trace);
+            wr->prompt_meaning = NULL;
+            CHECK(after > before,
+                  "wonder-return: returned glyphs raise only existing spore resonance");
+
+            float cooled[GLYPH_COUNT]; memcpy(cooled, base, sizeof base);
+            CHECK(leo_wonder_return_meaning(wr, "tell me about zorble", cooled) < 0 &&
+                  !memcmp(cooled, base, sizeof base) && ep->recalls == 1,
+                  "wonder-return: cooldown prevents repetitive self-evocation");
+
+            const char *path = "/tmp/leo_wonder_return_v12.state";
+            int saved_return = leo_save_state(wr, path);
+            int loaded_return = saved_return && leo_load_state(woke, path);
+            CHECK(loaded_return && woke->school.n_wonders == 1 &&
+                  woke->school.wonders[0].recalls == 1 &&
+                  woke->school.wonders[0].last_recalled_turn == ep->last_recalled_turn &&
+                  woke->school.turn_clock == wr->school.turn_clock,
+                  "wonder-return: recall count and cooldown survive v12 sleep");
+
+            wr->school.turn_clock += LEO_WONDER_RETURN_COOLDOWN;
+            float thematic[GLYPH_COUNT];
+            leo_glyph_hist(wr, "animal beside water", thematic);
+            CHECK(leo_wonder_return_meaning(wr, "animal beside water", thematic) == 0 &&
+                  ep->recalls == 2,
+                  "wonder-return: answer plus a lived hypothesis can recognize the path without its name");
+
+            wr->school.turn_clock += LEO_WONDER_RETURN_COOLDOWN;
+            float unrelated[GLYPH_COUNT], unrelated_before[GLYPH_COUNT];
+            leo_glyph_hist(wr, "warm mother light", unrelated);
+            memcpy(unrelated_before, unrelated, sizeof unrelated);
+            CHECK(leo_wonder_return_meaning(wr, "warm mother light", unrelated) < 0 &&
+                  !memcmp(unrelated, unrelated_before, sizeof unrelated),
+                  "wonder-return: unrelated ordinary meaning stays byte-identical");
+
+            char meta_out[512]; int recalls_before_meta = ep->recalls;
+            leo_respond(wr, "is a wobble beside zorble", meta_out, sizeof meta_out);
+            CHECK(strstr(meta_out, "Wobble?") && ep->recalls == recalls_before_meta &&
+                  wr->school.returned_episode < 0,
+                  "wonder-return: a new School question cannot claim an unconsumed old recall");
+
+            float ablated[GLYPH_COUNT]; memcpy(ablated, base, sizeof base);
+            g_leo_wonder_return_on = 0;
+            CHECK(leo_wonder_return_meaning(wr, "tell me about zorble", ablated) < 0 &&
+                  !memcmp(ablated, base, sizeof base),
+                  "wonder-return: --no-wonder-return is a strict meaning ablation");
+
+            remove(path);
+            leo_free(wr); leo_free(woke);
+            g_leo_school_on = prev_school;
+            g_leo_wonder_on = prev_wonder;
+            g_leo_wonder_return_on = prev_return;
+            g_leo_capsule_on = prev_capsule;
+        }
+        free(wr); free(woke);
     }
 
     /* A.6 FORM fix: --mode is case-insensitive. leo_mode_from_name matched only the


### PR DESCRIPTION
Add a glyph-only returned-wonder path through existing spore resonance, with lived-turn cooldown, v12 persistence, v11 migration, a strict ablation, and evidence that ordinary voice remains unchanged.\n\nQuote: "It's no use going back to yesterday, because I was a different person then." - Lewis Carroll, Alice's Adventures in Wonderland\n\nMethod: The Arianna Method lets a learned answer return as attention without hard-coding what Leo must say.