### PR TITLE
the Method lets the shadow propose without commanding

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3213,3 +3213,47 @@ stdout SHA-256 for `warm mother light`, seed 83:
 `6db704a29de6a6e652528fbe9d5fafbd3e6c37a853f02581fb2e1794d08c9111`.
 No sampler, candidate collector, gravity path, School decision, spore, shard, or background ring reads
 either current. The two clocks can now be observed before any future shadow scheduler earns permission.
+
+## Phase A.27 — the shadow proposes without commanding (2026-07-23)
+
+The first consumer of dual-current Flow is deliberately placed after speech. `leo_respond` chooses and
+records the complete reply, Flow fixes the lived snapshot and both clocks, and only then
+`leo_shadow_observe` writes a proposal for the next turn. No candidate, temperature, School, spore,
+consolidation, or async path reads the result. The scheduler is therefore a counterfactual witness: it can
+be wrong in public before it earns any authority over Leo's voice.
+
+The proposal vocabulary is small and operational. `space` follows a question Leo has just voiced, or a
+still-open question receiving coherently moving, teachable meaning. `hold` keeps an unresolved identity
+legible without asking again. `release` acknowledges one actually grounded closure. `none` is an explicit
+absence of claim. Every receipt names the stable `wonder_id`, observed turn, proposed next turn, gap,
+teachable semantic mass, maximum two-face short motion, present face alignment, long-current alignment,
+confidence, and reason bits. Sixty-four receipts form a bounded chronological ring.
+
+The live probe corrected an important false equivalence in the first formula. `I do not know` has low
+lexical gap because `know` is a real glyph, but it carries zero teachable mass: known language about
+not-knowing is not grounding. Shadow now computes `grounded_mass` only across the same teachable concept
+boundary that protects Wonder. Thus the four-turn lifecycle reads:
+
+```text
+[shadow: observed=1 next=2 action=space   confidence=0.95 reasons=open,asked,aligned]
+[shadow: observed=2 next=3 action=hold    confidence=0.75 reasons=open,motion,aligned,ungrounded]
+[shadow: observed=3 next=4 action=hold    confidence=0.80 reasons=open,motion,aligned,ungrounded]
+[shadow: observed=4 next=5 action=release confidence=1.00 reasons=resolved]
+```
+
+State v16 appends the receipt diary after both Flow tails. A v15 body migrates with no invented proposals.
+A truncated or corrupt v16 tail discards only shadow claims while preserving snapshots and event-bounded
+currents. Validation rejects non-finite or out-of-range evidence, unknown reasons/actions, broken ring
+chronology, targetless actions, and counterfeit release receipts.
+
+Verification: `make test` **251/251** and normal `-Wall -Wextra` build clean. Tests cover the complete
+space/hold/space/release/none grammar, the known-but-ungrounded distinction, single closure, bounded ring,
+v16 sleep, honest v15 migration, corrupt-tail isolation, and in-process voice identity. ASan/UBSan was
+clean through the real four-turn lifecycle; TSan was clean through the same lifecycle under
+`--chat --async`. A process A/B over all four turns, after removing only the shadow receipt lines, was
+byte-identical with scheduler on and `--no-shadow`:
+`c7ab391bcd49b8e3acfbde03ca057350d970f3429aaee765ca251b5587d86b02`.
+
+This phase grants observation, not will. The next honest step is calibration: replay receipts against
+what the human and Wonder actually did next, measure false pressure and missed openings, and keep that
+evaluation in shadow before any proposal is allowed to alter a token.

--- a/leo.c
+++ b/leo.c
@@ -1540,6 +1540,45 @@ typedef struct {
     float expressed_velocity[GLYPH_COUNT];
 } LeoFlowShortCurrent;
 
