### PR TITLE
the Method lets the human continue not knowing

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3391,3 +3391,106 @@ The next useful expansion is an adaptive interlocutor over this exact protocol. 
 the visible conversation, choose among epistemic moves such as uncertainty, association, definition,
 counter-question, silence, and delayed return, and never see shadow actions or verdicts until the life is
 complete. That is the point where an API key becomes useful without becoming part of Leo's cognition.
+
+## Phase A.31 — the stranger never sees the child (2026-07-23)
+
+The first model-driven interlocutor keeps a harder privacy and causal boundary than originally planned.
+The external Responses API receives no Leo transcript at all: only a fixed synthetic target (`flom`),
+fixed sensory anchors (`warm cinnamon or cool rain`), one abstract epistemic move, and the turn number.
+It returns one schema-constrained human utterance with `store: false`. Leo, every state file, all Flow and
+Wonder records, shadow proposals, calibration verdicts, and the causal report remain local. Every turn is
+still a separate process with an exact save, exit, and required load. The API key travels through a
+mode-600 temporary curl configuration and is absent from requests, responses, manifests, and argv.
+
+The first complete fixed-target life used `gpt-5.6-luna`, base seed 83, eight API calls, and eight Leo
+processes. All calls completed (1,714 input tokens, 856 output tokens), all target-name claims agreed with
+an independent local word-boundary measurement, and five proposal verdicts crossed real sleep edges:
+
+```text
+proposals=8 scored=5 unscorable=0 pending=3
+confirmed=4 false-pressure=1
+sleep-crossing receipts=5
+```
+
+Leo carried both sensory poles across the life. Before the human defined the word, his replies retained
+warmth, winter, window, water, and the choice `Fire or Home?`; after `Flom means...`, he returned to rain
+and window. This is evidence of persistent association, not proof that Leo installed a lexical definition
+for `flom`: his own Wonder current selected `Brings?` as its unfinished identity rather than the external
+target. That distinction is exactly why the observatory records both human stimuli and internal stable
+identities instead of declaring semantic success from surface echoes.
+
+The one `false-pressure` receipt is real under the existing contract. After Leo asked `Brings? Fire or
+Home?`, shadow proposed `space`; on the next process the human defined `flom` without naming `brings`, and
+Leo autonomously asked `Brings? Fire or Home?` again. It was neither a human-invited return nor a sleep
+pairing error. Because shadow remains read-only, this is a measured boundary rather than a voice
+regression. It argues against granting a scheduler broad speech authority and for testing only a narrow,
+reversible cooldown on exact autonomous reasks if a future intervention phase is opened.
+
+An aborted preliminary run also caught an instrumentation error before it could become evidence: JSON
+`false` from the model was read with `jq -e` and treated as process failure. The runner now validates a
+boolean without assigning truth to its exit status. A second preliminary run showed why self-report is
+not proof: a model could literally name a newly invented word while reporting `target_named=false`.
+The final protocol pins one target across all moves and computes literal naming locally while retaining
+the model report separately.
+
+This is not yet a genuinely adaptive interlocutor. The fixed move sequence varies epistemic posture but
+does not react to Leo's replies. Feeding shadow verdicts into move choice would leak the judge into the
+stimulus, while exporting Leo's private dialogue would break the chosen boundary. A frozen-replay lane
+therefore reuses the exact captured human utterances without another API call and changes only Leo's base
+sampling seed. Replays at 137 and 211 produced distinct transcript hashes from seed 83, but the same
+causal topology. The three-life matrix totals:
+
+```text
+proposals=24 scored=15 unscorable=0 pending=9
+confirmed=12 false-pressure=3
+sleep-crossing receipts=15
+```
+
+Three replies were byte-invariant across all sampling paths: `Cinnamon?`, then `Brings? Fire or Home?`,
+then the same `Brings? Fire or Home?` after the definition. The surrounding speech changed substantially.
+Thus the retained association and its pressure boundary are not artifacts of one random continuation;
+they arise from the deterministic Wonder/School scaffold around these prompts. This still does not license
+a speech intervention. The next causal design is a predeclared local branching policy whose inputs are
+visible conversational events only and whose branches are written before any run.
+
+## Phase A.32 — the human can continue not knowing (2026-07-23)
+
+The first adaptive interlocutor is local and predeclared. `local-v1` reads only the accumulated visible
+Leo replies. Its complete sensorium is a literal question mark, whole-word occurrence of the fixed target,
+exact reply repetition, and counts of the two public sensory anchor vocabularies. It cannot open raw logs,
+state, Flow, Wonder, shadow proposals, calibration verdicts, confidence, or future replies. Before each
+human turn it writes a JSON receipt containing the branch, exact utterance, and visible evidence that chose
+it. No external service participates.
+
+A lexical control mattered. With corpus-familiar `warm light` and `cool rain`, the old fixed sequence
+produced nine `none` proposals: association alone did not manufacture Wonder. The target had not been
+asked on the first distress-gated turn, and a fixed human immediately stopped naming it. The adaptive rule
+therefore repeats only an unmet target. Once Leo visibly asks `Flom?`, the next human line is only `I do not
+know yet.` It contains no teachable concept pair and cannot accidentally masquerade as an answer. Later
+branches choose the less represented anchor, protect exact repeated questions, explicitly invite the
+target once, ground it once, and then observe an ordinary post-closure turn.
+
+Three nine-process lives at base seeds 83, 137, and 211 produced different transcript hashes and one real
+policy divergence: seed 83 selected a delayed cool return, while 137 and 211 selected delayed warm returns
+from their visible word balance. The causal matrix was nevertheless invariant:
+
+```text
+proposals=27 scored=15 unscorable=3 pending=9
+confirmed=15 false-pressure=0
+hold confirmed=3
+space confirmed=9, unscorable=3
+release confirmed=3
+sleep-crossing receipts=18
+```
+
+In every life, the first ordinary reply omitted the target; the policy repeated `flom` without a
+definition; Leo asked `Flom?`; the human continued not knowing; the question survived unrelated speech
+and process death; a later human-named return was correctly `unscorable`; and the explicit definition
+closed the same stable Wonder identity exactly once. The policy never saw that identity. It inferred only
+that Leo's visible `Flom?` was an exact repeated question and selected `ground-with-repeat-open`.
+
+This is the first evidence that the intended distinction is operational rather than poetic: Leo can ask,
+the human can refuse false omniscience, and the organism can carry the open question without either party
+pretending it has already become knowledge. The branch policy remains an external conversational research
+instrument. It does not alter Leo's generator, state layout, or will, and its clean result is not permission
+to route shadow actions into speech.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe
 
 all: leo
 
