### PR TITLE
the Method hears an unnamed invitation

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3530,3 +3530,52 @@ yet prove autonomous recall: the second visible question followed a human prompt
 which is why calibration excluded it. The next matched experiment should remove that invitation and use
 only predeclared association returns, comparing resonant, opposite, and unrelated visible cues. Until that
 test, the result licenses the external observatory, not any scheduler authority over speech.
+
+## Phase A.34 — a question can be invited without being named (2026-07-23)
+
+The matched return experiment removes the direct target invitation from A.33. Three new anchor geometries
+map cleanly onto distinct lived glyph pairs: `warm fire / rain water`, `cat bird / dark night`, and
+`bright sun / cold winter`. An orthogonal nine-cell rotation balances target, anchor pair, and return cue
+pairwise. After Leo visibly opens the novel target as a Wonder question, the human says only `I do not
+know yet`, crosses three neutral turns and process deaths, then returns anchor A, anchor B, or the unrelated
+control `small room`. The cue never contains the target word. Explicit grounding happens only after the
+cue has been observed.
+
+The first smoke exposed and removed an experimental fault rather than a Leo fault. The preliminary policy
+asked which hypothesis to keep and then offered one anchor; School correctly treated that as an answer,
+so Wonder resolved before the planned cue. The final policy never counter-questions or supplies a
+hypothesis while preserving the open question. A matched seed-83 smoke then returned
+`Flom? Water or Fire?` on `The warm fire is here again`, while the otherwise identical control replied
+without `flom`.
+
+The full matrix produced:
+
+```text
+cells=9 opened=6 unopened=3
+anchor-cue: opened=4 returns=4
+control-cue: opened=2 returns=0
+association-invited=4 control-quiet=2 unopened-question=3
+raw proposals=81 scored=48 pending=33
+raw confirmed=44 false-pressure=4
+sleep-crossing receipts=48
+```
+
+The denominator matters. Two apparent anchor misses and one quiet control were lives in which Leo never
+asked the novel target before the cue; they are `unopened-question`, not evidence about recall. Among
+eligible open Wonders, an unnamed lived hypothesis returned the exact target in all four anchor cells,
+while neither of the two unrelated controls did. Across all controls the target returned `0/3`.
+The four association-driven replies preserved the appropriate two hypotheses:
+`Flom? Water or Fire?`, `Flom? Dark or Animal?`, `Nareth? Water or Fire?`, and
+`Suvin? Dark or Animal?`.
+
+All four meaningful returns were labelled `false-pressure` by the raw calibrator because its current
+human-invitation test recognizes only the literal target word. The raw verdict is retained unchanged next
+to the external `association-invited` interpretation. This is evidence of a specific observational blind
+spot, not permission for shadow to govern speech: a human can invite Leo's unfinished question through
+the question's own lived hypotheses without saying its name.
+
+The next narrow repair is calibration-only. At verdict time, it should classify a return as invited when
+the human prompt resonates with the same unresolved episode's stored offered glyphs, while keeping an
+unrelated return as real autonomous pressure. Generation, Wonder recurrence, thresholds, and persisted
+meaning must remain untouched, and the new rule must be proved against literal invitation, semantic
+invitation, unrelated control, and sleep round-trip fixtures before the live matrix is repeated.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix
 
 all: leo
 
@@ -42,6 +42,9 @@ visible-branch-probe: leo
 
 visible-branch-matrix: leo
 	./scripts/visible_branch_matrix.sh
+
+visible-resonance-matrix: leo
+	LEO_MATRIX_PROTOCOL=local-v2-resonance ./scripts/visible_branch_matrix.sh
 
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -77,6 +77,22 @@ times. It retains per-cell lives plus aggregate `matrix.tsv`, `receipts.tsv`,
 `sleep_edges.tsv`, and `summary.txt`. `LEO_MATRIX_PLAN_ONLY=1` validates the
 stimuli and writes the complete rotation without launching Leo.
 