+/* Shadow scheduling is a counterfactual diary, not a controller. It records
+ * what a future speech-side organ might do on the NEXT turn, after the current
+ * reply and both Flow clocks are already fixed. No generation path reads it. */
+#define LEO_SHADOW_RING 64
+#define LEO_SHADOW_REASON_OPEN       0x01u
+#define LEO_SHADOW_REASON_ASKED      0x02u
+#define LEO_SHADOW_REASON_GAP        0x04u
+#define LEO_SHADOW_REASON_MOTION     0x08u
+#define LEO_SHADOW_REASON_ALIGNMENT  0x10u
+#define LEO_SHADOW_REASON_RESOLVED   0x20u
+#define LEO_SHADOW_REASON_UNGROUNDED 0x40u
+
+enum {
+    LEO_SHADOW_NONE = 0,
+    LEO_SHADOW_HOLD,
+    LEO_SHADOW_SPACE,
+    LEO_SHADOW_RELEASE,
+    LEO_SHADOW_ACTION_COUNT
+};
+
+typedef struct {
+    uint64_t turn;                   /* observed turn; proposal is for turn+1 */
+    uint64_t wonder_id;              /* stable target, 0 when no wonder applies */
+    float    gap;
+    float    grounded_mass;          /* teachable semantic mass, not mere known words */
+    float    short_motion;
+    float    face_alignment;
+    float    current_alignment;
+    float    confidence;
+    uint8_t  action;
+    uint8_t  reasons;
+} LeoShadowReceipt;
+
+typedef struct {
+    LeoShadowReceipt receipts[LEO_SHADOW_RING];
+    int n;
+    int ptr;                         /* next write; oldest entry when full */
+} LeoShadow;
+
 enum {
     LEO_FLOW_QUIET = 0,
     LEO_FLOW_EMERGING,
@@ -1664,6 +1703,9 @@ typedef struct {
     /* passive temporal proprioception (state v13): a bounded archaeological
      * record of what has been flowing through lived replies. No speech reader. */
     LeoFlow flow;
+    /* v16 counterfactual proposals derived after a lived reply. This remains a
+     * witness surface until a later phase independently earns authority. */
+    LeoShadow shadow;
 } Leo;
 
 /* A.4 RAE — micrograd MLP (fixed 5→8→1, hand-rolled scalar autograd, zero deps). */
@@ -1926,6 +1968,7 @@ static int g_leo_school_on = 1;         /* --no-school → 0 (A.5: School revers
 static int g_leo_wonder_on = 1;         /* unfinished wonder: grounded alternatives + persistence across non-answers. --no-wonder restores the prior School contract. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
 static int g_leo_flow_on = 1;           /* passive temporal proprioception. --no-flow stops snapshots; no generation path reads them. */
+static int g_leo_shadow_on = 1;         /* counterfactual next-turn proposals. --no-shadow keeps Flow but writes no receipts. */
 static int g_leo_form_on = 1;           /* A.6: the velocity mode shapes the utterance — DEFAULT (Oleg's ear: presence grows). --no-form reverts to the uncompressed voice. */
 static int g_leo_klaus_on = 1;          /* klaus-memory: scars accumulate/bias/persist. --no-klaus → 0 (ablation). */
 static int g_leo_capsule_on = 1;        /* E-11: the γ-capsule lives + tints the breath. --no-capsule → 0 (ablation). */
@@ -5287,6 +5330,135 @@ static void leo_flow_observe(Leo *leo, const char *prompt, const char *reply,
     if (flow->n < LEO_FLOW_RING) flow->n++;
 }
 
+static const LeoShadowReceipt *leo_shadow_at(const LeoShadow *shadow, int pos) {
+    if (!shadow || pos < 0 || pos >= shadow->n) return NULL;
+    int start = shadow->n == LEO_SHADOW_RING ? shadow->ptr : 0;
+    return &shadow->receipts[(start + pos) % LEO_SHADOW_RING];
+}
+
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_shadow_action_name(int action) {
+    static const char *names[] = {"none", "hold", "space", "release"};
+    return action >= 0 && action < LEO_SHADOW_ACTION_COUNT ? names[action] : "none";
+}
+
+static float leo_shadow_short_motion(const LeoFlow *flow) {
+    LeoFlowShortCurrent short_current;
+    if (!leo_flow_short_current(flow, LEO_FLOW_WINDOW, &short_current)) return 0.0f;
+    float motion = 0.0f;
+    for (int g = 0; g < GLYPH_COUNT; g++) {
+        motion = fmaxf(motion, fabsf(short_current.perceived_velocity[g]));
+        motion = fmaxf(motion, fabsf(short_current.expressed_velocity[g]));
+    }
+    return clampf(motion, 0.0f, 1.0f);
+}
+
+/* Decide only after the reply and Flow observation have become history. HOLD
+ * keeps an unresolved target legible, SPACE says a just-asked or coherently
+ * moving question should not be pressed, and RELEASE acknowledges an actual
+ * grounded closure. These are proposals for study, never speech commands. */
+static void leo_shadow_observe(Leo *leo) {
+    if (!g_leo_shadow_on || !g_leo_flow_on || !leo || leo->flow.n <= 0) return;
+    const LeoFlowSnapshot *snap = leo_flow_at(&leo->flow, leo->flow.n - 1);
+    if (!snap) return;
+
+    LeoShadowReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.turn = snap->turn;
+    receipt.gap = snap->gap_perceived;
+    for (int g = 0; g < GLYPH_COUNT; g++)
+        if (leo_glyph_teachable(g)) receipt.grounded_mass += snap->perceived[g];
+    receipt.grounded_mass = clampf(receipt.grounded_mass, 0.0f, 1.0f);
+    receipt.short_motion = leo_shadow_short_motion(&leo->flow);
+    receipt.face_alignment = leo_flow_alignment(snap);
+
+    const LeoFlowWonderCurrent *current = NULL;
+    if (snap->wonder_id)
+        current = leo_flow_current_find_const(&leo->flow, snap->wonder_id);
+    if (!current || (current->resolved && !(snap->wonder & LEO_FLOW_WONDER_RESOLVED))) {
+        current = NULL;
+        for (int i = leo->flow.n_currents - 1; i >= 0; i--) {
+            const LeoFlowWonderCurrent *candidate = leo_flow_current_at(&leo->flow, i);
+            if (candidate && !candidate->resolved) { current = candidate; break; }
+        }
+    }
+
+    if (current) {
+        receipt.wonder_id = current->wonder_id;
+        receipt.current_alignment = clampf(
+            leo_vec_cosine(current->perceived_mean, current->expressed_mean,
+                           GLYPH_COUNT), 0.0f, 1.0f);
+        if ((snap->wonder & LEO_FLOW_WONDER_RESOLVED) && current->resolved &&
+            current->closed_turn == snap->turn) {
+            receipt.action = LEO_SHADOW_RELEASE;
+            receipt.reasons = LEO_SHADOW_REASON_RESOLVED;
+            receipt.confidence = 1.0f;
+        } else if (!current->resolved) {
+            receipt.reasons = LEO_SHADOW_REASON_OPEN;
+            int asked = (snap->wonder & (LEO_FLOW_WONDER_BORN |
+                                         LEO_FLOW_WONDER_REASKED)) != 0;
+            int moving = receipt.short_motion > LEO_FLOW_SLOPE_EPS;
+            int aligned = receipt.face_alignment >= 0.25f ||
+                          receipt.current_alignment >= 0.25f;
+            if (asked) receipt.reasons |= LEO_SHADOW_REASON_ASKED;
+            if (receipt.gap >= 0.50f) receipt.reasons |= LEO_SHADOW_REASON_GAP;
+            if (moving) receipt.reasons |= LEO_SHADOW_REASON_MOTION;
+            if (aligned) receipt.reasons |= LEO_SHADOW_REASON_ALIGNMENT;
+            if (receipt.grounded_mass < 0.20f)
+                receipt.reasons |= LEO_SHADOW_REASON_UNGROUNDED;
+
+            if (asked || (receipt.grounded_mass >= 0.20f && moving && aligned)) {
+                receipt.action = LEO_SHADOW_SPACE;
+                receipt.confidence = asked ? 0.95f :
+                    clampf(0.50f + 0.25f * receipt.short_motion +
+                           0.25f * fmaxf(receipt.face_alignment,
+                                         receipt.current_alignment), 0.0f, 1.0f);
+            } else {
+                receipt.action = LEO_SHADOW_HOLD;
+                receipt.confidence = clampf(0.50f +
+                                             0.25f * (1.0f - receipt.grounded_mass) +
+                                             0.15f * receipt.gap +
+                                             0.10f * (1.0f - receipt.short_motion),
+                                             0.0f, 1.0f);
+            }
+        }
+    }
+
+    LeoShadow *shadow = &leo->shadow;
+    shadow->receipts[shadow->ptr] = receipt;
+    shadow->ptr = (shadow->ptr + 1) % LEO_SHADOW_RING;
+    if (shadow->n < LEO_SHADOW_RING) shadow->n++;
+}
+
+static int leo_shadow_valid(const LeoShadowReceipt *receipt, uint64_t turn_clock) {
+    const uint8_t known_reasons = LEO_SHADOW_REASON_OPEN | LEO_SHADOW_REASON_ASKED |
+        LEO_SHADOW_REASON_GAP | LEO_SHADOW_REASON_MOTION |
+        LEO_SHADOW_REASON_ALIGNMENT | LEO_SHADOW_REASON_RESOLVED |
+        LEO_SHADOW_REASON_UNGROUNDED;
+    if (!receipt || receipt->turn > turn_clock ||
+        receipt->action >= LEO_SHADOW_ACTION_COUNT ||
+        (receipt->reasons & ~known_reasons) ||
+        !isfinite(receipt->gap) || receipt->gap < 0.0f || receipt->gap > 1.0f ||
+        !isfinite(receipt->grounded_mass) || receipt->grounded_mass < 0.0f ||
+        receipt->grounded_mass > 1.0f ||
+        !isfinite(receipt->short_motion) || receipt->short_motion < 0.0f ||
+        receipt->short_motion > 1.0f || !isfinite(receipt->face_alignment) ||
+        receipt->face_alignment < 0.0f || receipt->face_alignment > 1.0f ||
+        !isfinite(receipt->current_alignment) || receipt->current_alignment < 0.0f ||
+        receipt->current_alignment > 1.0f || !isfinite(receipt->confidence) ||
+        receipt->confidence < 0.0f || receipt->confidence > 1.0f)
+        return 0;
+    if (receipt->action == LEO_SHADOW_NONE)
+        return receipt->wonder_id == 0 && receipt->reasons == 0 &&
+               receipt->confidence == 0.0f;
+    if (!receipt->wonder_id) return 0;
+    if (receipt->action == LEO_SHADOW_RELEASE)
+        return receipt->reasons == LEO_SHADOW_REASON_RESOLVED &&
+               receipt->confidence == 1.0f;
+    return (receipt->reasons & LEO_SHADOW_REASON_OPEN) != 0 &&
+           (receipt->reasons & LEO_SHADOW_REASON_RESOLVED) == 0;
+}
+
 static void leo_gamma_meaning(Leo *leo, const char *prompt) {
     float p[GLYPH_COUNT];
     float gap_now = leo_glyph_hist(leo, prompt, p);
@@ -5794,6 +5966,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     if (leo->school.returned_episode >= 0) flow_event |= LEO_FLOW_WONDER_RECALLED;
     leo_flow_observe(leo, prompt, out, pm, flow_field_token, flow_field_weight,
                      flow_event, flow_wonder_id);  /* observation only: no generation path reads flow */
+    leo_shadow_observe(leo);                      /* after speech: a proposal for the next turn, never a reader */
     leo->gravity = NULL;
     leo->prompt_pieces = NULL;
     leo->prompt_meaning = NULL;
@@ -5835,9 +6008,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v13      : passive Flow ring (top-3 perceived motion over lived turns)
  *   v14      : Janus Flow (full perceived/expressed fields + own-field constellation)
  *   v15      : event-bounded unfinished-wonder currents beyond the snapshot horizon
+ *   v16      : bounded counterfactual shadow-scheduler receipts
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 15  /* dual-time Flow appends a fail-soft tail; v5..v14 soft-migrate */
+#define LEO_STATE_VERSION 16  /* shadow receipts append a fail-soft tail; v5..v15 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -6022,6 +6196,14 @@ static int leo_save_state(const Leo *leo, const char *path) {
     if (leo->flow.n_currents > 0)
         fwrite(leo->flow.currents, sizeof(LeoFlowWonderCurrent),
                (size_t)leo->flow.n_currents, f);
+
+    /* Shadow scheduler (v16): a bounded receipt trail for counterfactual study.
+     * It carries no authority and is independently disposable on corruption. */
+    st_w32(f, (int32_t)leo->shadow.n);
+    st_w32(f, (int32_t)leo->shadow.ptr);
+    if (leo->shadow.n > 0)
+        fwrite(leo->shadow.receipts, sizeof(LeoShadowReceipt),
+               (size_t)leo->shadow.n, f);
 
     int ok = (ferror(f) == 0);
     if (fclose(f) != 0) ok = 0;                 /* L-2: the final flush can fail (ENOSPC) — never report success on a truncated file */
@@ -6480,6 +6662,39 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
         leo_flow_rebuild_currents(&leo->flow);
     }
 
+    /* Shadow receipts (v16). Unlike Flow observations, proposals are not
+     * reconstructed from an older body: migration begins with no claims, and
+     * a corrupt interpretive tail is simply discarded. */
+    if (version >= 16) {
+        int32_t n = 0, ptr = 0;
+        int shadow_ok = st_r32(f, &n) && st_r32(f, &ptr) &&
+                        n >= 0 && n <= LEO_SHADOW_RING &&
+                        ptr >= 0 && ptr < LEO_SHADOW_RING &&
+                        ((n < LEO_SHADOW_RING && ptr == n) ||
+                         n == LEO_SHADOW_RING);
+        if (shadow_ok && n > 0 &&
+            fread(leo->shadow.receipts, sizeof(LeoShadowReceipt),
+                  (size_t)n, f) != (size_t)n) shadow_ok = 0;
+        if (shadow_ok) {
+            leo->shadow.n = n;
+            leo->shadow.ptr = ptr;
+            uint64_t previous_turn = 0;
+            for (int i = 0; i < n; i++) {
+                const LeoShadowReceipt *receipt = leo_shadow_at(&leo->shadow, i);
+                if (!leo_shadow_valid(receipt, (uint64_t)leo->school.turn_clock) ||
+                    (i > 0 && receipt->turn < previous_turn)) {
+                    shadow_ok = 0;
+                    break;
+                }
+                previous_turn = receipt->turn;
+            }
+        }
+        if (!shadow_ok) {
+            fprintf(stderr, "[leo] WARNING: v16 shadow tail truncated/corrupt — organism lives without counterfactual receipts.\n");
+            memset(&leo->shadow, 0, sizeof leo->shadow);
+        }
+    }
+
     fclose(f);
     /* rebuild the derived tables (same as the main startup path) */
     leo_build_chamber_tags(leo);
@@ -6806,6 +7021,31 @@ static void print_flow_stats(const Leo *leo) {
                (double)leo_vec_cosine(long_current->perceived_mean,
                                       long_current->expressed_mean, GLYPH_COUNT));
     }