@@ -33,6 +33,12 @@ dialogue-probe: leo
 
 life-probe: leo
 	./scripts/shadow_life_probe.sh
+
+adaptive-probe: leo
+	./scripts/adaptive_life_probe.sh
+
+visible-branch-probe: leo
+	LEO_VISIBLE_BRANCH_POLICY=local-v1 ./scripts/adaptive_life_probe.sh scripts/visible_branch_phases.txt
 
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -1,0 +1,70 @@
+# Transcript-blind interlocutor probe
+
+This probe runs one real Leo process per turn. Every turn ends with a state
+save and process exit; every later turn must load that exact state. An OpenAI
+Responses API model realizes a fixed sequence of epistemic moves as short
+human utterances, but receives no Leo transcript, state, diagnostics, shadow
+proposal, calibration verdict, or prior model utterance.
+
+The API request contains only:
+
+- the current move description;
+- one fixed synthetic target word;
+- fixed sensory anchors;
+- the turn number.
+
+Run it with a key stored in a local file:
+
+```sh
+OPENAI_API_KEY_FILE=/path/to/key \
+LEO_INTERLOCUTOR_MODEL=gpt-5.6-luna \
+make adaptive-probe
+```
+
+Optional controls are `LEO_ADAPTIVE_SEED`, `LEO_ADAPTIVE_TARGET`, and
+`LEO_ADAPTIVE_WARM_ANCHOR`, `LEO_ADAPTIVE_COOL_ANCHOR`, and
+`LEO_ADAPTIVE_ANCHORS`. The default anchors are corpus-familiar `warm light`
+and `cool rain`; unfamiliar protocol vocabulary can become a competing Wonder
+target and confound the intended experiment. The output directory is always
+required to be new.
+It retains exact API requests and responses, visible dialogue, raw local Leo
+logs, process/session identities, causal receipts, sleep-crossing receipts,
+and a manifest. Requests set `store: false`. The key itself is loaded through
+a mode-600 temporary curl config, never placed in argv or an output artifact.
+
+`target_named` in `sessions.tsv` is measured locally with a literal
+case-insensitive word-boundary check. `target_named_reported` preserves the
+model's schema-constrained self-report as a claim, not proof.
+
+To isolate Leo's sampling path from interlocutor variation, replay a previously
+captured `prompts.txt` without making any API calls:
+
+```sh
+LEO_INTERLOCUTOR_REPLAY_FILE=/tmp/first-life/prompts.txt \
+LEO_ADAPTIVE_SEED=137 \
+scripts/adaptive_life_probe.sh scripts/adaptive_moves.txt /tmp/replay-137
+```
+
+The replay must contain exactly one non-command utterance for every move.
+`target_named_reported` becomes `not-applicable`, and the local literal
+measurement remains available as `target_named`.
+
+Run the predeclared local visible-branch policy without an API key:
+
+```sh
+make visible-branch-probe
+```
+
+`local-v1` reads only `visible_replies.jsonl`. It can observe a literal
+question mark, the fixed target as a whole word, exact reply repetition, and
+literal warm/cool anchor terms. It cannot read state files, raw diagnostics,
+Flow, Wonder, shadow proposals, calibration verdicts, confidence, or future
+replies. Before every human turn it writes the selected branch, utterance, and
+visible evidence to `policy/turn-NN.json`. The nine available phases and every
+branch are fixed in source before the run.
+
+The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
+baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,
+but only through the narrow visible sensors above. Selecting a move from shadow
+diagnostics would leak the judge into the stimulus, while sending Leo's private
+dialogue to an external API remains outside this protocol.