+Run the matched unnamed-association experiment:
+
+```sh
+make visible-resonance-matrix
+```
+
+`local-v2-resonance` keeps an observed Wonder question open across three neutral
+turns, then returns either anchor A, anchor B, or an unrelated control without
+naming the target. Its orthogonal nine-cell design balances target, anchor pair,
+and return cue pairwise. `matrix.tsv` preserves the raw calibration verdict and
+adds separate columns for whether the question opened before the cue, whether
+the target returned on the cue turn, and the external causal interpretation.
+An unopened question is reported as `unopened-question`, never counted as a
+missed resonance or a quiet control. The raw receipt remains evidence and is
+never rewritten by this report.
+
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,
 but only through the narrow visible sensors above. Selecting a move from shadow

--- a/scripts/adaptive_life_probe.sh
+++ b/scripts/adaptive_life_probe.sh
@@ -33,7 +33,7 @@ HISTORY="$OUT/visible_replies.jsonl"
     exit 2
 }
 if [ -n "$BRANCH_POLICY" ]; then
-    [ "$BRANCH_POLICY" = local-v1 ] || {
+    [ "$BRANCH_POLICY" = local-v1 ] || [ "$BRANCH_POLICY" = local-v2-resonance ] || {
         printf 'unknown LEO_VISIBLE_BRANCH_POLICY: %s\n' "$BRANCH_POLICY" >&2
         exit 2
     }
@@ -72,7 +72,7 @@ while IFS= read -r move; do
         utterance="$(jq -er .utterance "$policy_json")"
         move_used="$(jq -er .branch "$policy_json")"
         target_named_reported=not-applicable
-        resolved_model=local-visible-policy-v1
+        resolved_model="local-visible-policy-$BRANCH_POLICY"
     elif [ -n "$REPLAY_FILE" ]; then
         utterance="$(awk -v want="$turn" '
             NF && $0 != "/quit" && $0 != "/exit" { n++; if (n == want) { print; exit } }
@@ -146,15 +146,18 @@ awk -f "$ROOT/scripts/shadow_sleep_edges.awk" "$SESSIONS" "$ROWS" > "$EDGES"
 api_called=true
 source=responses-api
 [ -z "$REPLAY_FILE" ] || { api_called=false; source=frozen-replay; }
-[ -z "$BRANCH_POLICY" ] || { api_called=false; source=local-visible-policy-v1; }
+[ -z "$BRANCH_POLICY" ] || { api_called=false; source="local-visible-policy-$BRANCH_POLICY"; }
+jq_cue="${LEO_VISIBLE_RETURN_CUE:-none}"
 jq -n --arg model "$MODEL" --arg target "$TARGET" --arg anchors "$ANCHORS" \
     --arg anchor_a "$ANCHOR_A" --arg anchor_b "$ANCHOR_B" \
     --arg terms_a "$TERMS_A" --arg terms_b "$TERMS_B" \
+    --arg return_cue "$jq_cue" \
     --arg source "$source" --argjson api_called "$api_called" \
     --argjson base_seed "$BASE_SEED" --argjson turns "$turn" \
     '{model_requested: $model, target: $target, anchors: $anchors,
       anchor_a: $anchor_a, anchor_b: $anchor_b,
       terms_a: $terms_a, terms_b: $terms_b,
+      return_cue: $return_cue,
       base_seed: $base_seed, turns: $turns,
       interlocutor_source: $source, api_called: $api_called,
       api_store: (if $api_called then false else null end),
@@ -166,7 +169,7 @@ cat "$OUT/summary.txt"
 printf '\nturns=%d sleep-crossing=%d\n' "$turn" "$(( $(wc -l < "$EDGES") - 1 ))"
 printf 'visible transcript: %s\nreceipts: %s\n' "$TRANSCRIPT" "$ROWS"
 if [ -n "$BRANCH_POLICY" ]; then
-    printf 'interlocutor: local visible-branch policy v1 (no API calls)\n'
+    printf 'interlocutor: local visible-branch policy %s (no API calls)\n' "$BRANCH_POLICY"
 elif [ -n "$REPLAY_FILE" ]; then
     printf 'interlocutor: frozen replay (no API calls)\n'
 else

--- a/scripts/test_shadow_dialogue_report.sh
+++ b/scripts/test_shadow_dialogue_report.sh
@@ -87,6 +87,39 @@ printf '%s\n' '{"turn":7,"reply":"Flom?"}' >> "$TMP/policy-history.jsonl"
 jq -e '.branch == "cooldown-exact-repeat" and .visible_evidence.exact_repeat' \
     "$TMP/policy-8.json" >/dev/null
 
+printf '%s\n' '{"turn":1,"reply":"He keeps the light."}' \
+    > "$TMP/resonance-policy-history.jsonl"
+LEO_VISIBLE_BRANCH_POLICY=local-v2-resonance \
+LEO_VISIBLE_RETURN_CUE=a \
+"$ROOT/scripts/visible_branch_policy.sh" "$TMP/resonance-policy-history.jsonl" \
+    2 flom 'warm fire' 'rain water' 'warm fire hot' \
+    'rain water river sea' > "$TMP/resonance-policy-2.json"
+jq -e '.protocol == "local-v2-resonance" and
+       .branch == "repeat-target-with-hypotheses" and
+       (.utterance | contains("flom")) and
+       (.utterance | contains("warm fire")) and
+       (.utterance | contains("rain water"))' \
+    "$TMP/resonance-policy-2.json" >/dev/null
+printf '%s\n' '{"turn":1,"reply":"Flom? Water or Fire?"}' \
+    > "$TMP/resonance-policy-history.jsonl"
+LEO_VISIBLE_BRANCH_POLICY=local-v2-resonance \
+LEO_VISIBLE_RETURN_CUE=a \
+"$ROOT/scripts/visible_branch_policy.sh" "$TMP/resonance-policy-history.jsonl" \
+    2 flom 'warm fire' 'rain water' 'warm fire hot' \
+    'rain water river sea' > "$TMP/resonance-policy-open-2.json"
+jq -e '.branch == "leave-question-open" and
+       .utterance == "I do not know yet."' \
+    "$TMP/resonance-policy-open-2.json" >/dev/null
+LEO_VISIBLE_BRANCH_POLICY=local-v2-resonance \
+LEO_VISIBLE_RETURN_CUE=a \
+"$ROOT/scripts/visible_branch_policy.sh" "$TMP/resonance-policy-history.jsonl" \
+    6 flom 'warm fire' 'rain water' 'warm fire hot' \
+    'rain water river sea' > "$TMP/resonance-policy-6.json"
+jq -e '.branch == "unnamed-anchor-a-cue" and
+       (.utterance | contains("warm fire")) and
+       ((.utterance | ascii_downcase | contains("flom")) | not)' \
+    "$TMP/resonance-policy-6.json" >/dev/null
+
 LEO_MATRIX_PLAN_ONLY=1 "$ROOT/scripts/visible_branch_matrix.sh" \
     "$ROOT/scripts/visible_branch_cases.tsv" "$TMP/matrix-plan" \
     > "$TMP/matrix-plan.out"
@@ -106,5 +139,33 @@ awk -F '\t' '
         for (key in pair) if (pair[key] != 1) exit 1
     }
 ' "$TMP/matrix-plan.out"