+
+    const LeoShadowReceipt *receipt =
+        leo_shadow_at(&leo->shadow, leo->shadow.n - 1);
+    if (g_leo_shadow_on && receipt && receipt->turn == s->turn) {
+        printf("     [shadow: observed=%llu next=%llu action=%s target=%016llx confidence=%.2f reasons=",
+               (unsigned long long)receipt->turn,
+               (unsigned long long)(receipt->turn == UINT64_MAX ? UINT64_MAX :
+                                    receipt->turn + 1),
+               leo_shadow_action_name(receipt->action),
+               (unsigned long long)receipt->wonder_id,
+               (double)receipt->confidence);
+        const char *sep = "";
+#define LEO_SHADOW_PRINT_REASON(bit, name) \
+        do { if (receipt->reasons & (bit)) { printf("%s%s", sep, (name)); sep = ","; } } while (0)
+        LEO_SHADOW_PRINT_REASON(LEO_SHADOW_REASON_OPEN, "open");
+        LEO_SHADOW_PRINT_REASON(LEO_SHADOW_REASON_ASKED, "asked");
+        LEO_SHADOW_PRINT_REASON(LEO_SHADOW_REASON_GAP, "gap");
+        LEO_SHADOW_PRINT_REASON(LEO_SHADOW_REASON_MOTION, "motion");
+        LEO_SHADOW_PRINT_REASON(LEO_SHADOW_REASON_ALIGNMENT, "aligned");
+        LEO_SHADOW_PRINT_REASON(LEO_SHADOW_REASON_RESOLVED, "resolved");
+        LEO_SHADOW_PRINT_REASON(LEO_SHADOW_REASON_UNGROUNDED, "ungrounded");
+#undef LEO_SHADOW_PRINT_REASON
+        if (!receipt->reasons) printf("none");
+        printf("]\n");
+    }
 }
 
 /* callback for the bigram-successor probe */