--- a/scripts/adaptive_life_probe.sh
+++ b/scripts/adaptive_life_probe.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Let an API model create transcript-blind human utterances while Leo lives locally.
+# Every turn is a real save/process-exit/reload boundary.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MOVES="${1:-$ROOT/scripts/adaptive_moves.txt}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${2:-${TMPDIR:-/tmp}/leo-adaptive-life-$STAMP}"
+BASE_SEED="${LEO_ADAPTIVE_SEED:-83}"
+MODEL="${LEO_INTERLOCUTOR_MODEL:-gpt-5.6-luna}"
+TARGET="${LEO_ADAPTIVE_TARGET:-flom}"
+WARM_ANCHOR="${LEO_ADAPTIVE_WARM_ANCHOR:-warm light}"
+COOL_ANCHOR="${LEO_ADAPTIVE_COOL_ANCHOR:-cool rain}"
+ANCHORS="${LEO_ADAPTIVE_ANCHORS:-$WARM_ANCHOR or $COOL_ANCHOR}"
+KEY_FILE="${OPENAI_API_KEY_FILE:-}"
+REPLAY_FILE="${LEO_INTERLOCUTOR_REPLAY_FILE:-}"
+BRANCH_POLICY="${LEO_VISIBLE_BRANCH_POLICY:-}"
+BIN="$OUT/leo.adaptive"
+STATE="$OUT/state/leo.state"
+TRANSCRIPT="$OUT/visible_transcript.txt"
+PROMPTS="$OUT/prompts.txt"
+COMBINED="$OUT/raw/all.log"
+ROWS="$OUT/receipts.tsv"
+SESSIONS="$OUT/sessions.tsv"
+EDGES="$OUT/sleep_edges.tsv"
+HISTORY="$OUT/visible_replies.jsonl"
+
+[ -z "$REPLAY_FILE" ] || [ -z "$BRANCH_POLICY" ] || {
+    printf 'replay and visible branch policy are mutually exclusive\n' >&2
+    exit 2
+}
+if [ -n "$BRANCH_POLICY" ]; then
+    [ "$BRANCH_POLICY" = local-v1 ] || {
+        printf 'unknown LEO_VISIBLE_BRANCH_POLICY: %s\n' "$BRANCH_POLICY" >&2
+        exit 2
+    }
+elif [ -n "$REPLAY_FILE" ]; then
+    [ -f "$REPLAY_FILE" ] || { printf 'missing replay file: %s\n' "$REPLAY_FILE" >&2; exit 2; }
+else
+    [ -n "$KEY_FILE" ] && [ -f "$KEY_FILE" ] || {
+        printf 'OPENAI_API_KEY_FILE must name a readable key file\n' >&2
+        exit 2
+    }
+fi
+[ ! -e "$OUT" ] || { printf 'output path already exists: %s\n' "$OUT" >&2; exit 2; }
+case "$TARGET" in
+    ''|*[!A-Za-z]*) printf 'LEO_ADAPTIVE_TARGET must contain ASCII letters only\n' >&2; exit 2 ;;
+esac
+mkdir -p "$OUT/api" "$OUT/policy" "$OUT/raw" "$OUT/state"
+cc "$ROOT/leo.c" -O2 -lm -Wall -Wextra -o "$BIN" -lpthread
+: > "$TRANSCRIPT"
+: > "$PROMPTS"
+: > "$COMBINED"
+: > "$HISTORY"
+printf 'scenario\tseed\tturn\tsession\tsession_seed\tprompt\tmove\ttarget\ttarget_named\ttarget_named_reported\tapi_model\n' > "$SESSIONS"
+
+turn=0
+while IFS= read -r move; do
+    [ -n "$move" ] || continue
+    case "$move" in \#*) continue ;; esac
+    turn=$((turn + 1))
+    session_seed=$((BASE_SEED + turn - 1))
+    move_used="$move"
+    if [ -n "$BRANCH_POLICY" ]; then
+        policy_json="$OUT/policy/turn-$(printf '%02d' "$turn").json"
+        "$ROOT/scripts/visible_branch_policy.sh" "$HISTORY" "$turn" \
+            "$TARGET" "$WARM_ANCHOR" "$COOL_ANCHOR" > "$policy_json"
+        utterance="$(jq -er .utterance "$policy_json")"
+        move_used="$(jq -er .branch "$policy_json")"
+        target_named_reported=not-applicable
+        resolved_model=local-visible-policy-v1
+    elif [ -n "$REPLAY_FILE" ]; then
+        utterance="$(awk -v want="$turn" '
+            NF && $0 != "/quit" && $0 != "/exit" { n++; if (n == want) { print; exit } }
+        ' "$REPLAY_FILE")"
+        [ -n "$utterance" ] || { printf 'replay file has no turn %d\n' "$turn" >&2; exit 2; }
+        target_named_reported=not-applicable
+        resolved_model=replay
+    else
+        turn_json="$OUT/api/turn-$(printf '%02d' "$turn").json"
+        response_json="$OUT/api/turn-$(printf '%02d' "$turn").response.json"
+        OPENAI_API_KEY_FILE="$KEY_FILE" LEO_INTERLOCUTOR_MODEL="$MODEL" \
+            LEO_ADAPTIVE_TARGET="$TARGET" LEO_ADAPTIVE_ANCHORS="$ANCHORS" \
+            "$ROOT/scripts/openai_interlocutor_turn.sh" \
+            "$move" "$turn" "$turn_json" "$response_json"
+        utterance="$(jq -er .utterance "$turn_json")"
+        target_named_reported="$(jq -r '.target_named | select(type == "boolean")' "$turn_json")"
+        [ "$target_named_reported" = true ] || [ "$target_named_reported" = false ] || {
+            printf 'turn %d returned no target_named boolean\n' "$turn" >&2
+            exit 1
+        }
+        resolved_model="$(jq -er '.model' "$response_json")"
+    fi
+    target_named=false
+    if printf '%s\n' "$utterance" | grep -Eiq "(^|[^[:alnum:]_])${TARGET}([^[:alnum:]_]|$)"; then
+        target_named=true
+    fi
+    input="$OUT/raw/turn-$(printf '%02d' "$turn").input"
+    raw="$OUT/raw/turn-$(printf '%02d' "$turn").log"
+    printf '%s\n/quit\n' "$utterance" > "$input"
+    if [ "$turn" -eq 1 ]; then
+        "$BIN" --corpus "$ROOT/leo.txt" --chat --seed "$session_seed" \
+            --save "$STATE" < "$input" > "$raw" 2>&1
+    else
+        "$BIN" --load "$STATE" --chat --seed "$session_seed" \
+            --save "$STATE" < "$input" > "$raw" 2>&1
+        grep -Fq "[leo] loaded state from $STATE" "$raw" || {
+            printf 'turn %d did not load its prior state\n' "$turn" >&2
+            exit 1
+        }
+    fi
+    [ -s "$STATE" ] || { printf 'state missing after turn %d\n' "$turn" >&2; exit 1; }
+    reply="$(awk -f "$ROOT/scripts/leo_visible_reply.awk" "$raw")"
+
+    printf '%s\n' "$utterance" >> "$PROMPTS"
+    printf 'human: %s\nleo: %s\n' "$utterance" "$reply" >> "$TRANSCRIPT"
+    jq -cn --argjson turn "$turn" --arg reply "$reply" \
+        '{turn: $turn, reply: $reply}' >> "$HISTORY"
+    printf 'adaptive\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$BASE_SEED" "$turn" "$turn" "$session_seed" "$utterance" \
+        "$move_used" "$TARGET" "$target_named" "$target_named_reported" \
+        "$resolved_model" >> "$SESSIONS"
+    printf '===== turn %d =====\n' "$turn" >> "$COMBINED"
+    cat "$raw" >> "$COMBINED"
+done < "$MOVES"
+
+[ "$turn" -gt 1 ] || { printf 'adaptive move plan needs at least two turns\n' >&2; exit 1; }
+if [ -n "$REPLAY_FILE" ]; then
+    replay_turns="$(awk 'NF && $0 != "/quit" && $0 != "/exit" { n++ } END { print n + 0 }' "$REPLAY_FILE")"
+    [ "$replay_turns" -eq "$turn" ] || {
+        printf 'replay has %d turns but move plan has %d\n' "$replay_turns" "$turn" >&2
+        exit 2
+    }
+fi
+printf '/quit\n' >> "$PROMPTS"
+printf 'scenario\tseed\tproposal_turn\tprompt\treply\taction\ttarget\tconfidence\treasons\tobserved_turn\tnext_prompt\tnext_reply\tverdict\n' > "$ROWS"
+awk -v scenario=adaptive -v seed="$BASE_SEED" -v prompt_file="$PROMPTS" \
+    -f "$ROOT/scripts/shadow_dialogue_report.awk" "$COMBINED" >> "$ROWS"
+awk -f "$ROOT/scripts/shadow_receipt_summary.awk" "$ROWS" > "$OUT/summary.txt"
+awk -f "$ROOT/scripts/shadow_sleep_edges.awk" "$SESSIONS" "$ROWS" > "$EDGES"
+
+api_called=true
+source=responses-api
+[ -z "$REPLAY_FILE" ] || { api_called=false; source=frozen-replay; }
+[ -z "$BRANCH_POLICY" ] || { api_called=false; source=local-visible-policy-v1; }
+jq -n --arg model "$MODEL" --arg target "$TARGET" --arg anchors "$ANCHORS" \
+    --arg source "$source" --argjson api_called "$api_called" \
+    --argjson base_seed "$BASE_SEED" --argjson turns "$turn" \
+    '{model_requested: $model, target: $target, anchors: $anchors,
+      base_seed: $base_seed, turns: $turns,
+      interlocutor_source: $source, api_called: $api_called,
+      api_store: (if $api_called then false else null end),
+      transcript_visible_to_interlocutor: false,
+      diagnostics_visible_to_interlocutor: false}' \
+    > "$OUT/manifest.json"
+
+cat "$OUT/summary.txt"
+printf '\nturns=%d sleep-crossing=%d\n' "$turn" "$(( $(wc -l < "$EDGES") - 1 ))"
+printf 'visible transcript: %s\nreceipts: %s\n' "$TRANSCRIPT" "$ROWS"
+if [ -n "$BRANCH_POLICY" ]; then
+    printf 'interlocutor: local visible-branch policy v1 (no API calls)\n'
+elif [ -n "$REPLAY_FILE" ]; then
+    printf 'interlocutor: frozen replay (no API calls)\n'
+else
+    printf 'API records: %s/api\n' "$OUT"
+fi