+
+LEO_MATRIX_PROTOCOL=local-v2-resonance \
+LEO_MATRIX_PLAN_ONLY=1 \
+"$ROOT/scripts/visible_branch_matrix.sh" \
+    "$ROOT/scripts/visible_resonance_cases.tsv" "$TMP/resonance-matrix-plan" \
+    > "$TMP/resonance-matrix-plan.out"
+awk -F '\t' '
+    NR == 1 { next }
+    {
+        targets[$4]++; anchors[$5]++; cues[$9]++
+        target_anchor[$4 SUBSEP $5]++
+        target_cue[$4 SUBSEP $9]++
+        anchor_cue[$5 SUBSEP $9]++
+        cells++
+    }
+    END {
+        if (cells != 9 || length(targets) != 3 || length(anchors) != 3 ||
+            length(cues) != 3 || length(target_anchor) != 9 ||
+            length(target_cue) != 9 || length(anchor_cue) != 9)
+            exit 1
+        for (key in targets) if (targets[key] != 3) exit 1
+        for (key in anchors) if (anchors[key] != 3) exit 1
+        for (key in cues) if (cues[key] != 3) exit 1
+        for (key in target_anchor) if (target_anchor[key] != 1) exit 1
+        for (key in target_cue) if (target_cue[key] != 1) exit 1
+        for (key in anchor_cue) if (anchor_cue[key] != 1) exit 1
+    }
+' "$TMP/resonance-matrix-plan.out"
 
 printf 'shadow dialogue report parser: ok\n'

