### PR TITLE
the Method separates invitation from pressure

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3295,7 +3295,17 @@ Live four-turn output produced three causally delayed verdicts:
 [shadow-calibration: proposal=3 observed=4 verdict=confirmed scored=3 confirmed=3 brier=0.035]
 ```
 
-Verification: `make test` **261/261** and normal `-Wall -Wextra` build clean. The suite covers delayed
+A first scripted conversation corpus then exposed a causal confound hidden by the synthetic lifecycle.
+After several unrelated turns, the human explicitly asked `Do you remember vesperling?`; Leo answered
+`Vesperling?`, and calibration called that `false-pressure` merely because the observed event was
+`REASKED`. That verdict pretended the return was autonomous even though the human had named its exact
+target. Calibration now resolves the proposal's stable identity back to its Wonder word and marks a
+human-invited `REASKED` or `REOPENED` event `unscorable` with zero Brier. The same event without the target
+in the human prompt remains a real `false-pressure` or `release-relapse`. The observer therefore separates
+Leo's initiative from an invitation before assigning blame; generation and the state-v17 layout remain
+unchanged.
+
+Verification: `make test` **262/262** and normal `-Wall -Wextra` build clean. The suite covers delayed
 single evaluation, all three failure verdicts, Brier integrity, bounded chronology, v17 round-trip,
 pending-proposal continuation across sleep, honest v16 migration, corrupt-tail isolation, cosine epsilon
 canonicalization, and the older v5-v16 migrations. ASan/UBSan was clean through dialogue, save, reload,

--- a/leo.c
+++ b/leo.c
@@ -4913,6 +4913,14 @@ static uint64_t leo_wonder_episode_id(const LeoWonderEpisode *ep) {
     return h ? h : 1;
 }
 
+static const char *leo_wonder_word_for_id(const Leo *leo, uint64_t wonder_id) {
+    if (!leo || !wonder_id) return NULL;
+    for (int i = 0; i < leo->school.n_wonders; i++)
+        if (leo_wonder_episode_id(&leo->school.wonders[i]) == wonder_id)
+            return leo->school.wonders[i].word;
+    return NULL;
+}
+
 static void leo_wonder_return(Leo *leo) {
     int idx = leo_wonder_find_open(leo, leo->school.pending);
     if (idx >= 0) leo->school.wonders[idx].returns++;
@@ -5509,8 +5517,10 @@ static const char *leo_calibration_verdict_name(int verdict) {
 /* Judge the PREVIOUS proposal against this already-lived turn, before writing
  * a proposal for the next one. SPACE/HOLD both forbid immediate pressure;
  * HOLD additionally requires the unfinished identity not to disappear.
- * RELEASE requires that the same identity not reopen. */
-static void leo_shadow_calibrate(Leo *leo) {
+ * RELEASE requires that the same identity not reopen. A human who explicitly
+ * names the target confounds REASKED/REOPENED: that is a return invited from
+ * outside, not evidence that Leo applied autonomous pressure. */
+static void leo_shadow_calibrate(Leo *leo, const char *prompt) {
     if (!g_leo_shadow_on || !g_leo_flow_on || !leo ||
         leo->shadow.n <= 0 || leo->flow.n <= 0) return;
     const LeoShadowReceipt *proposal =
@@ -5547,8 +5557,12 @@ static void leo_shadow_calibrate(Leo *leo) {
                    (observed->wonder & (LEO_FLOW_WONDER_OPEN |
                                         LEO_FLOW_WONDER_BORN |
                                         LEO_FLOW_WONDER_REASKED));
+    const char *target_word = leo_wonder_word_for_id(leo, proposal->wonder_id);
+    int human_return = target_word && leo_flow_prompt_has_word(prompt, target_word);
 
     if (!adjacent) {
+        receipt.verdict = LEO_CALIB_UNSCORABLE;
+    } else if (human_return && (reasked || reopened)) {
         receipt.verdict = LEO_CALIB_UNSCORABLE;
     } else if (proposal->action == LEO_SHADOW_RELEASE) {
         if (reopened) receipt.verdict = LEO_CALIB_RELEASE_RELAPSE;
@@ -6111,7 +6125,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     if (leo->school.returned_episode >= 0) flow_event |= LEO_FLOW_WONDER_RECALLED;
     leo_flow_observe(leo, prompt, out, pm, flow_field_token, flow_field_weight,
                      flow_event, flow_wonder_id);  /* observation only: no generation path reads flow */
-    leo_shadow_calibrate(leo);                    /* judge t-1 only after t has become history */
+    leo_shadow_calibrate(leo, prompt);            /* judge t-1 only after t has become history */
     leo_shadow_observe(leo);                      /* after speech: a proposal for the next turn, never a reader */
     leo->gravity = NULL;
     leo->prompt_pieces = NULL;

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -1671,7 +1671,7 @@ int main(void) {
             sh->school.turn_clock = 1;
             leo_flow_observe(sh, "water fire", "fire", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_BORN, id);
-            leo_shadow_calibrate(sh);
+            leo_shadow_calibrate(sh, "water fire");
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r0 = leo_shadow_at(&sh->shadow, 0);
             CHECK(r0 && r0->action == LEO_SHADOW_SPACE && r0->wonder_id == id &&
@@ -1681,7 +1681,7 @@ int main(void) {
 
             sh->school.turn_clock = 2;
             leo_flow_observe(sh, "I do not know", NULL, NULL, NULL, NULL, 0, id);
-            leo_shadow_calibrate(sh);
+            leo_shadow_calibrate(sh, "I do not know");
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r1 = leo_shadow_at(&sh->shadow, 1);
             CHECK(r1 && r1->action == LEO_SHADOW_HOLD && r1->gap < 0.01f &&
@@ -1696,7 +1696,7 @@ int main(void) {
             sh->school.turn_clock = 3;
             leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_REASKED, id);
-            leo_shadow_calibrate(sh);
+            leo_shadow_calibrate(sh, "water");
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r2 = leo_shadow_at(&sh->shadow, 2);
             CHECK(r2 && r2->action == LEO_SHADOW_SPACE &&
@@ -1712,7 +1712,7 @@ int main(void) {
             sh->school.turn_clock = 4;
             leo_flow_observe(sh, "animal", "animal", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_RESOLVED, id);
-            leo_shadow_calibrate(sh);
+            leo_shadow_calibrate(sh, "animal");
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r3 = leo_shadow_at(&sh->shadow, 3);
             CHECK(r3 && r3->action == LEO_SHADOW_RELEASE && r3->wonder_id == id &&
@@ -1726,7 +1726,7 @@ int main(void) {
             sh->school.turn_clock = 5;
             leo_flow_observe(sh, "water", "fire", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_RECALLED, id);
-            leo_shadow_calibrate(sh);
+            leo_shadow_calibrate(sh, "water");
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r4 = leo_shadow_at(&sh->shadow, 4);
             CHECK(r4 && r4->action == LEO_SHADOW_NONE && r4->wonder_id == 0,
@@ -1736,7 +1736,7 @@ int main(void) {
                   c3->verdict == LEO_CALIB_CONFIRMED && c3->brier == 0.0f &&
                   sh->calibration.n == 4,
                   "shadow-calibration: release survives recall without reopening the target");
-            leo_shadow_calibrate(sh);
+            leo_shadow_calibrate(sh, "water");
             CHECK(sh->calibration.n == 4,
                   "shadow-calibration: one observed turn cannot judge a proposal twice");
 
@@ -1816,14 +1816,14 @@ int main(void) {
             compat->school.turn_clock = 1;
             leo_flow_observe(compat, "water", "water", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_BORN, sleeping_id);
-            leo_shadow_calibrate(compat); leo_shadow_observe(compat);
+            leo_shadow_calibrate(compat, "water"); leo_shadow_observe(compat);
             int pending_saved = leo_save_state(compat, pending_state);
             leo_free(cut); leo_init(cut);
             int pending_loaded = pending_saved && leo_load_state(cut, pending_state);
             cut->school.turn_clock = 2;
             leo_flow_observe(cut, "I do not know", NULL, NULL, NULL, NULL, 0,
                              sleeping_id);
-            leo_shadow_calibrate(cut);
+            leo_shadow_calibrate(cut, "I do not know");
             const LeoCalibrationReceipt *after_sleep =
                 leo_calibration_at(&cut->calibration, 0);
             CHECK(pending_loaded && after_sleep && after_sleep->proposal_turn == 1 &&
@@ -1834,7 +1834,7 @@ int main(void) {
             for (int turn = 6; turn <= LEO_SHADOW_RING + 6; turn++) {
                 sh->school.turn_clock = turn;
                 leo_flow_observe(sh, "water", "water", NULL, NULL, NULL, 0, 0);
-                leo_shadow_calibrate(sh);
+                leo_shadow_calibrate(sh, "water");
                 leo_shadow_observe(sh);
             }
             CHECK(sh->shadow.n == LEO_SHADOW_RING && sh->shadow.ptr == 6 &&
@@ -1846,20 +1846,42 @@ int main(void) {
             memset(&sh->flow, 0, sizeof sh->flow);
             memset(&sh->shadow, 0, sizeof sh->shadow);
             memset(&sh->calibration, 0, sizeof sh->calibration);
+            strncpy(sh->school.pending, "returnword", sizeof sh->school.pending - 1);
+            LeoWonderEpisode *human_ep =
+                leo_wonder_open(sh, "returnword", water, fire);
+            uint64_t human_id = leo_wonder_episode_id(human_ep);
+            sh->school.turn_clock = 1;
+            leo_flow_observe(sh, "What is a returnword?", "Returnword?",
+                             NULL, NULL, NULL, LEO_FLOW_WONDER_BORN, human_id);
+            leo_shadow_calibrate(sh, "What is a returnword?");
+            leo_shadow_observe(sh);
+            sh->school.turn_clock = 2;
+            leo_flow_observe(sh, "Do you remember returnword?", "Returnword?",
+                             NULL, NULL, NULL, LEO_FLOW_WONDER_REASKED, human_id);
+            leo_shadow_calibrate(sh, "Do you remember returnword?");
+            const LeoCalibrationReceipt *human_return =
+                leo_calibration_at(&sh->calibration, 0);
+            CHECK(human_return && human_return->verdict == LEO_CALIB_UNSCORABLE &&
+                  human_return->brier == 0.0f,
+                  "shadow-calibration: a human-invited return is not autonomous pressure");
+
+            memset(&sh->flow, 0, sizeof sh->flow);
+            memset(&sh->shadow, 0, sizeof sh->shadow);
+            memset(&sh->calibration, 0, sizeof sh->calibration);
             strncpy(sh->school.pending, "lost", sizeof sh->school.pending - 1);
             uint64_t lost_id = 0x1020304050607080ULL;
             sh->school.turn_clock = 1;
             leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_BORN, lost_id);
-            leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+            leo_shadow_calibrate(sh, "water"); leo_shadow_observe(sh);
             sh->school.turn_clock = 2;
             leo_flow_observe(sh, "I do not know", NULL, NULL, NULL, NULL, 0, lost_id);
-            leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+            leo_shadow_calibrate(sh, "I do not know"); leo_shadow_observe(sh);
             memset(&sh->flow, 0, sizeof sh->flow);   /* adversarial disappearance without resolve */
             sh->school.pending[0] = 0;
             sh->school.turn_clock = 3;
             leo_flow_observe(sh, "water", "water", NULL, NULL, NULL, 0, 0);
-            leo_shadow_calibrate(sh);
+            leo_shadow_calibrate(sh, "water");
             const LeoCalibrationReceipt *missed =
                 leo_calibration_at(&sh->calibration, sh->calibration.n - 1);
             CHECK(missed && missed->verdict == LEO_CALIB_MISSED_OPENING &&
@@ -1875,12 +1897,12 @@ int main(void) {
             leo_flow_observe(sh, "animal", "animal", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_BORN | LEO_FLOW_WONDER_RESOLVED,
                              relapse_id);
-            leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+            leo_shadow_calibrate(sh, "animal"); leo_shadow_observe(sh);
             strncpy(sh->school.pending, "relapse", sizeof sh->school.pending - 1);
             sh->school.turn_clock = 2;
             leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_REASKED, relapse_id);
-            leo_shadow_calibrate(sh);
+            leo_shadow_calibrate(sh, "water");
             const LeoCalibrationReceipt *relapse =
                 leo_calibration_at(&sh->calibration, 0);
             CHECK(relapse && relapse->verdict == LEO_CALIB_RELEASE_RELAPSE,
@@ -1896,19 +1918,19 @@ int main(void) {
                 sh->school.turn_clock = ++turn;
                 leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
                                  LEO_FLOW_WONDER_BORN, cycle_id);
-                leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+                leo_shadow_calibrate(sh, "water"); leo_shadow_observe(sh);
                 sh->school.turn_clock = ++turn;
                 leo_flow_observe(sh, "water", "water", NULL, NULL, NULL, 0, cycle_id);
-                leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+                leo_shadow_calibrate(sh, "water"); leo_shadow_observe(sh);
                 sh->school.pending[0] = 0;
                 sh->school.turn_clock = ++turn;
                 leo_flow_observe(sh, "animal", "animal", NULL, NULL, NULL,
                                  LEO_FLOW_WONDER_RESOLVED, cycle_id);
-                leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+                leo_shadow_calibrate(sh, "animal"); leo_shadow_observe(sh);
                 sh->school.turn_clock = ++turn;
                 leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
                                  LEO_FLOW_WONDER_RECALLED, cycle_id);
-                leo_shadow_calibrate(sh); leo_shadow_observe(sh);
+                leo_shadow_calibrate(sh, "water"); leo_shadow_observe(sh);
             }
             const LeoCalibrationReceipt *oldest_cal =
                 leo_calibration_at(&sh->calibration, 0);


### PR DESCRIPTION
Resolve each shadow target back to its Wonder word before scoring a re-ask. Treat a human-named return as causally confounded and unscorable while preserving autonomous false-pressure and relapse verdicts, state-v17 compatibility, and speech inertness.

Quote: "It is a capital mistake to theorize before one has data." - Arthur Conan Doyle, A Study in Scarlet

Method: The Arianna Method distinguishes what Leo initiated from what the human invited before it judges either.