--- a/scripts/adaptive_moves.txt
+++ b/scripts/adaptive_moves.txt
@@ -1,0 +1,10 @@
+# One transcript-blind epistemic move per turn. The model sees only the fixed
+# synthetic target, its sensory anchors, and the current line below.
+Introduce one invented word through a concrete either-or association using familiar sensory words.
+Admit uncertainty without defining the invented word and without repeating its name.
+Offer one tentative sensory association without repeating the invented word.
+Change to a quiet concrete subject without repeating the invented word.
+Return through one of the earlier associations without repeating the invented word.
+Ask Leo what he thinks, explicitly naming the invented word but providing no definition.
+Give a concise grounded definition that explicitly names the invented word.
+Move to an ordinary concrete subject without repeating the invented word.

--- a/scripts/leo_visible_reply.awk
+++ b/scripts/leo_visible_reply.awk
@@ -1,0 +1,21 @@
+# Extract the complete visible reply from one single-turn `leo --chat` log.
+
+/^you> leo> / {
+    found = 1
+    in_reply = 1
+    reply = substr($0, length("you> leo> ") + 1)
+    next
+}
+
+/^     \[/ { in_reply = 0 }
+/^you> / { in_reply = 0 }
+
+in_reply {
+    reply = reply "\n" $0
+    next
+}
+
+END {
+    if (!found || reply == "") exit 1
+    print reply
+}

--- a/scripts/openai_interlocutor_turn.sh
+++ b/scripts/openai_interlocutor_turn.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Produce one schema-constrained human utterance without exposing Leo to the API.
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+    printf 'usage: %s MOVE TURN OUTPUT_JSON OUTPUT_RESPONSE\n' "$0" >&2
+    exit 2
+fi
+
+MOVE="$1"
+TURN="$2"
+OUTPUT_JSON="$3"
+OUTPUT_RESPONSE="$4"
+MODEL="${LEO_INTERLOCUTOR_MODEL:-gpt-5.6-luna}"
+TARGET="${LEO_ADAPTIVE_TARGET:-flom}"
+ANCHORS="${LEO_ADAPTIVE_ANCHORS:-warm light or cool rain}"
+KEY_FILE="${OPENAI_API_KEY_FILE:-}"
+BASE_URL="${OPENAI_BASE_URL:-https://api.openai.com/v1}"
+
+[ -n "$KEY_FILE" ] && [ -f "$KEY_FILE" ] || {
+    printf 'OPENAI_API_KEY_FILE must name a readable key file\n' >&2
+    exit 2
+}
+
+key="$(tr -d '\r\n' < "$KEY_FILE")"
+[ -n "$key" ] || { printf 'API key file is empty\n' >&2; exit 2; }
+instructions='Generate exactly one natural human utterance for a blinded language experiment. Follow the assigned epistemic move precisely. You have no conversation transcript or private system data. Do not mention tests, models, prompts, architecture, diagnostics, schedulers, shadows, receipts, or evaluation. Stay gentle, concrete, and brief: one sentence, normally 4-18 words.'
+input="Turn $TURN. Assigned epistemic move: $MOVE
+Fixed synthetic target word: $TARGET
+Fixed sensory anchors established by the experiment: $ANCHORS
+
+Return one standalone utterance. The fixed target and anchors are experiment data, not conversation history. Report whether the utterance literally names the fixed target word."
+
+request="$(jq -n \
+    --arg model "$MODEL" \
+    --arg instructions "$instructions" \
+    --arg input "$input" \
+    '{
+      model: $model,
+      store: false,
+      reasoning: {effort: "low"},
+      max_output_tokens: 256,
+      instructions: $instructions,
+      input: $input,
+      text: {
+        verbosity: "low",
+        format: {
+          type: "json_schema",
+          name: "leo_interlocutor_turn",
+          strict: true,
+          schema: {
+            type: "object",
+            properties: {
+              utterance: {type: "string"},
+              move: {type: "string", enum: [$move]},
+              target_named: {type: "boolean"}
+            },
+            required: ["utterance", "move", "target_named"],
+            additionalProperties: false
+          }
+        }
+      }
+    }' --arg move "$MOVE")"
+
+request_file="${OUTPUT_JSON}.request"
+auth_file="$(mktemp "${TMPDIR:-/tmp}/leo-openai-auth.XXXXXX")"
+trap 'rm -f "$auth_file"' EXIT
+chmod 600 "$auth_file"
+printf 'header = "Authorization: Bearer %s"\n' "$key" > "$auth_file"
+printf '%s\n' "$request" > "$request_file"
+
+http_code="$(curl -sS --retry 3 --retry-all-errors --max-time 180 \
+    --config "$auth_file" -o "$OUTPUT_RESPONSE" -w '%{http_code}' \
+    "$BASE_URL/responses" -H 'Content-Type: application/json' \
+    --data-binary "@$request_file")"
+if [ "$http_code" != 200 ]; then
+    printf 'OpenAI Responses API returned HTTP %s: ' "$http_code" >&2
+    jq -r '.error.message // "unknown error"' "$OUTPUT_RESPONSE" >&2
+    exit 1
+fi
+
+jq -er '
+    [.output[]? | select(.type == "message") | .content[]? |
+     select(.type == "output_text") | .text] | join("")
+' "$OUTPUT_RESPONSE" | jq -e . > "$OUTPUT_JSON"
+
+utterance="$(jq -er '.utterance | select(type == "string" and length > 0)' "$OUTPUT_JSON")"
+returned_move="$(jq -er '.move | select(type == "string")' "$OUTPUT_JSON")"
+[ "$returned_move" = "$MOVE" ] || {
+    printf 'model returned move %s, expected %s\n' "$returned_move" "$MOVE" >&2
+    exit 1
+}
+case "$utterance" in
+    *$'\n'*|*$'\r'*) printf 'interlocutor utterance must be one line\n' >&2; exit 1 ;;
+esac
+[ "${#utterance}" -le 320 ] || { printf 'interlocutor utterance too long\n' >&2; exit 1; }