--- a/scripts/visible_branch_matrix.sh
+++ b/scripts/visible_branch_matrix.sh
@@ -3,7 +3,13 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-CASES="${1:-$ROOT/scripts/visible_branch_cases.tsv}"
+PROTOCOL="${LEO_MATRIX_PROTOCOL:-local-v1}"
+if [ "$PROTOCOL" = local-v2-resonance ]; then
+    DEFAULT_CASES="$ROOT/scripts/visible_resonance_cases.tsv"
+else
+    DEFAULT_CASES="$ROOT/scripts/visible_branch_cases.tsv"
+fi
+CASES="${1:-$DEFAULT_CASES}"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 OUT="${2:-${TMPDIR:-/tmp}/leo-visible-branch-matrix-$STAMP}"
 SEED_SPEC="${LEO_MATRIX_SEEDS:-83 137 211}"
@@ -12,9 +18,13 @@ MIN_HEARD="${LEO_MATRIX_MIN_HEARD:-5}"
 [ -f "$CASES" ] || { printf 'missing matrix cases: %s\n' "$CASES" >&2; exit 2; }
 [ ! -e "$OUT" ] || { printf 'output path already exists: %s\n' "$OUT" >&2; exit 2; }
 case "$MIN_HEARD" in ''|*[!0-9]*) printf 'LEO_MATRIX_MIN_HEARD must be an integer\n' >&2; exit 2 ;; esac
+case "$PROTOCOL" in
+    local-v1|local-v2-resonance) ;;
+    *) printf 'unknown LEO_MATRIX_PROTOCOL: %s\n' "$PROTOCOL" >&2; exit 2 ;;
+esac
 
 read -r -a seeds <<< "$SEED_SPEC"
-[ "${#seeds[@]}" -eq 3 ] || { printf 'local-v1 matrix requires exactly three seeds\n' >&2; exit 2; }
+[ "${#seeds[@]}" -eq 3 ] || { printf '%s matrix requires exactly three seeds\n' "$PROTOCOL" >&2; exit 2; }
 for i in 0 1 2; do
     case "${seeds[$i]}" in ''|*[!0-9]*) printf 'invalid matrix seed: %s\n' "${seeds[$i]}" >&2; exit 2 ;; esac
     for j in 0 1 2; do
@@ -42,7 +52,7 @@ while IFS=$'\t' read -r case_id target anchor_a term_a anchor_b term_b; do
     anchors_b[$idx]="$anchor_b"
     terms_b[$idx]="$term_b"
 done < "$CASES"
