### PR TITLE
the Method lets the next turn judge the shadow

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3257,3 +3257,53 @@ byte-identical with scheduler on and `--no-shadow`:
 This phase grants observation, not will. The next honest step is calibration: replay receipts against
 what the human and Wonder actually did next, measure false pressure and missed openings, and keep that
 evaluation in shadow before any proposal is allowed to alter a token.
+
+## Phase A.28 — the next turn judges the shadow (2026-07-23)
+
+Shadow confidence is no longer allowed to validate itself on the turn where it was produced. After reply
+`t` becomes immutable history, the scheduler proposes for `t+1`. Only after reply `t+1` and its Flow
+snapshot exist does `leo_shadow_calibrate` judge the prior proposal; the new proposal for `t+2` is written
+after that verdict. Reload preserves this ordering: an unevaluated proposal saved at sleep receives its
+first verdict from the first lived turn after waking.
+
+Calibration judges scheduling semantics rather than trying to predict the human's sentence. `space` is
+not wrong when the human says "I do not know"; allowing that answer was the point. Instead, the ledger
+names structural failures: `false-pressure` when the existing organism reasks immediately despite a
+`hold/space` proposal, `missed-opening` when an unfinished target disappears without resolution, and
+`release-relapse` when the same released identity returns open. Everything else is `confirmed`; a
+non-adjacent turn is `unscorable`, never silently paired. Confidence is recorded with a Brier score, but
+no threshold or weight is adapted online. Measurement precedes self-modification.
+
+Each `LeoCalibrationReceipt` copies the proposal turn, observed turn, stable wonder identity, proposed
+action and confidence, observed Wonder event, verdict, and Brier error. The 64-entry ring is independent
+of the proposal ring and remains read-only to generation. State v17 appends this ledger after the v16
+shadow tail. A v16 body wakes with no retroactive verdicts; a damaged v17 tail discards only calibration
+while preserving Flow and shadow; verdict chronology and semantic evidence are validated on load.
+
+The first process-level save/reload found a floating-point boundary that synthetic vectors missed:
+cosine alignment for a perfect live match was `1.00000012`. The v16 loader correctly rejected values over
+its stated unit interval, but that made an honest live receipt look corrupt. New receipts now clamp cosine
+at birth. Existing v16/v17 states accept only a `1e-4` numerical halo and canonicalize all scalar evidence
+back into `[0,1]` during load. A dedicated regression writes `1+epsilon`, sleeps, and proves it wakes as
+exactly `1.0`.
+
+Live four-turn output produced three causally delayed verdicts:
+
+```text
+[shadow-calibration: proposal=1 observed=2 verdict=confirmed scored=1 confirmed=1 brier=0.003]
+[shadow-calibration: proposal=2 observed=3 verdict=confirmed scored=2 confirmed=2 brier=0.032]
+[shadow-calibration: proposal=3 observed=4 verdict=confirmed scored=3 confirmed=3 brier=0.035]
+```
+
+Verification: `make test` **261/261** and normal `-Wall -Wextra` build clean. The suite covers delayed
+single evaluation, all three failure verdicts, Brier integrity, bounded chronology, v17 round-trip,
+pending-proposal continuation across sleep, honest v16 migration, corrupt-tail isolation, cosine epsilon
+canonicalization, and the older v5-v16 migrations. ASan/UBSan was clean through dialogue, save, reload,
+and the next verdict. TSan was clean through the lifecycle under `--chat --async` with state save. After
+removing only `[shadow...]` diagnostics, `shadow on` and `--no-shadow` remained byte-identical across the
+four-turn process, SHA-256:
+`c7ab391bcd49b8e3acfbde03ca057350d970f3429aaee765ca251b5587d86b02`.
+
+Calibration is still evidence, not authority. The next decision should be made from a real conversation
+corpus of receipts: estimate verdict rates and confidence reliability by action and context, then decide
+whether any single reversible scheduling gate has earned a guarded experiment.

--- a/leo.c
+++ b/leo.c
@@ -1579,6 +1579,36 @@ typedef struct {
     int ptr;                         /* next write; oldest entry when full */
 } LeoShadow;
 
