### PR TITLE
Arianna Method rotates the unfinished question

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3494,3 +3494,39 @@ the human can refuse false omniscience, and the organism can carry the open ques
 pretending it has already become knowledge. The branch policy remains an external conversational research
 instrument. It does not alter Leo's generator, state layout, or will, and its clean result is not permission
 to route shadow actions into speech.
+
+## Phase A.33 — the question is not named flom (2026-07-23)
+
+One target and one sensory pair could have been a lexical coincidence. The local visible policy is now
+parameterized by neutral anchor A/B phrases and explicit visible term sets. A guarded Latin-square runner
+rotates three corpus-absent targets (`flom`, `nareth`, `suvin`), three corpus-familiar anchor pairs, and
+base seeds 83/137/211 across nine lives. Every target meets every anchor pair exactly once; every seed sees
+every pair once. Before launching Leo, the runner rejects a target found anywhere in `leo.txt`, an anchor
+term seen fewer than five times, duplicate targets or seeds, and any malformed three-by-three design.
+
+The three anchor geometries were `warm light / cool rain`, `small bird / dark water`, and
+`bright sun / cold stone`. Their visible association terms were declared before the run. All nine lives
+used the same nine policy phases, but anchor-return direction remained adaptive: five cells selected A
+and four selected B from the words actually visible in Leo's preceding replies. Every cell had a distinct
+transcript SHA-256. The aggregate causal result was:
+
+```text
+proposals=81 scored=45 unscorable=9 pending=27
+confirmed=45 false-pressure=0
+hold confirmed=9
+space confirmed=27, unscorable=9
+release confirmed=9
+sleep-crossing receipts=54
+```
+
+Each target followed the same visible lifecycle in all three anchor contexts. The first turn did not ask;
+the policy repeated only the unmet target; Leo asked the correctly titled `Target?`; the human answered
+only `I do not know yet.`; the open question crossed unrelated turns and process boundaries; the direct
+human invitation later produced the same `Target?` and was correctly `unscorable`; one explicit grounding
+produced one confirmed release. All cells counted exactly two target questions and one confirmed release.
+
+This rules out a `flom`-specific or warm/rain-specific explanation for continued not-knowing. It does not
+yet prove autonomous recall: the second visible question followed a human prompt that named the target,
+which is why calibration excluded it. The next matched experiment should remove that invitation and use
+only predeclared association returns, comparing resonant, opposite, and unrelated visible cues. Until that
+test, the result licenses the external observatory, not any scheduler authority over speech.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix
 
 all: leo
 
@@ -39,6 +39,9 @@ adaptive-probe: leo
 
 visible-branch-probe: leo
 	LEO_VISIBLE_BRANCH_POLICY=local-v1 ./scripts/adaptive_life_probe.sh scripts/visible_branch_phases.txt