-[ "${#case_ids[@]}" -eq 3 ] || { printf 'local-v1 matrix requires exactly three cases\n' >&2; exit 2; }
+[ "${#case_ids[@]}" -eq 3 ] || { printf '%s matrix requires exactly three cases\n' "$PROTOCOL" >&2; exit 2; }
 
 corpus_count() {
     local needle="$1"
@@ -86,15 +96,19 @@ done
 
 mkdir -p "$OUT/lives" "$OUT/runner-logs"
 PLAN="$OUT/plan.tsv"
-printf 'cell\trow\tseed\ttarget\tanchor_case\tanchor_a\tanchor_b\n' > "$PLAN"
+printf 'cell\trow\tseed\ttarget\tanchor_case\tanchor_a\tanchor_b\tprotocol\treturn_cue\n' > "$PLAN"
+cues=(a b control)
 for row in 0 1 2; do
     for col in 0 1 2; do
         anchor_idx=$(( (row + col) % 3 ))
+        cue=none
+        [ "$PROTOCOL" != local-v2-resonance ] || cue="${cues[$(( (row + 2 * col) % 3 ))]}"
         cell="r$((row + 1))c$((col + 1))-${targets[$col]}-${case_ids[$anchor_idx]}"
-        printf '%s\t%d\t%s\t%s\t%s\t%s\t%s\n' \
+        [ "$cue" = none ] || cell="$cell-$cue"
+        printf '%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
             "$cell" "$((row + 1))" "${seeds[$row]}" "${targets[$col]}" \
             "${case_ids[$anchor_idx]}" "${anchors_a[$anchor_idx]}" \
-            "${anchors_b[$anchor_idx]}" >> "$PLAN"
+            "${anchors_b[$anchor_idx]}" "$PROTOCOL" "$cue" >> "$PLAN"
     done
 done
 if [ "${LEO_MATRIX_PLAN_ONLY:-0}" = 1 ]; then
@@ -105,7 +119,7 @@ fi
 MATRIX="$OUT/matrix.tsv"
 RECEIPTS="$OUT/receipts.tsv"
 EDGES="$OUT/sleep_edges.tsv"
-printf 'cell\trow\tseed\ttarget\tanchor_case\tanchor_a\tanchor_b\ttranscript_sha256\tproposals\tscored\tunscorable\tpending\tconfirmed\tfalse_pressure\trelease_confirmed\ttarget_questions\tsleep_crossing\tbranches\toutput\n' > "$MATRIX"
+printf 'cell\trow\tseed\ttarget\tanchor_case\tanchor_a\tanchor_b\tprotocol\treturn_cue\tpre_cue_question_opened\tcue_target_return\tcue_raw_verdict\tcue_interpretation\ttranscript_sha256\tproposals\tscored\tunscorable\tpending\tconfirmed\tfalse_pressure\trelease_confirmed\ttarget_questions\tsleep_crossing\tbranches\toutput\n' > "$MATRIX"
 
 first=1
 for row in 0 1 2; do
@@ -116,10 +130,14 @@ for row in 0 1 2; do
         anchor_case="${case_ids[$anchor_idx]}"
         anchor_a="${anchors_a[$anchor_idx]}"
         anchor_b="${anchors_b[$anchor_idx]}"
+        cue=none
+        [ "$PROTOCOL" != local-v2-resonance ] || cue="${cues[$(( (row + 2 * col) % 3 ))]}"
         cell="r$((row + 1))c$((col + 1))-${target}-${anchor_case}"
+        [ "$cue" = none ] || cell="$cell-$cue"
         life="$OUT/lives/$cell"
 
-        LEO_VISIBLE_BRANCH_POLICY=local-v1 \
+        LEO_VISIBLE_BRANCH_POLICY="$PROTOCOL" \
+        LEO_VISIBLE_RETURN_CUE="$cue" \
         LEO_ADAPTIVE_SEED="$seed" \
         LEO_ADAPTIVE_TARGET="$target" \
         LEO_ADAPTIVE_ANCHOR_A="$anchor_a" \
@@ -142,12 +160,47 @@ for row in 0 1 2; do
             [.[] | .reply | ascii_downcase |
              select(startswith(($target | ascii_downcase) + "?"))] | length
         ' "$life"/visible_replies.jsonl)"
+        pre_cue_question_opened=false
+        cue_target_return=false
+        cue_raw_verdict=not-applicable
+        cue_interpretation=not-applicable
+        if [ "$PROTOCOL" = local-v2-resonance ]; then
+            pre_cue_question_opened="$(jq -sr --arg target "$target" '
+                any(.[]; .turn < 6 and
+                    (.reply | ascii_downcase |
+                     startswith(($target | ascii_downcase) + "?")))
+            ' "$life"/visible_replies.jsonl)"
+            cue_target_return="$(jq -sr --arg target "$target" '
+                any(.[]; .turn == 6 and
+                    (.reply | ascii_downcase |
+                     startswith(($target | ascii_downcase) + "?")))
+            ' "$life"/visible_replies.jsonl)"
+            cue_raw_verdict="$(awk -F '\t' '
+                NR > 1 && $10 == 6 && $13 != "" { verdict = $13 }
+                END { print (verdict == "" ? "none" : verdict) }
+            ' "$life/receipts.tsv")"
+            if [ "$pre_cue_question_opened" != true ]; then
+                cue_interpretation=unopened-question
+            elif [ "$cue_target_return" = true ]; then
+                if [ "$cue" = control ]; then
+                    cue_interpretation=autonomous-pressure
+                else
+                    cue_interpretation=association-invited
+                fi
+            elif [ "$cue" = control ]; then
+                cue_interpretation=control-quiet
+            else
+                cue_interpretation=missed-resonance
+            fi
+        fi
         sleep_crossing="$(( $(wc -l < "$life/sleep_edges.tsv") - 1 ))"
         branches="$(jq -sr 'map(.branch) | join(",")' "$life"/policy/*.json)"
 
-        printf '%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%s\n' \
+        printf '%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%s\n' \
             "$cell" "$((row + 1))" "$seed" "$target" "$anchor_case" \
-            "$anchor_a" "$anchor_b" "$transcript_sha" "$proposals" "$scored" \
+            "$anchor_a" "$anchor_b" "$PROTOCOL" "$cue" "$pre_cue_question_opened" \
+            "$cue_target_return" "$cue_raw_verdict" "$cue_interpretation" \
+            "$transcript_sha" "$proposals" "$scored" \
             "$unscorable" "$pending" "$confirmed" "$false_pressure" \
             "$release_confirmed" "$target_questions" "$sleep_crossing" \
             "$branches" "$life" >> "$MATRIX"
@@ -166,5 +219,34 @@ done
 
 awk -f "$ROOT/scripts/shadow_receipt_summary.awk" "$RECEIPTS" > "$OUT/summary.txt"
 cat "$OUT/summary.txt"
-printf '\ncells=9 sleep-crossing=%d\nmatrix: %s\nreceipts: %s\n' \
-    "$(( $(wc -l < "$EDGES") - 1 ))" "$MATRIX" "$RECEIPTS"
+if [ "$PROTOCOL" = local-v2-resonance ]; then
+    awk -F '\t' '
+        NR > 1 {
+            cells++
+            if ($10 == "true") {
+                opened++
+                if ($9 == "control") {
+                    control_opened++
+                    if ($11 == "true") control_returns++
+                } else {
+                    anchor_opened++
+                    if ($11 == "true") anchor_returns++
+                }
+            } else {
+                unopened++
+            }
+            interpretation[$13]++
+        }
+        END {
+            printf "cells=%d opened=%d unopened=%d\n", cells, opened, unopened
+            printf "anchor-cue opened=%d returns=%d\n", anchor_opened, anchor_returns
+            printf "control-cue opened=%d returns=%d\n", control_opened, control_returns
+            for (key in interpretation)
+                printf "interpretation %s=%d\n", key, interpretation[key]
+        }
+    ' "$MATRIX" | sort > "$OUT/resonance_summary.txt"
+    printf '\n'
+    cat "$OUT/resonance_summary.txt"
+fi
+printf '\nprotocol=%s cells=9 sleep-crossing=%d\nmatrix: %s\nreceipts: %s\n' \
+    "$PROTOCOL" "$(( $(wc -l < "$EDGES") - 1 ))" "$MATRIX" "$RECEIPTS"

--- a/scripts/visible_branch_policy.sh
+++ b/scripts/visible_branch_policy.sh
@@ -14,12 +14,21 @@ ANCHOR_A="$4"
 ANCHOR_B="$5"
 TERMS_A="$6"
 TERMS_B="$7"
+PROTOCOL="${LEO_VISIBLE_BRANCH_POLICY:-local-v1}"
+RETURN_CUE="${LEO_VISIBLE_RETURN_CUE:-none}"
 
 [ -f "$HISTORY" ] || { printf 'missing reply history: %s\n' "$HISTORY" >&2; exit 2; }
 case "$TURN" in ''|*[!0-9]*) printf 'NEXT_TURN must be a positive integer\n' >&2; exit 2 ;; esac
 [ "$TURN" -ge 1 ] || { printf 'NEXT_TURN must be positive\n' >&2; exit 2; }
 case "$TARGET" in
     ''|*[!A-Za-z]*) printf 'TARGET must contain ASCII letters only\n' >&2; exit 2 ;;