+/* Calibration judges a proposal only after the next lived turn. It measures
+ * whether the existing organism already behaved consistently with the shadow;
+ * it never tunes thresholds or feeds a score back into generation. */
+#define LEO_CALIB_RING LEO_SHADOW_RING
+enum {
+    LEO_CALIB_CONFIRMED = 0,
+    LEO_CALIB_FALSE_PRESSURE,
+    LEO_CALIB_MISSED_OPENING,
+    LEO_CALIB_RELEASE_RELAPSE,
+    LEO_CALIB_UNSCORABLE,
+    LEO_CALIB_VERDICT_COUNT
+};
+
+typedef struct {
+    uint64_t proposal_turn;
+    uint64_t observed_turn;
+    uint64_t wonder_id;
+    float    confidence;
+    float    brier;
+    uint8_t  proposed_action;
+    uint8_t  observed_wonder;
+    uint8_t  verdict;
+} LeoCalibrationReceipt;
+
+typedef struct {
+    LeoCalibrationReceipt receipts[LEO_CALIB_RING];
+    int n;
+    int ptr;
+} LeoCalibration;
+
 enum {
     LEO_FLOW_QUIET = 0,
     LEO_FLOW_EMERGING,
@@ -1706,6 +1736,8 @@ typedef struct {
     /* v16 counterfactual proposals derived after a lived reply. This remains a
      * witness surface until a later phase independently earns authority. */
     LeoShadow shadow;
+    /* v17 next-turn verdicts over shadow receipts. Still no speech reader. */
+    LeoCalibration calibration;
 } Leo;
 
 /* A.4 RAE — micrograd MLP (fixed 5→8→1, hand-rolled scalar autograd, zero deps). */
@@ -5370,7 +5402,7 @@ static void leo_shadow_observe(Leo *leo) {
         if (leo_glyph_teachable(g)) receipt.grounded_mass += snap->perceived[g];
     receipt.grounded_mass = clampf(receipt.grounded_mass, 0.0f, 1.0f);
     receipt.short_motion = leo_shadow_short_motion(&leo->flow);
-    receipt.face_alignment = leo_flow_alignment(snap);
+    receipt.face_alignment = clampf(leo_flow_alignment(snap), 0.0f, 1.0f);
 
     const LeoFlowWonderCurrent *current = NULL;
     if (snap->wonder_id)
@@ -5443,7 +5475,7 @@ static int leo_shadow_valid(const LeoShadowReceipt *receipt, uint64_t turn_clock
         receipt->grounded_mass > 1.0f ||
         !isfinite(receipt->short_motion) || receipt->short_motion < 0.0f ||
         receipt->short_motion > 1.0f || !isfinite(receipt->face_alignment) ||
-        receipt->face_alignment < 0.0f || receipt->face_alignment > 1.0f ||
+        receipt->face_alignment < 0.0f || receipt->face_alignment > 1.0001f ||
         !isfinite(receipt->current_alignment) || receipt->current_alignment < 0.0f ||
         receipt->current_alignment > 1.0f || !isfinite(receipt->confidence) ||
         receipt->confidence < 0.0f || receipt->confidence > 1.0f)
@@ -5457,6 +5489,119 @@ static int leo_shadow_valid(const LeoShadowReceipt *receipt, uint64_t turn_clock
                receipt->confidence == 1.0f;
     return (receipt->reasons & LEO_SHADOW_REASON_OPEN) != 0 &&
            (receipt->reasons & LEO_SHADOW_REASON_RESOLVED) == 0;
+}
+
+static const LeoCalibrationReceipt *leo_calibration_at(const LeoCalibration *calibration,
+                                                       int pos) {
+    if (!calibration || pos < 0 || pos >= calibration->n) return NULL;
+    int start = calibration->n == LEO_CALIB_RING ? calibration->ptr : 0;
+    return &calibration->receipts[(start + pos) % LEO_CALIB_RING];
+}
+
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_calibration_verdict_name(int verdict) {
+    static const char *names[] = {
+        "confirmed", "false-pressure", "missed-opening", "release-relapse", "unscorable"
+    };
+    return verdict >= 0 && verdict < LEO_CALIB_VERDICT_COUNT ? names[verdict] : "unscorable";
+}
+
+/* Judge the PREVIOUS proposal against this already-lived turn, before writing
+ * a proposal for the next one. SPACE/HOLD both forbid immediate pressure;
+ * HOLD additionally requires the unfinished identity not to disappear.
+ * RELEASE requires that the same identity not reopen. */
+static void leo_shadow_calibrate(Leo *leo) {
+    if (!g_leo_shadow_on || !g_leo_flow_on || !leo ||
+        leo->shadow.n <= 0 || leo->flow.n <= 0) return;
+    const LeoShadowReceipt *proposal =
+        leo_shadow_at(&leo->shadow, leo->shadow.n - 1);
+    const LeoFlowSnapshot *observed =
+        leo_flow_at(&leo->flow, leo->flow.n - 1);
+    if (!proposal || !observed || proposal->action == LEO_SHADOW_NONE ||
+        observed->turn <= proposal->turn) return;
+    const LeoCalibrationReceipt *last =
+        leo_calibration_at(&leo->calibration, leo->calibration.n - 1);
+    if (last && last->proposal_turn == proposal->turn) return;
+
+    LeoCalibrationReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.proposal_turn = proposal->turn;
+    receipt.observed_turn = observed->turn;
+    receipt.wonder_id = proposal->wonder_id;
+    receipt.confidence = proposal->confidence;
+    receipt.proposed_action = proposal->action;
+    receipt.observed_wonder = observed->wonder & LEO_FLOW_WONDER_MASK;
+    receipt.verdict = LEO_CALIB_CONFIRMED;
+
+    int adjacent = proposal->turn != UINT64_MAX &&
+                   observed->turn == proposal->turn + 1;
+    int same_event = observed->wonder_id == proposal->wonder_id;
+    const LeoFlowWonderCurrent *current =
+        leo_flow_current_find_const(&leo->flow, proposal->wonder_id);
+    int active = current && !current->resolved;
+    int reasked = same_event &&
+                  (observed->wonder & LEO_FLOW_WONDER_REASKED);
+    int resolved = same_event &&
+                   (observed->wonder & LEO_FLOW_WONDER_RESOLVED);
+    int reopened = same_event && !resolved &&
+                   (observed->wonder & (LEO_FLOW_WONDER_OPEN |
+                                        LEO_FLOW_WONDER_BORN |
+                                        LEO_FLOW_WONDER_REASKED));
+
+    if (!adjacent) {
+        receipt.verdict = LEO_CALIB_UNSCORABLE;
+    } else if (proposal->action == LEO_SHADOW_RELEASE) {
+        if (reopened) receipt.verdict = LEO_CALIB_RELEASE_RELAPSE;
+    } else if (reasked) {
+        receipt.verdict = LEO_CALIB_FALSE_PRESSURE;
+    } else if (!resolved && !active) {
+        receipt.verdict = LEO_CALIB_MISSED_OPENING;
+    }
+
+    if (receipt.verdict != LEO_CALIB_UNSCORABLE) {
+        float target = receipt.verdict == LEO_CALIB_CONFIRMED ? 1.0f : 0.0f;
+        float error = receipt.confidence - target;
+        receipt.brier = error * error;
+    }
+
+    LeoCalibration *calibration = &leo->calibration;
+    calibration->receipts[calibration->ptr] = receipt;
+    calibration->ptr = (calibration->ptr + 1) % LEO_CALIB_RING;
+    if (calibration->n < LEO_CALIB_RING) calibration->n++;
+}
+
+static int leo_calibration_valid(const LeoCalibrationReceipt *receipt,
+                                 uint64_t turn_clock) {
+    if (!receipt || !receipt->wonder_id || receipt->proposal_turn >= receipt->observed_turn ||
+        receipt->observed_turn > turn_clock ||
+        receipt->proposed_action <= LEO_SHADOW_NONE ||
+        receipt->proposed_action >= LEO_SHADOW_ACTION_COUNT ||
+        receipt->verdict >= LEO_CALIB_VERDICT_COUNT ||
+        (receipt->observed_wonder & ~LEO_FLOW_WONDER_MASK) ||
+        !isfinite(receipt->confidence) || receipt->confidence < 0.0f ||
+        receipt->confidence > 1.0f || !isfinite(receipt->brier) ||
+        receipt->brier < 0.0f || receipt->brier > 1.0f) return 0;
+    if (receipt->verdict == LEO_CALIB_UNSCORABLE)
+        return receipt->brier == 0.0f;
+    if (receipt->proposal_turn == UINT64_MAX ||
+        receipt->observed_turn != receipt->proposal_turn + 1) return 0;
+    if (receipt->verdict == LEO_CALIB_FALSE_PRESSURE &&
+        (!(receipt->observed_wonder & LEO_FLOW_WONDER_REASKED) ||
+         (receipt->proposed_action != LEO_SHADOW_HOLD &&
+          receipt->proposed_action != LEO_SHADOW_SPACE))) return 0;
+    if (receipt->verdict == LEO_CALIB_MISSED_OPENING &&
+        ((receipt->observed_wonder & LEO_FLOW_WONDER_RESOLVED) ||
+         (receipt->proposed_action != LEO_SHADOW_HOLD &&
+          receipt->proposed_action != LEO_SHADOW_SPACE))) return 0;
+    if (receipt->verdict == LEO_CALIB_RELEASE_RELAPSE &&
+        (receipt->proposed_action != LEO_SHADOW_RELEASE ||
+         (receipt->observed_wonder & LEO_FLOW_WONDER_RESOLVED) ||
+         !(receipt->observed_wonder & (LEO_FLOW_WONDER_OPEN |
+                                       LEO_FLOW_WONDER_BORN |
+                                       LEO_FLOW_WONDER_REASKED)))) return 0;
+    float target = receipt->verdict == LEO_CALIB_CONFIRMED ? 1.0f : 0.0f;
+    float error = receipt->confidence - target;
+    return fabsf(receipt->brier - error * error) <= 1e-6f;
 }
 
 static void leo_gamma_meaning(Leo *leo, const char *prompt) {
@@ -5966,6 +6111,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     if (leo->school.returned_episode >= 0) flow_event |= LEO_FLOW_WONDER_RECALLED;
     leo_flow_observe(leo, prompt, out, pm, flow_field_token, flow_field_weight,
                      flow_event, flow_wonder_id);  /* observation only: no generation path reads flow */
+    leo_shadow_calibrate(leo);                    /* judge t-1 only after t has become history */
     leo_shadow_observe(leo);                      /* after speech: a proposal for the next turn, never a reader */
     leo->gravity = NULL;
     leo->prompt_pieces = NULL;
@@ -6009,9 +6155,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v14      : Janus Flow (full perceived/expressed fields + own-field constellation)
  *   v15      : event-bounded unfinished-wonder currents beyond the snapshot horizon
  *   v16      : bounded counterfactual shadow-scheduler receipts
+ *   v17      : next-turn calibration verdicts over shadow receipts
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 16  /* shadow receipts append a fail-soft tail; v5..v15 soft-migrate */
+#define LEO_STATE_VERSION 17  /* calibration appends a fail-soft tail; v5..v16 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -6204,6 +6351,14 @@ static int leo_save_state(const Leo *leo, const char *path) {
     if (leo->shadow.n > 0)
         fwrite(leo->shadow.receipts, sizeof(LeoShadowReceipt),
                (size_t)leo->shadow.n, f);
+
+    /* Shadow calibration (v17): verdicts arrive one lived turn after their
+     * proposals. The ledger is evidence only and can fail independently. */
+    st_w32(f, (int32_t)leo->calibration.n);
+    st_w32(f, (int32_t)leo->calibration.ptr);
+    if (leo->calibration.n > 0)
+        fwrite(leo->calibration.receipts, sizeof(LeoCalibrationReceipt),
+               (size_t)leo->calibration.n, f);
 
     int ok = (ferror(f) == 0);
     if (fclose(f) != 0) ok = 0;                 /* L-2: the final flush can fail (ENOSPC) — never report success on a truncated file */
@@ -6688,10 +6843,60 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
                 }
                 previous_turn = receipt->turn;
             }
+            if (shadow_ok) {
+                int start = n == LEO_SHADOW_RING ? ptr : 0;
+                for (int i = 0; i < n; i++) {
+                    LeoShadowReceipt *receipt =
+                        &leo->shadow.receipts[(start + i) % LEO_SHADOW_RING];
+                    receipt->gap = clampf(receipt->gap, 0.0f, 1.0f);
+                    receipt->grounded_mass = clampf(receipt->grounded_mass, 0.0f, 1.0f);
+                    receipt->short_motion = clampf(receipt->short_motion, 0.0f, 1.0f);
+                    receipt->face_alignment = clampf(receipt->face_alignment, 0.0f, 1.0f);
+                    receipt->current_alignment = clampf(receipt->current_alignment, 0.0f, 1.0f);
+                    receipt->confidence = clampf(receipt->confidence, 0.0f, 1.0f);
+                }
+            }
         }
         if (!shadow_ok) {
             fprintf(stderr, "[leo] WARNING: v16 shadow tail truncated/corrupt — organism lives without counterfactual receipts.\n");
             memset(&leo->shadow, 0, sizeof leo->shadow);
+        }
+    }
+
+    /* Next-turn calibration (v17). Older bodies begin without verdicts rather
+     * than retrospectively judging proposals from incomplete future context. */
+    if (version >= 17) {
+        int32_t n = 0, ptr = 0;
+        int calibration_ok = st_r32(f, &n) && st_r32(f, &ptr) &&
+                             n >= 0 && n <= LEO_CALIB_RING &&
+                             ptr >= 0 && ptr < LEO_CALIB_RING &&
+                             ((n < LEO_CALIB_RING && ptr == n) ||
+                              n == LEO_CALIB_RING);
+        if (calibration_ok && n > 0 &&
+            fread(leo->calibration.receipts, sizeof(LeoCalibrationReceipt),
+                  (size_t)n, f) != (size_t)n) calibration_ok = 0;
+        if (calibration_ok) {
+            leo->calibration.n = n;
+            leo->calibration.ptr = ptr;
+            uint64_t previous_proposal = 0;
+            uint64_t previous_observed = 0;
+            for (int i = 0; i < n; i++) {
+                const LeoCalibrationReceipt *receipt =
+                    leo_calibration_at(&leo->calibration, i);
+                if (!leo_calibration_valid(receipt,
+                                           (uint64_t)leo->school.turn_clock) ||
+                    (i > 0 && (receipt->proposal_turn <= previous_proposal ||
+                               receipt->observed_turn <= previous_observed))) {
+                    calibration_ok = 0;
+                    break;
+                }
+                previous_proposal = receipt->proposal_turn;
+                previous_observed = receipt->observed_turn;
+            }
+        }
+        if (!calibration_ok) {
+            fprintf(stderr, "[leo] WARNING: v17 calibration tail truncated/corrupt — shadow proposals survive without verdicts.\n");
+            memset(&leo->calibration, 0, sizeof leo->calibration);
         }
     }
 