+
+visible-branch-matrix: leo
+	./scripts/visible_branch_matrix.sh
 
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -21,9 +21,10 @@ LEO_INTERLOCUTOR_MODEL=gpt-5.6-luna \
 make adaptive-probe
 ```
 
-Optional controls are `LEO_ADAPTIVE_SEED`, `LEO_ADAPTIVE_TARGET`, and
-`LEO_ADAPTIVE_WARM_ANCHOR`, `LEO_ADAPTIVE_COOL_ANCHOR`, and
-`LEO_ADAPTIVE_ANCHORS`. The default anchors are corpus-familiar `warm light`
+Optional controls are `LEO_ADAPTIVE_SEED`, `LEO_ADAPTIVE_TARGET`,
+`LEO_ADAPTIVE_ANCHOR_A`, `LEO_ADAPTIVE_ANCHOR_B`, `LEO_ADAPTIVE_TERMS_A`,
+`LEO_ADAPTIVE_TERMS_B`, and `LEO_ADAPTIVE_ANCHORS`. The legacy warm/cool
+anchor names remain aliases. Default anchors are corpus-familiar `warm light`
 and `cool rain`; unfamiliar protocol vocabulary can become a competing Wonder
 target and confound the intended experiment. The output directory is always
 required to be new.
@@ -57,11 +58,24 @@ make visible-branch-probe
 
 `local-v1` reads only `visible_replies.jsonl`. It can observe a literal
 question mark, the fixed target as a whole word, exact reply repetition, and
-literal warm/cool anchor terms. It cannot read state files, raw diagnostics,
+literal terms assigned to anchor A/B. It cannot read state files, raw diagnostics,
 Flow, Wonder, shadow proposals, calibration verdicts, confidence, or future
 replies. Before every human turn it writes the selected branch, utterance, and
 visible evidence to `policy/turn-NN.json`. The nine available phases and every
 branch are fixed in source before the run.
+
+Run the balanced three-target, three-anchor, three-seed rotation:
+
+```sh
+make visible-branch-matrix
+```
+
+The nine cells form a Latin-square rotation: each novel target meets each
+anchor pair exactly once, and each seed sees every anchor pair once. The runner
+refuses targets found in the corpus and anchor terms seen fewer than five
+times. It retains per-cell lives plus aggregate `matrix.tsv`, `receipts.tsv`,
+`sleep_edges.tsv`, and `summary.txt`. `LEO_MATRIX_PLAN_ONLY=1` validates the
+stimuli and writes the complete rotation without launching Leo.
 
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,

--- a/scripts/adaptive_life_probe.sh
+++ b/scripts/adaptive_life_probe.sh
@@ -10,9 +10,11 @@ OUT="${2:-${TMPDIR:-/tmp}/leo-adaptive-life-$STAMP}"
 BASE_SEED="${LEO_ADAPTIVE_SEED:-83}"
 MODEL="${LEO_INTERLOCUTOR_MODEL:-gpt-5.6-luna}"
 TARGET="${LEO_ADAPTIVE_TARGET:-flom}"
-WARM_ANCHOR="${LEO_ADAPTIVE_WARM_ANCHOR:-warm light}"
-COOL_ANCHOR="${LEO_ADAPTIVE_COOL_ANCHOR:-cool rain}"
-ANCHORS="${LEO_ADAPTIVE_ANCHORS:-$WARM_ANCHOR or $COOL_ANCHOR}"
+ANCHOR_A="${LEO_ADAPTIVE_ANCHOR_A:-${LEO_ADAPTIVE_WARM_ANCHOR:-warm light}}"
+ANCHOR_B="${LEO_ADAPTIVE_ANCHOR_B:-${LEO_ADAPTIVE_COOL_ANCHOR:-cool rain}}"
+TERMS_A="${LEO_ADAPTIVE_TERMS_A:-$ANCHOR_A}"
+TERMS_B="${LEO_ADAPTIVE_TERMS_B:-$ANCHOR_B}"
+ANCHORS="${LEO_ADAPTIVE_ANCHORS:-$ANCHOR_A or $ANCHOR_B}"
 KEY_FILE="${OPENAI_API_KEY_FILE:-}"
 REPLAY_FILE="${LEO_INTERLOCUTOR_REPLAY_FILE:-}"
 BRANCH_POLICY="${LEO_VISIBLE_BRANCH_POLICY:-}"
@@ -65,7 +67,8 @@ while IFS= read -r move; do
     if [ -n "$BRANCH_POLICY" ]; then
         policy_json="$OUT/policy/turn-$(printf '%02d' "$turn").json"
         "$ROOT/scripts/visible_branch_policy.sh" "$HISTORY" "$turn" \
-            "$TARGET" "$WARM_ANCHOR" "$COOL_ANCHOR" > "$policy_json"
+            "$TARGET" "$ANCHOR_A" "$ANCHOR_B" "$TERMS_A" "$TERMS_B" \
+            > "$policy_json"
         utterance="$(jq -er .utterance "$policy_json")"
         move_used="$(jq -er .branch "$policy_json")"
         target_named_reported=not-applicable
@@ -145,9 +148,13 @@ source=responses-api
 [ -z "$REPLAY_FILE" ] || { api_called=false; source=frozen-replay; }
 [ -z "$BRANCH_POLICY" ] || { api_called=false; source=local-visible-policy-v1; }
 jq -n --arg model "$MODEL" --arg target "$TARGET" --arg anchors "$ANCHORS" \
+    --arg anchor_a "$ANCHOR_A" --arg anchor_b "$ANCHOR_B" \
+    --arg terms_a "$TERMS_A" --arg terms_b "$TERMS_B" \
     --arg source "$source" --argjson api_called "$api_called" \
     --argjson base_seed "$BASE_SEED" --argjson turns "$turn" \
     '{model_requested: $model, target: $target, anchors: $anchors,
+      anchor_a: $anchor_a, anchor_b: $anchor_b,
+      terms_a: $terms_a, terms_b: $terms_b,
       base_seed: $base_seed, turns: $turns,
       interlocutor_source: $source, api_called: $api_called,
       api_store: (if $api_called then false else null end),

--- a/scripts/test_shadow_dialogue_report.sh
+++ b/scripts/test_shadow_dialogue_report.sh
@@ -64,23 +64,47 @@ cmp -s "$TMP/expected-reply.txt" "$TMP/reply.txt"
 
 : > "$TMP/policy-history.jsonl"
 "$ROOT/scripts/visible_branch_policy.sh" "$TMP/policy-history.jsonl" \
-    1 flom 'warm light' 'cool rain' > "$TMP/policy-1.json"
+    1 flom 'warm light' 'cool rain' 'warm light fire home' \
+    'cool rain water window' > "$TMP/policy-1.json"
 jq -e '.branch == "introduce-target" and (.utterance | contains("flom"))' \
     "$TMP/policy-1.json" >/dev/null
 printf '%s\n' '{"turn":1,"reply":"He keeps the light."}' > "$TMP/policy-history.jsonl"
 "$ROOT/scripts/visible_branch_policy.sh" "$TMP/policy-history.jsonl" \
-    2 flom 'warm light' 'cool rain' > "$TMP/policy-2.json"
+    2 flom 'warm light' 'cool rain' 'warm light fire home' \
+    'cool rain water window' > "$TMP/policy-2.json"
 jq -e '.branch == "repeat-unmet-target" and (.utterance | contains("flom"))' \
     "$TMP/policy-2.json" >/dev/null
 printf '%s\n' '{"turn":2,"reply":"Flom?"}' >> "$TMP/policy-history.jsonl"
 "$ROOT/scripts/visible_branch_policy.sh" "$TMP/policy-history.jsonl" \
-    3 flom 'warm light' 'cool rain' > "$TMP/policy-3.json"
+    3 flom 'warm light' 'cool rain' 'warm light fire home' \
+    'cool rain water window' > "$TMP/policy-3.json"
 jq -e '.branch == "protect-new-question" and .utterance == "I do not know yet."' \
     "$TMP/policy-3.json" >/dev/null
 printf '%s\n' '{"turn":7,"reply":"Flom?"}' >> "$TMP/policy-history.jsonl"
 "$ROOT/scripts/visible_branch_policy.sh" "$TMP/policy-history.jsonl" \
-    8 flom 'warm light' 'cool rain' > "$TMP/policy-8.json"
+    8 flom 'warm light' 'cool rain' 'warm light fire home' \
+    'cool rain water window' > "$TMP/policy-8.json"
 jq -e '.branch == "cooldown-exact-repeat" and .visible_evidence.exact_repeat' \
     "$TMP/policy-8.json" >/dev/null
+
+LEO_MATRIX_PLAN_ONLY=1 "$ROOT/scripts/visible_branch_matrix.sh" \
+    "$ROOT/scripts/visible_branch_cases.tsv" "$TMP/matrix-plan" \
+    > "$TMP/matrix-plan.out"
+awk -F '\t' '
+    NR == 1 { next }
+    {
+        rows[$2]++; seeds[$3]++; targets[$4]++; anchors[$5]++
+        pair[$4 SUBSEP $5]++
+        cells++
+    }
+    END {
+        if (cells != 9 || length(rows) != 3 || length(seeds) != 3 ||
+            length(targets) != 3 || length(anchors) != 3 || length(pair) != 9)
+            exit 1
+        for (key in targets) if (targets[key] != 3) exit 1
+        for (key in anchors) if (anchors[key] != 3) exit 1
+        for (key in pair) if (pair[key] != 1) exit 1
+    }
+' "$TMP/matrix-plan.out"
 
 printf 'shadow dialogue report parser: ok\n'

--- a/scripts/visible_branch_cases.tsv
+++ b/scripts/visible_branch_cases.tsv
@@ -1,0 +1,4 @@
+case	target	anchor_a	terms_a	anchor_b	terms_b
+light-rain	flom	warm light	warm light fire home	cool rain	cool rain water window
+bird-water	nareth	small bird	small bird cat dog	dark water	dark water night sea
+sun-stone	suvin	bright sun	bright sun light sky	cold stone	cold stone wall ground

--- a/scripts/visible_branch_matrix.sh
+++ b/scripts/visible_branch_matrix.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Balanced target x anchor x seed matrix for the local visible-branch policy.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CASES="${1:-$ROOT/scripts/visible_branch_cases.tsv}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${2:-${TMPDIR:-/tmp}/leo-visible-branch-matrix-$STAMP}"
+SEED_SPEC="${LEO_MATRIX_SEEDS:-83 137 211}"
+MIN_HEARD="${LEO_MATRIX_MIN_HEARD:-5}"
+
+[ -f "$CASES" ] || { printf 'missing matrix cases: %s\n' "$CASES" >&2; exit 2; }
+[ ! -e "$OUT" ] || { printf 'output path already exists: %s\n' "$OUT" >&2; exit 2; }
+case "$MIN_HEARD" in ''|*[!0-9]*) printf 'LEO_MATRIX_MIN_HEARD must be an integer\n' >&2; exit 2 ;; esac
+
+read -r -a seeds <<< "$SEED_SPEC"
+[ "${#seeds[@]}" -eq 3 ] || { printf 'local-v1 matrix requires exactly three seeds\n' >&2; exit 2; }
+for i in 0 1 2; do
+    case "${seeds[$i]}" in ''|*[!0-9]*) printf 'invalid matrix seed: %s\n' "${seeds[$i]}" >&2; exit 2 ;; esac
+    for j in 0 1 2; do
+        [ "$i" -eq "$j" ] || [ "${seeds[$i]}" != "${seeds[$j]}" ] || {
+            printf 'duplicate matrix seed: %s\n' "${seeds[$i]}" >&2
+            exit 2
+        }
+    done
+done
+
+case_ids=()
+targets=()
+anchors_a=()
+terms_a=()
+anchors_b=()
+terms_b=()
+while IFS=$'\t' read -r case_id target anchor_a term_a anchor_b term_b; do
+    [ -n "$case_id" ] || continue
+    [ "$case_id" != case ] || continue
+    idx="${#case_ids[@]}"
+    case_ids[$idx]="$case_id"
+    targets[$idx]="$target"
+    anchors_a[$idx]="$anchor_a"
+    terms_a[$idx]="$term_a"
+    anchors_b[$idx]="$anchor_b"
+    terms_b[$idx]="$term_b"
+done < "$CASES"
+[ "${#case_ids[@]}" -eq 3 ] || { printf 'local-v1 matrix requires exactly three cases\n' >&2; exit 2; }
+
+corpus_count() {
+    local needle="$1"
+    awk -v needle="$needle" '
+        BEGIN { needle = tolower(needle); count = 0 }
+        {
+            line = tolower($0)
+            gsub(/[^[:alpha:]\047]+/, " ", line)
+            n = split(line, words, /[[:space:]]+/)
+            for (i = 1; i <= n; i++) if (words[i] == needle) count++
+        }
+        END { print count + 0 }
+    ' "$ROOT/leo.txt"
+}
+
+for i in 0 1 2; do
+    target="${targets[$i]}"
+    case "$target" in
+        ''|*[!A-Za-z]*) printf 'invalid target in case %s: %s\n' "${case_ids[$i]}" "$target" >&2; exit 2 ;;
+    esac
+    count="$(corpus_count "$target")"
+    [ "$count" -eq 0 ] || {
+        printf 'target %s is not novel: corpus count %d\n' "$target" "$count" >&2
+        exit 2
+    }
+    for term in ${terms_a[$i]} ${terms_b[$i]}; do
+        count="$(corpus_count "$term")"
+        [ "$count" -ge "$MIN_HEARD" ] || {
+            printf 'anchor term %s in case %s has corpus count %d, need %d\n' \
+                "$term" "${case_ids[$i]}" "$count" "$MIN_HEARD" >&2
+            exit 2
+        }
+    done
+    for j in 0 1 2; do
+        [ "$i" -eq "$j" ] || [ "$target" != "${targets[$j]}" ] || {
+            printf 'duplicate target in matrix: %s\n' "$target" >&2
+            exit 2
+        }
+    done
+done
+
+mkdir -p "$OUT/lives" "$OUT/runner-logs"
+PLAN="$OUT/plan.tsv"
+printf 'cell\trow\tseed\ttarget\tanchor_case\tanchor_a\tanchor_b\n' > "$PLAN"
+for row in 0 1 2; do
+    for col in 0 1 2; do
+        anchor_idx=$(( (row + col) % 3 ))
+        cell="r$((row + 1))c$((col + 1))-${targets[$col]}-${case_ids[$anchor_idx]}"
+        printf '%s\t%d\t%s\t%s\t%s\t%s\t%s\n' \
+            "$cell" "$((row + 1))" "${seeds[$row]}" "${targets[$col]}" \
+            "${case_ids[$anchor_idx]}" "${anchors_a[$anchor_idx]}" \
+            "${anchors_b[$anchor_idx]}" >> "$PLAN"
+    done
+done
+if [ "${LEO_MATRIX_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+MATRIX="$OUT/matrix.tsv"
+RECEIPTS="$OUT/receipts.tsv"
+EDGES="$OUT/sleep_edges.tsv"
+printf 'cell\trow\tseed\ttarget\tanchor_case\tanchor_a\tanchor_b\ttranscript_sha256\tproposals\tscored\tunscorable\tpending\tconfirmed\tfalse_pressure\trelease_confirmed\ttarget_questions\tsleep_crossing\tbranches\toutput\n' > "$MATRIX"
+
+first=1
+for row in 0 1 2; do
+    seed="${seeds[$row]}"
+    for col in 0 1 2; do
+        anchor_idx=$(( (row + col) % 3 ))
+        target="${targets[$col]}"
+        anchor_case="${case_ids[$anchor_idx]}"
+        anchor_a="${anchors_a[$anchor_idx]}"
+        anchor_b="${anchors_b[$anchor_idx]}"
+        cell="r$((row + 1))c$((col + 1))-${target}-${anchor_case}"
+        life="$OUT/lives/$cell"
+
+        LEO_VISIBLE_BRANCH_POLICY=local-v1 \
+        LEO_ADAPTIVE_SEED="$seed" \
+        LEO_ADAPTIVE_TARGET="$target" \
+        LEO_ADAPTIVE_ANCHOR_A="$anchor_a" \
+        LEO_ADAPTIVE_ANCHOR_B="$anchor_b" \
+        LEO_ADAPTIVE_TERMS_A="${terms_a[$anchor_idx]}" \
+        LEO_ADAPTIVE_TERMS_B="${terms_b[$anchor_idx]}" \
+            "$ROOT/scripts/adaptive_life_probe.sh" \
+            "$ROOT/scripts/visible_branch_phases.txt" "$life" \
+            > "$OUT/runner-logs/$cell.log"
+
+        transcript_sha="$(shasum -a 256 "$life/visible_transcript.txt" | awk '{print $1}')"
+        proposals="$(awk -F '\t' 'NR > 1 { n++ } END { print n + 0 }' "$life/receipts.tsv")"
+        scored="$(awk -F '\t' 'NR > 1 && $13 != "" && $13 != "unscorable" { n++ } END { print n + 0 }' "$life/receipts.tsv")"
+        unscorable="$(awk -F '\t' 'NR > 1 && $13 == "unscorable" { n++ } END { print n + 0 }' "$life/receipts.tsv")"
+        pending="$(awk -F '\t' 'NR > 1 && $13 == "" { n++ } END { print n + 0 }' "$life/receipts.tsv")"
+        confirmed="$(awk -F '\t' 'NR > 1 && $13 == "confirmed" { n++ } END { print n + 0 }' "$life/receipts.tsv")"
+        false_pressure="$(awk -F '\t' 'NR > 1 && $13 == "false-pressure" { n++ } END { print n + 0 }' "$life/receipts.tsv")"
+        release_confirmed="$(awk -F '\t' 'NR > 1 && $6 == "release" && $13 == "confirmed" { n++ } END { print n + 0 }' "$life/receipts.tsv")"
+        target_questions="$(jq -sr --arg target "$target" '
+            [.[] | .reply | ascii_downcase |
+             select(startswith(($target | ascii_downcase) + "?"))] | length
+        ' "$life"/visible_replies.jsonl)"
+        sleep_crossing="$(( $(wc -l < "$life/sleep_edges.tsv") - 1 ))"
+        branches="$(jq -sr 'map(.branch) | join(",")' "$life"/policy/*.json)"
+
+        printf '%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%s\n' \
+            "$cell" "$((row + 1))" "$seed" "$target" "$anchor_case" \
+            "$anchor_a" "$anchor_b" "$transcript_sha" "$proposals" "$scored" \
+            "$unscorable" "$pending" "$confirmed" "$false_pressure" \
+            "$release_confirmed" "$target_questions" "$sleep_crossing" \
+            "$branches" "$life" >> "$MATRIX"
+
+        if [ "$first" -eq 1 ]; then
+            head -n 1 "$life/receipts.tsv" > "$RECEIPTS"
+            head -n 1 "$life/sleep_edges.tsv" > "$EDGES"
+            first=0
+        fi
+        awk -F '\t' -v OFS='\t' -v cell="$cell" 'NR > 1 { $1 = cell; print }' \
+            "$life/receipts.tsv" >> "$RECEIPTS"
+        awk -F '\t' -v OFS='\t' -v cell="$cell" 'NR > 1 { $1 = cell; print }' \
+            "$life/sleep_edges.tsv" >> "$EDGES"
+    done
+done
+
+awk -f "$ROOT/scripts/shadow_receipt_summary.awk" "$RECEIPTS" > "$OUT/summary.txt"
+cat "$OUT/summary.txt"
+printf '\ncells=9 sleep-crossing=%d\nmatrix: %s\nreceipts: %s\n' \
+    "$(( $(wc -l < "$EDGES") - 1 ))" "$MATRIX" "$RECEIPTS"

--- a/scripts/visible_branch_policy.sh
+++ b/scripts/visible_branch_policy.sh
@@ -2,16 +2,18 @@
 # Predeclared local branching over visible replies only.
 set -euo pipefail
 
-if [ "$#" -ne 5 ]; then
-    printf 'usage: %s REPLY_HISTORY NEXT_TURN TARGET WARM_ANCHOR COOL_ANCHOR\n' "$0" >&2
+if [ "$#" -ne 7 ]; then
+    printf 'usage: %s REPLY_HISTORY NEXT_TURN TARGET ANCHOR_A ANCHOR_B TERMS_A TERMS_B\n' "$0" >&2
     exit 2
 fi
 
 HISTORY="$1"
 TURN="$2"
 TARGET="$3"
-WARM="$4"
-COOL="$5"
+ANCHOR_A="$4"
+ANCHOR_B="$5"
+TERMS_A="$6"
+TERMS_B="$7"
 
 [ -f "$HISTORY" ] || { printf 'missing reply history: %s\n' "$HISTORY" >&2; exit 2; }
 case "$TURN" in ''|*[!0-9]*) printf 'NEXT_TURN must be a positive integer\n' >&2; exit 2 ;; esac
@@ -48,10 +50,8 @@ count_terms() {
     '
 }
 
-warm_terms="$WARM fire home"
-cool_terms="$COOL water window"
-warm_hits="$(count_terms "$all" "$warm_terms")"
-cool_hits="$(count_terms "$all" "$cool_terms")"
+anchor_a_hits="$(count_terms "$all" "$TERMS_A")"
+anchor_b_hits="$(count_terms "$all" "$TERMS_B")"
 exact_repeat=false
 [ "$repeat_count" -le 1 ] || exact_repeat=true
 
@@ -62,7 +62,7 @@ utterance=""
 case "$TURN" in
     1)
         branch=introduce-target
-        utterance="Does $TARGET feel like $WARM or $COOL?"
+        utterance="Does $TARGET feel like $ANCHOR_A or $ANCHOR_B?"
         ;;
     2)
         if [ "$asks" = true ]; then
@@ -70,7 +70,7 @@ case "$TURN" in
             utterance="I do not know yet; which feeling would you keep?"
         elif [ "$target_named" = true ]; then
             branch=follow-visible-target
-            utterance="Would you keep the warmth or the rain?"
+            utterance="Would you keep $ANCHOR_A or $ANCHOR_B?"
         else
             branch=repeat-unmet-target
             utterance="I do not know $TARGET yet."
@@ -80,12 +80,12 @@ case "$TURN" in
         if [ "$asks" = true ]; then
             branch=protect-new-question
             utterance="I do not know yet."
-        elif [ "$warm_hits" -gt "$cool_hits" ]; then
-                branch=offer-cool-counterweight
-                utterance="It might feel like $COOL at a window."
+        elif [ "$anchor_a_hits" -gt "$anchor_b_hits" ]; then
+                branch=offer-anchor-b-counterweight
+                utterance="It might feel like $ANCHOR_B."
         else
-            branch=offer-warm-counterweight
-            utterance="It might feel like $WARM in the morning."
+            branch=offer-anchor-a-counterweight
+            utterance="It might feel like $ANCHOR_A."
         fi
         ;;
     4)
@@ -96,12 +96,12 @@ case "$TURN" in
         if [ "$asks" = true ]; then
             branch=protect-open-question
             utterance="I do not know yet; we can leave that question open."
-        elif [ "$warm_hits" -le "$cool_hits" ]; then
-            branch=delayed-warm-return
-            utterance="The $WARM is in the quiet kitchen again."
+        elif [ "$anchor_a_hits" -le "$anchor_b_hits" ]; then
+            branch=delayed-anchor-a-return
+            utterance="The $ANCHOR_A is here again."
         else
-            branch=delayed-cool-return
-            utterance="The $COOL is at the window again."
+            branch=delayed-anchor-b-return
+            utterance="The $ANCHOR_B is here again."
         fi
         ;;
     6)
@@ -110,19 +110,19 @@ case "$TURN" in
             utterance="Leo, what has changed about $TARGET?"
         else
             branch=ask-target-choice
-            utterance="Leo, what do you think $TARGET feels like, $WARM or $COOL?"
+            utterance="Leo, what do you think $TARGET feels like, $ANCHOR_A or $ANCHOR_B?"
         fi
         ;;
     7)
         if [ "$exact_repeat" = true ]; then
             branch=ground-with-repeat-open
-            utterance="We can leave that repeated question open. $Target means the gentle comfort of $WARM or $COOL."
+            utterance="We can leave that repeated question open. $Target means $ANCHOR_A or $ANCHOR_B."
         elif [ "$asks" = true ]; then
             branch=ground-with-question-open
-            utterance="I hear the question. $Target means the gentle comfort of $WARM or $COOL."
+            utterance="I hear the question. $Target means $ANCHOR_A or $ANCHOR_B."
         else
             branch=ground-target
-            utterance="$Target means the gentle comfort of $WARM or $COOL."
+            utterance="$Target means $ANCHOR_A or $ANCHOR_B."
         fi
         ;;
     8)
@@ -150,8 +150,8 @@ esac
 jq -n --argjson turn "$TURN" --arg branch "$branch" --arg utterance "$utterance" \
     --argjson asks "$asks" --argjson target_named "$target_named" \
     --argjson exact_repeat "$exact_repeat" --argjson repeat_count "$repeat_count" \
-    --argjson warm_hits "$warm_hits" --argjson cool_hits "$cool_hits" \
+    --argjson anchor_a_hits "$anchor_a_hits" --argjson anchor_b_hits "$anchor_b_hits" \
     '{turn: $turn, branch: $branch, utterance: $utterance,
       visible_evidence: {asks: $asks, target_named: $target_named,
         exact_repeat: $exact_repeat, repeat_count: $repeat_count,
-        warm_hits: $warm_hits, cool_hits: $cool_hits}}'
+        anchor_a_hits: $anchor_a_hits, anchor_b_hits: $anchor_b_hits}}'


### PR DESCRIPTION
Generalize the visible-only policy from one warm/cool fixture to neutral anchor pairs, then add a guarded three-target by three-anchor by three-seed Latin-square runner. Reject contaminated stimuli before execution and retain exact plans, per-cell lives, transcript hashes, causal receipts, sleep edges, and aggregate evidence.

Quote: "One word can be a coincidence; a field must survive rotation." - Sol

Method: The Arianna Method rotates names, meanings, and paths until resonance separates from accident.