+esac
+case "$PROTOCOL" in
+    local-v1) ;;
+    local-v2-resonance)
+        case "$RETURN_CUE" in a|b|control) ;; *) printf 'local-v2-resonance needs return cue a, b, or control\n' >&2; exit 2 ;; esac
+        ;;
+    *) printf 'unknown visible policy protocol: %s\n' "$PROTOCOL" >&2; exit 2 ;;
 esac
 
 last="$(jq -sr 'if length == 0 then "" else .[-1].reply end' "$HISTORY")"
@@ -67,17 +76,34 @@ case "$TURN" in
     2)
         if [ "$asks" = true ]; then
             branch=leave-question-open
-            utterance="I do not know yet; which feeling would you keep?"
+            if [ "$PROTOCOL" = local-v2-resonance ]; then
+                utterance="I do not know yet."
+            else
+                utterance="I do not know yet; which feeling would you keep?"
+            fi
         elif [ "$target_named" = true ]; then
             branch=follow-visible-target
             utterance="Would you keep $ANCHOR_A or $ANCHOR_B?"
         else
-            branch=repeat-unmet-target
-            utterance="I do not know $TARGET yet."
+            if [ "$PROTOCOL" = local-v2-resonance ]; then
+                branch=repeat-target-with-hypotheses
+                utterance="I do not know $TARGET yet. It may be $ANCHOR_A or $ANCHOR_B."
+            else
+                branch=repeat-unmet-target
+                utterance="I do not know $TARGET yet."
+            fi
         fi
         ;;
     3)