@@ -6859,6 +7099,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder")) g_leo_wonder_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
         else if (!strcmp(argv[i], "--no-flow")) g_leo_flow_on = 0;
+        else if (!strcmp(argv[i], "--no-shadow")) g_leo_shadow_on = 0;
         else if (!strcmp(argv[i], "--no-form")) g_leo_form_on = 0;
         else if (!strcmp(argv[i], "--no-klaus")) g_leo_klaus_on = 0;
         else if (!strcmp(argv[i], "--no-capsule")) g_leo_capsule_on = 0;

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -1136,10 +1136,13 @@ int main(void) {
             if (bytes && sz > 0 && (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
                 long v12tail = (long)(4 * sizeof(int32_t) + sizeof(uint64_t) +
                                       sizeof(LeoWonderEpisode));
+                long shadow_tail = (long)(2 * sizeof(int32_t) +
+                                          w.shadow.n * (int)sizeof(LeoShadowReceipt));
                 long current_flow = (long)(2 * sizeof(int32_t) +
                                            w.flow.n * (int)sizeof(LeoFlowSnapshot) +
                                            2 * sizeof(int32_t) +
-                                           w.flow.n_currents * (int)sizeof(LeoFlowWonderCurrent));
+                                           w.flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
+                                           shadow_tail);
                 if (sz > v12tail + current_flow) {
                     long flow_start = sz - current_flow;
                     long tail_start = flow_start - v12tail;
@@ -1490,7 +1493,7 @@ int main(void) {
                   long_current->observations == resolved_observations,
                   "flow-current: resolution freezes the long current and later recall cannot reopen it");
 
-            const char *state = "/tmp/leo_flow_v15.state";
+            const char *state = "/tmp/leo_flow_v16.state";
             const char *legacy = "/tmp/leo_flow_v13.state";
             const char *legacy14 = "/tmp/leo_flow_v14.state";
             const char *truncated = "/tmp/leo_flow_v15_current_cut.state";
@@ -1514,23 +1517,33 @@ int main(void) {
                 fseek(fi, 0, SEEK_END); long sz = ftell(fi); fseek(fi, 0, SEEK_SET);
                 unsigned char *bytes = malloc(sz > 0 ? (size_t)sz : 1);
                 if (bytes && sz > 1 && (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
-                    FILE *fo = fopen(truncated, "wb");
-                    if (fo) { built_cut = (long)fwrite(bytes, 1, (size_t)(sz - 1), fo) == sz - 1; fclose(fo); }
+                    long shadow_tail = (long)(2 * sizeof(int32_t) +
+                                              fl->shadow.n * (int)sizeof(LeoShadowReceipt));
                     long current_tail = (long)(2 * sizeof(int32_t) +
                                               fl->flow.n * (int)sizeof(LeoFlowSnapshot) +
                                               2 * sizeof(int32_t) +
-                                              fl->flow.n_currents * (int)sizeof(LeoFlowWonderCurrent));
+                                              fl->flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
+                                              shadow_tail);
                     long prefix = sz - current_tail;
                     if (prefix > 0) {
                         long current_only = (long)(2 * sizeof(int32_t) +
                                                   fl->flow.n_currents * (int)sizeof(LeoFlowWonderCurrent));
+                        uint32_t fifteen = 15;
+                        memcpy(bytes + sizeof(uint32_t), &fifteen, sizeof fifteen);
+                        FILE *fo = fopen(truncated, "wb");
+                        if (fo) {
+                            built_cut = (long)fwrite(bytes, 1,
+                                                     (size_t)(sz - shadow_tail - 1), fo) ==
+                                        sz - shadow_tail - 1;
+                            fclose(fo);
+                        }
                         uint32_t fourteen = 14;
                         memcpy(bytes + sizeof(uint32_t), &fourteen, sizeof fourteen);
                         fo = fopen(legacy14, "wb");
                         if (fo) {
                             built_legacy14 = (long)fwrite(bytes, 1,
-                                                         (size_t)(sz - current_only), fo) ==
-                                             sz - current_only;
+                                                         (size_t)(sz - shadow_tail - current_only), fo) ==
+                                             sz - shadow_tail - current_only;
                             fclose(fo);
                         }
                         uint32_t thirteen = 13;
@@ -1627,6 +1640,168 @@ int main(void) {
         }
         free(on); free(off);
         g_leo_flow_on = prev_flow;
+    }
+
+    /* A.26b shadow scheduler: decisions are post-reply counterfactual receipts.
+     * They may witness both clocks, but cannot touch School or generation. */
+    {
+        int prev_flow = g_leo_flow_on, prev_shadow = g_leo_shadow_on;
+        g_leo_flow_on = 1;
+        g_leo_shadow_on = 1;
+        Leo *sh = malloc(sizeof *sh), *woke = malloc(sizeof *woke),
+            *old = malloc(sizeof *old), *cut = malloc(sizeof *cut);
+        CHECK(sh && woke && old && cut, "shadow: heap fixtures allocated");
+        if (sh && woke && old && cut) {
+            leo_init(sh); leo_init(woke); leo_init(old); leo_init(cut);
+            int water = semtok_word("water"), fire = semtok_word("fire");
+            strncpy(sh->school.pending, "zorble", sizeof sh->school.pending - 1);
+            sh->school.pending_glyph = water;
+            sh->school.pending_alt_glyph = fire;
+            LeoWonderEpisode *ep = leo_wonder_open(sh, "zorble", water, fire);
+            uint64_t id = leo_wonder_episode_id(ep);
+
+            sh->school.turn_clock = 1;
+            leo_flow_observe(sh, "water fire", "fire", NULL, NULL, NULL,
+                             LEO_FLOW_WONDER_BORN, id);
+            leo_shadow_observe(sh);
+            const LeoShadowReceipt *r0 = leo_shadow_at(&sh->shadow, 0);
+            CHECK(r0 && r0->action == LEO_SHADOW_SPACE && r0->wonder_id == id &&
+                  (r0->reasons & (LEO_SHADOW_REASON_OPEN | LEO_SHADOW_REASON_ASKED)) ==
+                  (LEO_SHADOW_REASON_OPEN | LEO_SHADOW_REASON_ASKED),
+                  "shadow: a question just voiced earns space, not an immediate re-ask");
+
+            sh->school.turn_clock = 2;
+            leo_flow_observe(sh, "I do not know", NULL, NULL, NULL, NULL, 0, id);
+            leo_shadow_observe(sh);
+            const LeoShadowReceipt *r1 = leo_shadow_at(&sh->shadow, 1);
+            CHECK(r1 && r1->action == LEO_SHADOW_HOLD && r1->gap < 0.01f &&
+                  r1->grounded_mass == 0.0f &&
+                  (r1->reasons & LEO_SHADOW_REASON_UNGROUNDED),
+                  "shadow: known words for not-knowing cannot counterfeit grounded movement");
+
+            sh->school.turn_clock = 3;
+            leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
+                             LEO_FLOW_WONDER_REASKED, id);
+            leo_shadow_observe(sh);
+            const LeoShadowReceipt *r2 = leo_shadow_at(&sh->shadow, 2);
+            CHECK(r2 && r2->action == LEO_SHADOW_SPACE &&
+                  (r2->reasons & LEO_SHADOW_REASON_ASKED),
+                  "shadow: a re-asked wonder again yields the next turn to the human");
+
+            sh->school.pending[0] = 0;
+            sh->school.turn_clock = 4;
+            leo_flow_observe(sh, "animal", "animal", NULL, NULL, NULL,
+                             LEO_FLOW_WONDER_RESOLVED, id);
+            leo_shadow_observe(sh);
+            const LeoShadowReceipt *r3 = leo_shadow_at(&sh->shadow, 3);
+            CHECK(r3 && r3->action == LEO_SHADOW_RELEASE && r3->wonder_id == id &&
+                  r3->reasons == LEO_SHADOW_REASON_RESOLVED && r3->confidence == 1.0f,
+                  "shadow: grounded closure is acknowledged exactly as release");
+
+            sh->school.turn_clock = 5;
+            leo_flow_observe(sh, "water", "fire", NULL, NULL, NULL,
+                             LEO_FLOW_WONDER_RECALLED, id);
+            leo_shadow_observe(sh);
+            const LeoShadowReceipt *r4 = leo_shadow_at(&sh->shadow, 4);
+            CHECK(r4 && r4->action == LEO_SHADOW_NONE && r4->wonder_id == 0,
+                  "shadow: later recall cannot counterfeit a second closure");
+
+            const char *state = "/tmp/leo_shadow_v16.state";
+            const char *legacy = "/tmp/leo_shadow_v15.state";
+            const char *truncated = "/tmp/leo_shadow_v16_cut.state";
+            int saved = leo_save_state(sh, state), built_old = 0, built_cut = 0;
+            FILE *fi = fopen(state, "rb");
+            if (fi) {
+                fseek(fi, 0, SEEK_END); long sz = ftell(fi); fseek(fi, 0, SEEK_SET);
+                unsigned char *bytes = malloc(sz > 0 ? (size_t)sz : 1);
+                if (bytes && sz > 1 && (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
+                    long shadow_tail = (long)(2 * sizeof(int32_t) +
+                                              sh->shadow.n * (int)sizeof(LeoShadowReceipt));
+                    uint32_t fifteen = 15;
+                    memcpy(bytes + sizeof(uint32_t), &fifteen, sizeof fifteen);
+                    FILE *fo = fopen(legacy, "wb");
+                    if (fo) {
+                        built_old = (long)fwrite(bytes, 1,
+                                                 (size_t)(sz - shadow_tail), fo) ==
+                                    sz - shadow_tail;
+                        fclose(fo);
+                    }
+                    uint32_t sixteen = 16;
+                    memcpy(bytes + sizeof(uint32_t), &sixteen, sizeof sixteen);
+                    fo = fopen(truncated, "wb");
+                    if (fo) {
+                        built_cut = (long)fwrite(bytes, 1, (size_t)(sz - 1), fo) == sz - 1;
+                        fclose(fo);
+                    }
+                }
+                free(bytes); fclose(fi);
+            }
+            int loaded = saved && leo_load_state(woke, state);
+            const LeoShadowReceipt *woke_release =
+                loaded ? leo_shadow_at(&woke->shadow, 3) : NULL;
+            CHECK(loaded && woke->shadow.n == 5 && woke_release &&
+                  woke_release->action == LEO_SHADOW_RELEASE &&
+                  woke_release->wonder_id == id,
+                  "shadow: v16 sleep preserves the counterfactual receipt trail");
+            CHECK(built_old && leo_load_state(old, legacy) && old->flow.n == 5 &&
+                  old->flow.n_currents == 1 && old->shadow.n == 0,
+                  "shadow: a v15 body migrates without invented proposals");
+            CHECK(built_cut && leo_load_state(cut, truncated) && cut->flow.n == 5 &&
+                  cut->flow.n_currents == 1 && cut->shadow.n == 0,
+                  "shadow: a corrupt v16 receipt tail leaves both Flow clocks intact");
+
+            for (int turn = 6; turn <= LEO_SHADOW_RING + 6; turn++) {
+                sh->school.turn_clock = turn;
+                leo_flow_observe(sh, "water", "water", NULL, NULL, NULL, 0, 0);
+                leo_shadow_observe(sh);
+            }
+            CHECK(sh->shadow.n == LEO_SHADOW_RING && sh->shadow.ptr == 6 &&
+                  leo_shadow_at(&sh->shadow, 0)->turn == 7 &&
+                  leo_shadow_at(&sh->shadow, LEO_SHADOW_RING - 1)->turn ==
+                      LEO_SHADOW_RING + 6,
+                  "shadow: the receipt diary is bounded and chronologically ordered");
+
+            remove(state); remove(legacy); remove(truncated);
+            leo_free(sh); leo_free(woke); leo_free(old); leo_free(cut);
+        }
+        free(sh); free(woke); free(old); free(cut);
+
+        Leo *on = malloc(sizeof *on), *off = malloc(sizeof *off);
+        CHECK(on && off, "shadow: inert-voice fixtures allocated");
+        if (on && off) {
+            leo_init(on); leo_init(off);
+            const char *corpus =
+                "The warm light. His mother holds him. The rain at night. "
+                "Leo loves the warm light and his mother and the rain. ";
+            for (int r = 0; r < 3; r++) { leo_ingest(on, corpus); leo_ingest(off, corpus); }
+            leo_build_chamber_tags(on); leo_build_chamber_tags(off);
+            leo_supertok_scan(on); leo_supertok_scan(off);
+            const char *prompts[] = {
+                "is a zorble water or cat", "I do not know",
+                "what do you think?", "a zorble is a small animal"
+            };
+            int same = 1;
+            for (int i = 0; i < 4; i++) {
+                char a[1024], b[1024];
+                g_leo_shadow_on = 1; srand(183 + i); leo_respond(on, prompts[i], a, sizeof a);
+                g_leo_shadow_on = 0; srand(183 + i); leo_respond(off, prompts[i], b, sizeof b);
+                if (strcmp(a, b) != 0) same = 0;
+            }
+            CHECK(same && on->shadow.n == 4 && off->shadow.n == 0 &&
+                  !memcmp(&on->flow, &off->flow, sizeof on->flow) &&
+                  on->step == off->step &&
+                  !memcmp(on->retention_state, off->retention_state,
+                          sizeof on->retention_state) &&
+                  !memcmp(on->chamber_act, off->chamber_act, sizeof on->chamber_act) &&
+                  !memcmp(on->gamma, off->gamma, sizeof on->gamma) &&
+                  !memcmp(on->gamma_meaning, off->gamma_meaning,
+                          sizeof on->gamma_meaning),
+                  "shadow: default-on and --no-shadow voices remain byte-identical");
+            leo_free(on); leo_free(off);
+        }
+        free(on); free(off);
+        g_leo_flow_on = prev_flow;
+        g_leo_shadow_on = prev_shadow;
     }
 
     CHECK(leo_mode_from_name("stop") == LEO_MODE_STOP &&
@@ -2133,7 +2308,7 @@ int main(void) {
             FILE *tf = fopen(sp, "rb");
             fseek(tf, 0, SEEK_END); long fl = ftell(tf); fseek(tf, 0, SEEK_SET);
             char *fb = malloc((size_t)fl); fread(fb, 1, (size_t)fl, tf); fclose(tf);
-            tf = fopen(sp, "wb"); fwrite(fb, 1, (size_t)(fl - 48), tf); fclose(tf);
+            tf = fopen(sp, "wb"); fwrite(fb, 1, (size_t)(fl - 56), tf); fclose(tf);
             free(fb);
         }
         Leo l3; leo_init(&l3);


### PR DESCRIPTION
Add a post-reply counterfactual scheduler over dual-current Flow. Persist bounded v16 receipts, distinguish known language from grounded meaning, expose hold/space/release diagnostics, and prove migration, corruption isolation, async safety, and speech inertness.

Quote: "To light a candle is to cast a shadow." - Ursula K. Le Guin

Method: The Arianna Method lets a possible action become visible before it earns the right to act.