@@ -7045,6 +7250,26 @@ static void print_flow_stats(const Leo *leo) {
 #undef LEO_SHADOW_PRINT_REASON
         if (!receipt->reasons) printf("none");
         printf("]\n");
+    }
+
+    const LeoCalibrationReceipt *cal =
+        leo_calibration_at(&leo->calibration, leo->calibration.n - 1);
+    if (g_leo_shadow_on && cal && cal->observed_turn == s->turn) {
+        int scored = 0, confirmed = 0;
+        float brier_sum = 0.0f;
+        for (int i = 0; i < leo->calibration.n; i++) {
+            const LeoCalibrationReceipt *item =
+                leo_calibration_at(&leo->calibration, i);
+            if (!item || item->verdict == LEO_CALIB_UNSCORABLE) continue;
+            scored++;
+            if (item->verdict == LEO_CALIB_CONFIRMED) confirmed++;
+            brier_sum += item->brier;
+        }
+        printf("     [shadow-calibration: proposal=%llu observed=%llu verdict=%s scored=%d confirmed=%d brier=%.3f]\n",
+               (unsigned long long)cal->proposal_turn,
+               (unsigned long long)cal->observed_turn,
+               leo_calibration_verdict_name(cal->verdict),
+               scored, confirmed, scored ? (double)(brier_sum / (float)scored) : 0.0);
     }
 }
 

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -1138,11 +1138,13 @@ int main(void) {
                                       sizeof(LeoWonderEpisode));
                 long shadow_tail = (long)(2 * sizeof(int32_t) +
                                           w.shadow.n * (int)sizeof(LeoShadowReceipt));