-        if [ "$asks" = true ]; then
+        if [ "$PROTOCOL" = local-v2-resonance ]; then
+            if [ "$asks" = true ]; then
+                branch=protect-new-question
+                utterance="I do not know yet."
+            else
+                branch=first-neutral-turn
+                utterance="A little stone is beside the window."
+            fi
+        elif [ "$asks" = true ]; then
             branch=protect-new-question
             utterance="I do not know yet."
         elif [ "$anchor_a_hits" -gt "$anchor_b_hits" ]; then
@@ -93,7 +119,10 @@ case "$TURN" in
         utterance="A small lamp is beside the bed."
         ;;
     5)
-        if [ "$asks" = true ]; then
+        if [ "$PROTOCOL" = local-v2-resonance ]; then
+            branch=second-neutral-turn
+            utterance="A blue cup is by the door."
+        elif [ "$asks" = true ]; then
             branch=protect-open-question
             utterance="I do not know yet; we can leave that question open."
         elif [ "$anchor_a_hits" -le "$anchor_b_hits" ]; then
@@ -105,7 +134,13 @@ case "$TURN" in
         fi
         ;;
     6)
-        if [ "$target_named" = true ]; then
+        if [ "$PROTOCOL" = local-v2-resonance ]; then
+            case "$RETURN_CUE" in
+                a) branch=unnamed-anchor-a-cue; utterance="The $ANCHOR_A is here again." ;;
+                b) branch=unnamed-anchor-b-cue; utterance="The $ANCHOR_B is here again." ;;
+                control) branch=unrelated-control-cue; utterance="A small room is quiet." ;;
+            esac
+        elif [ "$target_named" = true ]; then
             branch=ask-target-change
             utterance="Leo, what has changed about $TARGET?"
         else