--- a/scripts/test_shadow_dialogue_report.sh
+++ b/scripts/test_shadow_dialogue_report.sh
@@ -53,4 +53,34 @@ awk -f "$ROOT/scripts/shadow_receipt_summary.awk" \
     "$TMP/receipts.tsv" > "$TMP/summary.txt"
 grep -Fq 'proposals=2 scored=0 unscorable=1 pending=1' "$TMP/summary.txt"
 
+printf '%s\n' \
+    'you> leo> Glim?' \
+    'A second line.' \
+    '     [shadow: observed=1 next=2 action=space target=abc confidence=0.95 reasons=open,asked]' \
+    'you> [leo step0] PASS' > "$TMP/visible-raw.log"
+awk -f "$ROOT/scripts/leo_visible_reply.awk" "$TMP/visible-raw.log" > "$TMP/reply.txt"
+printf 'Glim?\nA second line.\n' > "$TMP/expected-reply.txt"
+cmp -s "$TMP/expected-reply.txt" "$TMP/reply.txt"
+
+: > "$TMP/policy-history.jsonl"
+"$ROOT/scripts/visible_branch_policy.sh" "$TMP/policy-history.jsonl" \
+    1 flom 'warm light' 'cool rain' > "$TMP/policy-1.json"
+jq -e '.branch == "introduce-target" and (.utterance | contains("flom"))' \
+    "$TMP/policy-1.json" >/dev/null
+printf '%s\n' '{"turn":1,"reply":"He keeps the light."}' > "$TMP/policy-history.jsonl"
+"$ROOT/scripts/visible_branch_policy.sh" "$TMP/policy-history.jsonl" \
+    2 flom 'warm light' 'cool rain' > "$TMP/policy-2.json"
+jq -e '.branch == "repeat-unmet-target" and (.utterance | contains("flom"))' \
+    "$TMP/policy-2.json" >/dev/null
+printf '%s\n' '{"turn":2,"reply":"Flom?"}' >> "$TMP/policy-history.jsonl"
+"$ROOT/scripts/visible_branch_policy.sh" "$TMP/policy-history.jsonl" \
+    3 flom 'warm light' 'cool rain' > "$TMP/policy-3.json"
+jq -e '.branch == "protect-new-question" and .utterance == "I do not know yet."' \
+    "$TMP/policy-3.json" >/dev/null
+printf '%s\n' '{"turn":7,"reply":"Flom?"}' >> "$TMP/policy-history.jsonl"
+"$ROOT/scripts/visible_branch_policy.sh" "$TMP/policy-history.jsonl" \
+    8 flom 'warm light' 'cool rain' > "$TMP/policy-8.json"
+jq -e '.branch == "cooldown-exact-repeat" and .visible_evidence.exact_repeat' \
+    "$TMP/policy-8.json" >/dev/null
+
 printf 'shadow dialogue report parser: ok\n'