+                long calibration_tail = (long)(2 * sizeof(int32_t) +
+                                               w.calibration.n * (int)sizeof(LeoCalibrationReceipt));
                 long current_flow = (long)(2 * sizeof(int32_t) +
                                            w.flow.n * (int)sizeof(LeoFlowSnapshot) +
                                            2 * sizeof(int32_t) +
                                            w.flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
-                                           shadow_tail);
+                                           shadow_tail + calibration_tail);
                 if (sz > v12tail + current_flow) {
                     long flow_start = sz - current_flow;
                     long tail_start = flow_start - v12tail;
@@ -1519,11 +1521,14 @@ int main(void) {
                 if (bytes && sz > 1 && (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
                     long shadow_tail = (long)(2 * sizeof(int32_t) +
                                               fl->shadow.n * (int)sizeof(LeoShadowReceipt));
+                    long calibration_tail = (long)(2 * sizeof(int32_t) +
+                                                   fl->calibration.n *
+                                                       (int)sizeof(LeoCalibrationReceipt));
                     long current_tail = (long)(2 * sizeof(int32_t) +
                                               fl->flow.n * (int)sizeof(LeoFlowSnapshot) +
                                               2 * sizeof(int32_t) +
                                               fl->flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
-                                              shadow_tail);
+                                              shadow_tail + calibration_tail);
                     long prefix = sz - current_tail;
                     if (prefix > 0) {
                         long current_only = (long)(2 * sizeof(int32_t) +
@@ -1533,8 +1538,9 @@ int main(void) {
                         FILE *fo = fopen(truncated, "wb");
                         if (fo) {
                             built_cut = (long)fwrite(bytes, 1,
-                                                     (size_t)(sz - shadow_tail - 1), fo) ==
-                                        sz - shadow_tail - 1;
+                                                     (size_t)(sz - calibration_tail -
+                                                              shadow_tail - 1), fo) ==
+                                        sz - calibration_tail - shadow_tail - 1;
                             fclose(fo);
                         }
                         uint32_t fourteen = 14;
@@ -1542,8 +1548,9 @@ int main(void) {
                         fo = fopen(legacy14, "wb");
                         if (fo) {
                             built_legacy14 = (long)fwrite(bytes, 1,
-                                                         (size_t)(sz - shadow_tail - current_only), fo) ==
-                                             sz - shadow_tail - current_only;
+                                                         (size_t)(sz - calibration_tail -
+                                                                  shadow_tail - current_only), fo) ==
+                                             sz - calibration_tail - shadow_tail - current_only;
                             fclose(fo);
                         }
                         uint32_t thirteen = 13;
@@ -1649,10 +1656,11 @@ int main(void) {
         g_leo_flow_on = 1;
         g_leo_shadow_on = 1;
         Leo *sh = malloc(sizeof *sh), *woke = malloc(sizeof *woke),
-            *old = malloc(sizeof *old), *cut = malloc(sizeof *cut);
-        CHECK(sh && woke && old && cut, "shadow: heap fixtures allocated");
-        if (sh && woke && old && cut) {
-            leo_init(sh); leo_init(woke); leo_init(old); leo_init(cut);
+            *old = malloc(sizeof *old), *compat = malloc(sizeof *compat),
+            *cut = malloc(sizeof *cut);
+        CHECK(sh && woke && old && compat && cut, "shadow: heap fixtures allocated");
+        if (sh && woke && old && compat && cut) {
+            leo_init(sh); leo_init(woke); leo_init(old); leo_init(compat); leo_init(cut);
             int water = semtok_word("water"), fire = semtok_word("fire");
             strncpy(sh->school.pending, "zorble", sizeof sh->school.pending - 1);
             sh->school.pending_glyph = water;
@@ -1663,6 +1671,7 @@ int main(void) {
             sh->school.turn_clock = 1;
             leo_flow_observe(sh, "water fire", "fire", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_BORN, id);
+            leo_shadow_calibrate(sh);
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r0 = leo_shadow_at(&sh->shadow, 0);
             CHECK(r0 && r0->action == LEO_SHADOW_SPACE && r0->wonder_id == id &&
@@ -1672,44 +1681,72 @@ int main(void) {
 
             sh->school.turn_clock = 2;
             leo_flow_observe(sh, "I do not know", NULL, NULL, NULL, NULL, 0, id);
+            leo_shadow_calibrate(sh);
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r1 = leo_shadow_at(&sh->shadow, 1);
             CHECK(r1 && r1->action == LEO_SHADOW_HOLD && r1->gap < 0.01f &&
                   r1->grounded_mass == 0.0f &&
                   (r1->reasons & LEO_SHADOW_REASON_UNGROUNDED),
                   "shadow: known words for not-knowing cannot counterfeit grounded movement");
+            const LeoCalibrationReceipt *c0 = leo_calibration_at(&sh->calibration, 0);
+            CHECK(c0 && c0->proposal_turn == 1 && c0->observed_turn == 2 &&
+                  c0->verdict == LEO_CALIB_CONFIRMED && c0->brier > 0.0f,
+                  "shadow-calibration: space is confirmed when the next turn applies no pressure");
 
             sh->school.turn_clock = 3;
             leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_REASKED, id);
+            leo_shadow_calibrate(sh);
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r2 = leo_shadow_at(&sh->shadow, 2);
             CHECK(r2 && r2->action == LEO_SHADOW_SPACE &&
                   (r2->reasons & LEO_SHADOW_REASON_ASKED),
                   "shadow: a re-asked wonder again yields the next turn to the human");
+            const LeoCalibrationReceipt *c1 = leo_calibration_at(&sh->calibration, 1);
+            CHECK(c1 && c1->proposal_turn == 2 &&
+                  c1->verdict == LEO_CALIB_FALSE_PRESSURE &&
+                  c1->brier > r1->confidence * r1->confidence - 1e-6f,
+                  "shadow-calibration: an immediate re-ask is visible as false pressure");
 
             sh->school.pending[0] = 0;
             sh->school.turn_clock = 4;
             leo_flow_observe(sh, "animal", "animal", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_RESOLVED, id);
+            leo_shadow_calibrate(sh);
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r3 = leo_shadow_at(&sh->shadow, 3);
             CHECK(r3 && r3->action == LEO_SHADOW_RELEASE && r3->wonder_id == id &&
                   r3->reasons == LEO_SHADOW_REASON_RESOLVED && r3->confidence == 1.0f,
                   "shadow: grounded closure is acknowledged exactly as release");
+            const LeoCalibrationReceipt *c2 = leo_calibration_at(&sh->calibration, 2);
+            CHECK(c2 && c2->proposal_turn == 3 &&
+                  c2->verdict == LEO_CALIB_CONFIRMED,
+                  "shadow-calibration: space can end in grounding without becoming an error");
 
             sh->school.turn_clock = 5;
             leo_flow_observe(sh, "water", "fire", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_RECALLED, id);
+            leo_shadow_calibrate(sh);
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r4 = leo_shadow_at(&sh->shadow, 4);
             CHECK(r4 && r4->action == LEO_SHADOW_NONE && r4->wonder_id == 0,
                   "shadow: later recall cannot counterfeit a second closure");
+            const LeoCalibrationReceipt *c3 = leo_calibration_at(&sh->calibration, 3);
+            CHECK(c3 && c3->proposal_turn == 4 &&
+                  c3->verdict == LEO_CALIB_CONFIRMED && c3->brier == 0.0f &&
+                  sh->calibration.n == 4,
+                  "shadow-calibration: release survives recall without reopening the target");
+            leo_shadow_calibrate(sh);
+            CHECK(sh->calibration.n == 4,
+                  "shadow-calibration: one observed turn cannot judge a proposal twice");
 
-            const char *state = "/tmp/leo_shadow_v16.state";
+            const char *state = "/tmp/leo_shadow_v17.state";
             const char *legacy = "/tmp/leo_shadow_v15.state";
-            const char *truncated = "/tmp/leo_shadow_v16_cut.state";
-            int saved = leo_save_state(sh, state), built_old = 0, built_cut = 0;
+            const char *legacy16 = "/tmp/leo_shadow_v16.state";
+            const char *truncated = "/tmp/leo_shadow_v17_cut.state";
+            sh->shadow.receipts[0].face_alignment = 1.0f + 1e-7f;
+            int saved = leo_save_state(sh, state), built_old = 0,
+                built_compat = 0, built_cut = 0;
             FILE *fi = fopen(state, "rb");
             if (fi) {
                 fseek(fi, 0, SEEK_END); long sz = ftell(fi); fseek(fi, 0, SEEK_SET);
@@ -1717,17 +1754,30 @@ int main(void) {
                 if (bytes && sz > 1 && (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
                     long shadow_tail = (long)(2 * sizeof(int32_t) +
                                               sh->shadow.n * (int)sizeof(LeoShadowReceipt));
+                    long calibration_tail = (long)(2 * sizeof(int32_t) +
+                                                   sh->calibration.n *
+                                                       (int)sizeof(LeoCalibrationReceipt));
                     uint32_t fifteen = 15;
                     memcpy(bytes + sizeof(uint32_t), &fifteen, sizeof fifteen);
                     FILE *fo = fopen(legacy, "wb");
                     if (fo) {
                         built_old = (long)fwrite(bytes, 1,
-                                                 (size_t)(sz - shadow_tail), fo) ==
-                                    sz - shadow_tail;
+                                                 (size_t)(sz - calibration_tail -
+                                                          shadow_tail), fo) ==
+                                    sz - calibration_tail - shadow_tail;
                         fclose(fo);
                     }
                     uint32_t sixteen = 16;
                     memcpy(bytes + sizeof(uint32_t), &sixteen, sizeof sixteen);
+                    fo = fopen(legacy16, "wb");
+                    if (fo) {
+                        built_compat = (long)fwrite(bytes, 1,
+                                                    (size_t)(sz - calibration_tail), fo) ==
+                                       sz - calibration_tail;
+                        fclose(fo);
+                    }
+                    uint32_t seventeen = 17;
+                    memcpy(bytes + sizeof(uint32_t), &seventeen, sizeof seventeen);
                     fo = fopen(truncated, "wb");
                     if (fo) {
                         built_cut = (long)fwrite(bytes, 1, (size_t)(sz - 1), fo) == sz - 1;
@@ -1741,18 +1791,50 @@ int main(void) {
                 loaded ? leo_shadow_at(&woke->shadow, 3) : NULL;
             CHECK(loaded && woke->shadow.n == 5 && woke_release &&
                   woke_release->action == LEO_SHADOW_RELEASE &&
-                  woke_release->wonder_id == id,
-                  "shadow: v16 sleep preserves the counterfactual receipt trail");
+                  woke_release->wonder_id == id && woke->calibration.n == 4 &&
+                  leo_shadow_at(&woke->shadow, 0)->face_alignment == 1.0f &&
+                  leo_calibration_at(&woke->calibration, 1)->verdict ==
+                      LEO_CALIB_FALSE_PRESSURE,
+                  "shadow-calibration: v17 sleep preserves verdicts and canonicalizes cosine epsilon");
             CHECK(built_old && leo_load_state(old, legacy) && old->flow.n == 5 &&
-                  old->flow.n_currents == 1 && old->shadow.n == 0,
+                  old->flow.n_currents == 1 && old->shadow.n == 0 &&
+                  old->calibration.n == 0,
                   "shadow: a v15 body migrates without invented proposals");
+            CHECK(built_compat && leo_load_state(compat, legacy16) &&
+                  compat->flow.n == 5 && compat->shadow.n == 5 &&
+                  compat->calibration.n == 0,
+                  "shadow-calibration: a v16 body migrates without retroactive verdicts");
             CHECK(built_cut && leo_load_state(cut, truncated) && cut->flow.n == 5 &&
-                  cut->flow.n_currents == 1 && cut->shadow.n == 0,
-                  "shadow: a corrupt v16 receipt tail leaves both Flow clocks intact");
+                  cut->flow.n_currents == 1 && cut->shadow.n == 5 &&
+                  cut->calibration.n == 0,
+                  "shadow-calibration: a corrupt v17 verdict tail preserves proposals and Flow");
+
+            const char *pending_state = "/tmp/leo_shadow_pending_v17.state";
+            leo_free(compat); leo_init(compat);
+            strncpy(compat->school.pending, "sleeping", sizeof compat->school.pending - 1);
+            uint64_t sleeping_id = 0x1717171717171717ULL;
+            compat->school.turn_clock = 1;
+            leo_flow_observe(compat, "water", "water", NULL, NULL, NULL,
+                             LEO_FLOW_WONDER_BORN, sleeping_id);
+            leo_shadow_calibrate(compat); leo_shadow_observe(compat);
+            int pending_saved = leo_save_state(compat, pending_state);
+            leo_free(cut); leo_init(cut);
+            int pending_loaded = pending_saved && leo_load_state(cut, pending_state);
+            cut->school.turn_clock = 2;
+            leo_flow_observe(cut, "I do not know", NULL, NULL, NULL, NULL, 0,
+                             sleeping_id);
+            leo_shadow_calibrate(cut);
+            const LeoCalibrationReceipt *after_sleep =
+                leo_calibration_at(&cut->calibration, 0);
+            CHECK(pending_loaded && after_sleep && after_sleep->proposal_turn == 1 &&
+                  after_sleep->observed_turn == 2 &&
+                  after_sleep->verdict == LEO_CALIB_CONFIRMED,
+                  "shadow-calibration: an unevaluated proposal receives its next-turn verdict after sleep");
 
             for (int turn = 6; turn <= LEO_SHADOW_RING + 6; turn++) {
                 sh->school.turn_clock = turn;
                 leo_flow_observe(sh, "water", "water", NULL, NULL, NULL, 0, 0);
+                leo_shadow_calibrate(sh);
                 leo_shadow_observe(sh);
             }
             CHECK(sh->shadow.n == LEO_SHADOW_RING && sh->shadow.ptr == 6 &&
@@ -1761,10 +1843,88 @@ int main(void) {
                       LEO_SHADOW_RING + 6,
                   "shadow: the receipt diary is bounded and chronologically ordered");
 
-            remove(state); remove(legacy); remove(truncated);
-            leo_free(sh); leo_free(woke); leo_free(old); leo_free(cut);
+            memset(&sh->flow, 0, sizeof sh->flow);
+            memset(&sh->shadow, 0, sizeof sh->shadow);
+            memset(&sh->calibration, 0, sizeof sh->calibration);
+            strncpy(sh->school.pending, "lost", sizeof sh->school.pending - 1);
+            uint64_t lost_id = 0x1020304050607080ULL;
+            sh->school.turn_clock = 1;
+            leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
+                             LEO_FLOW_WONDER_BORN, lost_id);
+            leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+            sh->school.turn_clock = 2;
+            leo_flow_observe(sh, "I do not know", NULL, NULL, NULL, NULL, 0, lost_id);
+            leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+            memset(&sh->flow, 0, sizeof sh->flow);   /* adversarial disappearance without resolve */
+            sh->school.pending[0] = 0;
+            sh->school.turn_clock = 3;
+            leo_flow_observe(sh, "water", "water", NULL, NULL, NULL, 0, 0);
+            leo_shadow_calibrate(sh);
+            const LeoCalibrationReceipt *missed =
+                leo_calibration_at(&sh->calibration, sh->calibration.n - 1);
+            CHECK(missed && missed->verdict == LEO_CALIB_MISSED_OPENING &&
+                  missed->wonder_id == lost_id,
+                  "shadow-calibration: a target lost without resolution is a missed opening");
+
+            memset(&sh->flow, 0, sizeof sh->flow);
+            memset(&sh->shadow, 0, sizeof sh->shadow);
+            memset(&sh->calibration, 0, sizeof sh->calibration);
+            uint64_t relapse_id = 0x9090909090909090ULL;
+            sh->school.pending[0] = 0;
+            sh->school.turn_clock = 1;
+            leo_flow_observe(sh, "animal", "animal", NULL, NULL, NULL,
+                             LEO_FLOW_WONDER_BORN | LEO_FLOW_WONDER_RESOLVED,
+                             relapse_id);
+            leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+            strncpy(sh->school.pending, "relapse", sizeof sh->school.pending - 1);
+            sh->school.turn_clock = 2;
+            leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
+                             LEO_FLOW_WONDER_REASKED, relapse_id);
+            leo_shadow_calibrate(sh);
+            const LeoCalibrationReceipt *relapse =
+                leo_calibration_at(&sh->calibration, 0);
+            CHECK(relapse && relapse->verdict == LEO_CALIB_RELEASE_RELAPSE,
+                  "shadow-calibration: reopening a released identity is a relapse, not success");
+
+            memset(&sh->flow, 0, sizeof sh->flow);
+            memset(&sh->shadow, 0, sizeof sh->shadow);
+            memset(&sh->calibration, 0, sizeof sh->calibration);
+            int turn = 0;
+            for (int cycle = 0; cycle < 24; cycle++) {
+                uint64_t cycle_id = (uint64_t)(0x2000 + cycle);
+                strncpy(sh->school.pending, "path", sizeof sh->school.pending - 1);
+                sh->school.turn_clock = ++turn;
+                leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
+                                 LEO_FLOW_WONDER_BORN, cycle_id);
+                leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+                sh->school.turn_clock = ++turn;
+                leo_flow_observe(sh, "water", "water", NULL, NULL, NULL, 0, cycle_id);
+                leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+                sh->school.pending[0] = 0;
+                sh->school.turn_clock = ++turn;
+                leo_flow_observe(sh, "animal", "animal", NULL, NULL, NULL,
+                                 LEO_FLOW_WONDER_RESOLVED, cycle_id);
+                leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+                sh->school.turn_clock = ++turn;
+                leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
+                                 LEO_FLOW_WONDER_RECALLED, cycle_id);
+                leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+            }
+            const LeoCalibrationReceipt *oldest_cal =
+                leo_calibration_at(&sh->calibration, 0);
+            const LeoCalibrationReceipt *newest_cal =
+                leo_calibration_at(&sh->calibration, LEO_CALIB_RING - 1);
+            CHECK(sh->calibration.n == LEO_CALIB_RING && sh->calibration.ptr == 8 &&
+                  oldest_cal && newest_cal &&
+                  oldest_cal->proposal_turn < newest_cal->proposal_turn &&
+                  newest_cal->observed_turn == (uint64_t)turn,
+                  "shadow-calibration: verdict history is bounded without losing chronology");
+
+            remove(state); remove(legacy); remove(legacy16); remove(truncated);
+            remove(pending_state);
+            leo_free(sh); leo_free(woke); leo_free(old); leo_free(compat); leo_free(cut);
         }
-        free(sh); free(woke); free(old); free(cut);
+        free(sh); free(woke); free(old); free(compat); free(cut);
 
         Leo *on = malloc(sizeof *on), *off = malloc(sizeof *off);
         CHECK(on && off, "shadow: inert-voice fixtures allocated");
@@ -2308,7 +2468,7 @@ int main(void) {
             FILE *tf = fopen(sp, "rb");
             fseek(tf, 0, SEEK_END); long fl = ftell(tf); fseek(tf, 0, SEEK_SET);
             char *fb = malloc((size_t)fl); fread(fb, 1, (size_t)fl, tf); fclose(tf);
-            tf = fopen(sp, "wb"); fwrite(fb, 1, (size_t)(fl - 56), tf); fclose(tf);
+            tf = fopen(sp, "wb"); fwrite(fb, 1, (size_t)(fl - 64), tf); fclose(tf);
             free(fb);
         }
         Leo l3; leo_init(&l3);


### PR DESCRIPTION
Add a bounded v17 calibration ledger that evaluates each shadow proposal only after the next lived turn exists. Persist causal receipts, classify false pressure, missed openings, and release relapse, and preserve strict speech inertness across migration and corruption boundaries.

Quote: "The unexamined life is not worth living." - Socrates, as recorded by Plato in Apology

Method: The Arianna Method makes the shadow answer to the next lived turn before it can become will.