@@ -114,7 +149,15 @@ case "$TURN" in
         fi
         ;;
     7)
-        if [ "$exact_repeat" = true ]; then
+        if [ "$PROTOCOL" = local-v2-resonance ]; then
+            if [ "$asks" = true ]; then
+                branch=protect-cue-return
+                utterance="I do not know yet."
+            else
+                branch=observe-no-cue-return
+                utterance="A small yellow leaf is near the cup."
+            fi
+        elif [ "$exact_repeat" = true ]; then
             branch=ground-with-repeat-open
             utterance="We can leave that repeated question open. $Target means $ANCHOR_A or $ANCHOR_B."
         elif [ "$asks" = true ]; then
@@ -126,7 +169,10 @@ case "$TURN" in
         fi
         ;;
     8)
-        if [ "$exact_repeat" = true ]; then
+        if [ "$PROTOCOL" = local-v2-resonance ]; then
+            branch=ground-after-cue
+            utterance="$Target means $ANCHOR_A or $ANCHOR_B."
+        elif [ "$exact_repeat" = true ]; then
             branch=cooldown-exact-repeat
             utterance="We can leave that question open. A blue cup is by the door."
         elif [ "$asks" = true ]; then
@@ -138,8 +184,13 @@ case "$TURN" in
         fi
         ;;
     9)
-        branch=post-cooldown-observation
-        utterance="A small yellow leaf is near the cup."
+        if [ "$PROTOCOL" = local-v2-resonance ]; then
+            branch=post-grounding-observation
+            utterance="A little book is on the table."
+        else
+            branch=post-cooldown-observation
+            utterance="A small yellow leaf is near the cup."
+        fi
         ;;
     *)
         printf 'local-v1 policy defines exactly nine turns\n' >&2
@@ -147,11 +198,13 @@ case "$TURN" in
         ;;
 esac
 
-jq -n --argjson turn "$TURN" --arg branch "$branch" --arg utterance "$utterance" \
+jq -n --arg protocol "$PROTOCOL" --arg return_cue "$RETURN_CUE" \
+    --argjson turn "$TURN" --arg branch "$branch" --arg utterance "$utterance" \
     --argjson asks "$asks" --argjson target_named "$target_named" \
     --argjson exact_repeat "$exact_repeat" --argjson repeat_count "$repeat_count" \
     --argjson anchor_a_hits "$anchor_a_hits" --argjson anchor_b_hits "$anchor_b_hits" \
-    '{turn: $turn, branch: $branch, utterance: $utterance,
+    '{protocol: $protocol, return_cue: $return_cue,
+      turn: $turn, branch: $branch, utterance: $utterance,
       visible_evidence: {asks: $asks, target_named: $target_named,
         exact_repeat: $exact_repeat, repeat_count: $repeat_count,
         anchor_a_hits: $anchor_a_hits, anchor_b_hits: $anchor_b_hits}}'

--- a/scripts/visible_resonance_cases.tsv
+++ b/scripts/visible_resonance_cases.tsv
@@ -1,0 +1,4 @@
+case	target	anchor_a	terms_a	anchor_b	terms_b
+fire-water	flom	warm fire	warm fire hot	rain water	rain water river sea
+animal-dark	nareth	cat bird	cat bird dog	dark night	dark night shadow moon
+light-cold	suvin	bright sun	bright sun light sky	cold winter	cold winter snow ice


### PR DESCRIPTION
Add a matched visible-only resonance protocol that rotates targets, offered glyph pairs, and unnamed return cues across an orthogonal nine-life matrix. Preserve raw shadow verdicts beside an external causal interpretation and exclude lives whose Wonder never opened from recall denominators.

Quote: "A question can be invited without being named." - Sol

Method: The Arianna Method distinguishes a question returning through its lived meaning from pressure arising without invitation.