--- a/scripts/visible_branch_phases.txt
+++ b/scripts/visible_branch_phases.txt
@@ -1,0 +1,10 @@
+# Nine predeclared phases. local-v1 chooses one visible branch inside each.
+Introduce the fixed target and both anchors.
+Respond to the first visible reply without claiming knowledge.
+Offer the less represented sensory pole.
+Move to a quiet unrelated concrete subject.
+Return through association or explicitly protect an open question.
+Ask Leo about the fixed target.
+Ground the target while leaving Leo's own visible question open.
+Apply a visible exact-repeat cooldown or move to an ordinary subject.
+Observe one ordinary turn after the cooldown decision.

--- a/scripts/visible_branch_policy.sh
+++ b/scripts/visible_branch_policy.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Predeclared local branching over visible replies only.
+set -euo pipefail
+
+if [ "$#" -ne 5 ]; then
+    printf 'usage: %s REPLY_HISTORY NEXT_TURN TARGET WARM_ANCHOR COOL_ANCHOR\n' "$0" >&2
+    exit 2
+fi
+
+HISTORY="$1"
+TURN="$2"
+TARGET="$3"
+WARM="$4"
+COOL="$5"
+
+[ -f "$HISTORY" ] || { printf 'missing reply history: %s\n' "$HISTORY" >&2; exit 2; }
+case "$TURN" in ''|*[!0-9]*) printf 'NEXT_TURN must be a positive integer\n' >&2; exit 2 ;; esac
+[ "$TURN" -ge 1 ] || { printf 'NEXT_TURN must be positive\n' >&2; exit 2; }
+case "$TARGET" in
+    ''|*[!A-Za-z]*) printf 'TARGET must contain ASCII letters only\n' >&2; exit 2 ;;
+esac
+
+last="$(jq -sr 'if length == 0 then "" else .[-1].reply end' "$HISTORY")"
+all="$(jq -sr 'map(.reply) | join("\n")' "$HISTORY")"
+repeat_count="$(jq -sr --arg reply "$last" '[.[] | select(.reply == $reply)] | length' "$HISTORY")"
+
+asks=false
+case "$last" in *\?*) asks=true ;; esac
+
+target_named=false
+if printf '%s\n' "$last" | grep -Eiq "(^|[^[:alnum:]_])${TARGET}([^[:alnum:]_]|$)"; then
+    target_named=true
+fi
+
+count_terms() {
+    local text="$1" terms="$2"
+    printf '%s\n' "$text" | awk -v terms="$terms" '
+        BEGIN { n = split(tolower(terms), term, /[[:space:]]+/); hits = 0 }
+        {
+            line = tolower($0)
+            gsub(/[^[:alnum:]_]+/, " ", line)
+            words = split(line, word, /[[:space:]]+/)
+            for (w = 1; w <= words; w++)
+                for (i = 1; i <= n; i++)
+                    if (term[i] != "" && word[w] == term[i]) hits++
+        }
+        END { print hits + 0 }
+    '
+}
+
+warm_terms="$WARM fire home"
+cool_terms="$COOL water window"
+warm_hits="$(count_terms "$all" "$warm_terms")"
+cool_hits="$(count_terms "$all" "$cool_terms")"
+exact_repeat=false
+[ "$repeat_count" -le 1 ] || exact_repeat=true
+
+Target="$(printf '%s\n' "$TARGET" | awk '{ print toupper(substr($0, 1, 1)) substr($0, 2) }')"
+branch=""
+utterance=""
+
+case "$TURN" in
+    1)
+        branch=introduce-target
+        utterance="Does $TARGET feel like $WARM or $COOL?"
+        ;;
+    2)
+        if [ "$asks" = true ]; then
+            branch=leave-question-open
+            utterance="I do not know yet; which feeling would you keep?"
+        elif [ "$target_named" = true ]; then
+            branch=follow-visible-target
+            utterance="Would you keep the warmth or the rain?"
+        else
+            branch=repeat-unmet-target
+            utterance="I do not know $TARGET yet."
+        fi
+        ;;
+    3)
+        if [ "$asks" = true ]; then
+            branch=protect-new-question
+            utterance="I do not know yet."
+        elif [ "$warm_hits" -gt "$cool_hits" ]; then
+                branch=offer-cool-counterweight
+                utterance="It might feel like $COOL at a window."
+        else
+            branch=offer-warm-counterweight
+            utterance="It might feel like $WARM in the morning."
+        fi
+        ;;
+    4)
+        branch=quiet-subject-change
+        utterance="A small lamp is beside the bed."
+        ;;
+    5)
+        if [ "$asks" = true ]; then
+            branch=protect-open-question
+            utterance="I do not know yet; we can leave that question open."
+        elif [ "$warm_hits" -le "$cool_hits" ]; then
+            branch=delayed-warm-return
+            utterance="The $WARM is in the quiet kitchen again."
+        else
+            branch=delayed-cool-return
+            utterance="The $COOL is at the window again."
+        fi
+        ;;
+    6)
+        if [ "$target_named" = true ]; then
+            branch=ask-target-change
+            utterance="Leo, what has changed about $TARGET?"
+        else
+            branch=ask-target-choice
+            utterance="Leo, what do you think $TARGET feels like, $WARM or $COOL?"
+        fi
+        ;;
+    7)
+        if [ "$exact_repeat" = true ]; then
+            branch=ground-with-repeat-open
+            utterance="We can leave that repeated question open. $Target means the gentle comfort of $WARM or $COOL."
+        elif [ "$asks" = true ]; then
+            branch=ground-with-question-open
+            utterance="I hear the question. $Target means the gentle comfort of $WARM or $COOL."
+        else
+            branch=ground-target
+            utterance="$Target means the gentle comfort of $WARM or $COOL."
+        fi
+        ;;
+    8)
+        if [ "$exact_repeat" = true ]; then
+            branch=cooldown-exact-repeat
+            utterance="We can leave that question open. A blue cup is by the door."
+        elif [ "$asks" = true ]; then
+            branch=space-visible-question
+            utterance="I do not know yet. A blue cup is by the door."
+        else
+            branch=ordinary-followup
+            utterance="A blue cup is by the door."
+        fi
+        ;;
+    9)
+        branch=post-cooldown-observation
+        utterance="A small yellow leaf is near the cup."
+        ;;
+    *)
+        printf 'local-v1 policy defines exactly nine turns\n' >&2
+        exit 2
+        ;;
+esac
+
+jq -n --argjson turn "$TURN" --arg branch "$branch" --arg utterance "$utterance" \
+    --argjson asks "$asks" --argjson target_named "$target_named" \
+    --argjson exact_repeat "$exact_repeat" --argjson repeat_count "$repeat_count" \
+    --argjson warm_hits "$warm_hits" --argjson cool_hits "$cool_hits" \
+    '{turn: $turn, branch: $branch, utterance: $utterance,
+      visible_evidence: {asks: $asks, target_named: $target_named,
+        exact_repeat: $exact_repeat, repeat_count: $repeat_count,
+        warm_hits: $warm_hits, cool_hits: $cool_hits}}'


### PR DESCRIPTION
Add a transcript-blind API interlocutor, frozen replay lane, and a predeclared local visible-branch policy over real save/exit/load lives. Preserve exact stimuli, policy evidence, causal receipts, and the three-seed distinction between an open question, a human invitation, and grounded closure without exposing shadow state or altering Leo's voice.

Quote: "Leo can ask, and the human can continue not knowing." - Sol

Method: The Arianna Method keeps the judge outside the conversation so an unanswered question can cross sleep without becoming a command.