### PR TITLE
the Method hears semantic invitation

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3579,3 +3579,37 @@ the human prompt resonates with the same unresolved episode's stored offered gly
 unrelated return as real autonomous pressure. Generation, Wonder recurrence, thresholds, and persisted
 meaning must remain untouched, and the new rule must be proved against literal invitation, semantic
 invitation, unrelated control, and sleep round-trip fixtures before the live matrix is repeated.
+
+## Phase A.35 — calibration hears the question's meaning (2026-07-23)
+
+The A.34 repair changes only the next-turn judge. Given a proposal's stable `wonder_id`, calibration now
+locates that exact persisted Wonder episode and asks whether the human prompt contains either its literal
+target or one of its two stored offered glyphs. The glyph scan uses School's existing teachable concept
+votes, the same semantic evidence by which an open Wonder recognizes a return. A matching `REASKED` or
+`REOPENED` event is `unscorable`: the human supplied the causal invitation, even without speaking the
+question's title. An unrelated prompt remains eligible for `false-pressure`.
+
+Four unit contracts pin the boundary:
+
+- literal target invitation remains `unscorable`;
+- an offered glyph invites the same episode without naming it;
+- unrelated `small room` leaves an artificial reask as scored autonomous pressure;
+- save/load preserves the episode's offered glyphs and semantic invitation.
+
+The suite is **265/265**. No state field, version, threshold, return mechanism, generator path, or spoken
+buffer changed. The full A.34 matrix was then repeated from the same targets, anchors, seeds, and policy:
+
+```text
+proposals=81 scored=44 unscorable=4 pending=33
+confirmed=44 false-pressure=0
+anchor-cue: opened=4 returns=4, all four unscorable
+control-cue: opened=2 returns=0, both confirmed
+unopened-question=3
+sleep-crossing receipts=48
+```
+
+Every one of the nine visible transcript SHA-256 values is identical to the pre-repair A.34 run. Thus
+calibration no longer accuses the four semantically invited returns, while Leo's voice and behavior are
+byte-identical and the unrelated controls remain quiet. The external interpretation and the organism's
+raw receipt now agree without granting shadow any authority over speech. The normal build is warning-free;
+ASan/UBSan passed the corpus smoke, and TSan reported no race through a live `--chat --async` turn.

--- a/leo.c
+++ b/leo.c
@@ -4913,11 +4913,12 @@ static uint64_t leo_wonder_episode_id(const LeoWonderEpisode *ep) {
     return h ? h : 1;
 }
 
-static const char *leo_wonder_word_for_id(const Leo *leo, uint64_t wonder_id) {
+static const LeoWonderEpisode *leo_wonder_for_id(const Leo *leo,
+                                                 uint64_t wonder_id) {
     if (!leo || !wonder_id) return NULL;
     for (int i = 0; i < leo->school.n_wonders; i++)
         if (leo_wonder_episode_id(&leo->school.wonders[i]) == wonder_id)
-            return leo->school.wonders[i].word;
+            return &leo->school.wonders[i];
     return NULL;
 }
 
@@ -5514,12 +5515,31 @@ static const char *leo_calibration_verdict_name(int verdict) {
     return verdict >= 0 && verdict < LEO_CALIB_VERDICT_COUNT ? names[verdict] : "unscorable";
 }
 
+/* The human can causally invite an unfinished question without repeating its
+ * title. Mirror Wonder's own open-episode resonance contract against the exact
+ * episode named by the proposal: literal target OR either offered hypothesis.
+ * This only changes how the observer scores a lived return. */
+static int leo_wonder_prompt_invites(const Leo *leo, uint64_t wonder_id,
+                                     const char *prompt) {
+    const LeoWonderEpisode *ep = leo_wonder_for_id(leo, wonder_id);
+    if (!ep || !prompt) return 0;
+    if (leo_flow_prompt_has_word(prompt, ep->word)) return 1;
+    int hist[GLYPH_COUNT];
+    leo_school_glyph_votes(leo, prompt, hist, 1);
+    int offered[2] = {ep->offered_glyph, ep->offered_alt_glyph};
+    for (int i = 0; i < 2; i++)
+        if (offered[i] >= 0 && offered[i] < GLYPH_COUNT &&
+            hist[offered[i]] > 0) return 1;
+    return 0;
+}
+
 /* Judge the PREVIOUS proposal against this already-lived turn, before writing
  * a proposal for the next one. SPACE/HOLD both forbid immediate pressure;
  * HOLD additionally requires the unfinished identity not to disappear.
- * RELEASE requires that the same identity not reopen. A human who explicitly
- * names the target confounds REASKED/REOPENED: that is a return invited from
- * outside, not evidence that Leo applied autonomous pressure. */
+ * RELEASE requires that the same identity not reopen. A human who names the
+ * target or returns one of that episode's offered hypotheses confounds
+ * REASKED/REOPENED: that is a return invited from outside, not evidence that
+ * Leo applied autonomous pressure. */
 static void leo_shadow_calibrate(Leo *leo, const char *prompt) {
     if (!g_leo_shadow_on || !g_leo_flow_on || !leo ||
         leo->shadow.n <= 0 || leo->flow.n <= 0) return;
@@ -5557,12 +5577,12 @@ static void leo_shadow_calibrate(Leo *leo, const char *prompt) {
                    (observed->wonder & (LEO_FLOW_WONDER_OPEN |
                                         LEO_FLOW_WONDER_BORN |
                                         LEO_FLOW_WONDER_REASKED));
-    const char *target_word = leo_wonder_word_for_id(leo, proposal->wonder_id);
-    int human_return = target_word && leo_flow_prompt_has_word(prompt, target_word);
+    int human_invitation =
+        leo_wonder_prompt_invites(leo, proposal->wonder_id, prompt);
 
     if (!adjacent) {
         receipt.verdict = LEO_CALIB_UNSCORABLE;
-    } else if (human_return && (reasked || reopened)) {
+    } else if (human_invitation && (reasked || reopened)) {
         receipt.verdict = LEO_CALIB_UNSCORABLE;
     } else if (proposal->action == LEO_SHADOW_RELEASE) {
         if (reopened) receipt.verdict = LEO_CALIB_RELEASE_RELAPSE;

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -1694,9 +1694,9 @@ int main(void) {
                   "shadow-calibration: space is confirmed when the next turn applies no pressure");
 
             sh->school.turn_clock = 3;
-            leo_flow_observe(sh, "water", "water", NULL, NULL, NULL,
+            leo_flow_observe(sh, "small room", "water", NULL, NULL, NULL,
                              LEO_FLOW_WONDER_REASKED, id);
-            leo_shadow_calibrate(sh, "water");
+            leo_shadow_calibrate(sh, "small room");
             leo_shadow_observe(sh);
             const LeoShadowReceipt *r2 = leo_shadow_at(&sh->shadow, 2);
             CHECK(r2 && r2->action == LEO_SHADOW_SPACE &&
@@ -1863,7 +1863,82 @@ int main(void) {
                 leo_calibration_at(&sh->calibration, 0);
             CHECK(human_return && human_return->verdict == LEO_CALIB_UNSCORABLE &&
                   human_return->brier == 0.0f,
-                  "shadow-calibration: a human-invited return is not autonomous pressure");
+                  "shadow-calibration: a literal human invitation is not autonomous pressure");
+
+            memset(&sh->flow, 0, sizeof sh->flow);
+            memset(&sh->shadow, 0, sizeof sh->shadow);
+            memset(&sh->calibration, 0, sizeof sh->calibration);
+            strncpy(sh->school.pending, "fieldword", sizeof sh->school.pending - 1);
+            LeoWonderEpisode *field_ep =
+                leo_wonder_open(sh, "fieldword", water, fire);
+            uint64_t field_id = leo_wonder_episode_id(field_ep);
+            sh->school.turn_clock = 1;
+            leo_flow_observe(sh, "What is fieldword? Water or fire?", "Fieldword?",
+                             NULL, NULL, NULL, LEO_FLOW_WONDER_BORN, field_id);
+            leo_shadow_calibrate(sh, "What is fieldword? Water or fire?");
+            leo_shadow_observe(sh);
+            sh->school.turn_clock = 2;
+            leo_flow_observe(sh, "The warm fire is here again", "Fieldword?",
+                             NULL, NULL, NULL, LEO_FLOW_WONDER_REASKED, field_id);
+            leo_shadow_calibrate(sh, "The warm fire is here again");
+            const LeoCalibrationReceipt *semantic_return =
+                leo_calibration_at(&sh->calibration, 0);
+            CHECK(semantic_return &&
+                  semantic_return->verdict == LEO_CALIB_UNSCORABLE &&
+                  semantic_return->brier == 0.0f,
+                  "shadow-calibration: an offered glyph can invite a return without naming it");
+
+            memset(&sh->flow, 0, sizeof sh->flow);
+            memset(&sh->shadow, 0, sizeof sh->shadow);
+            memset(&sh->calibration, 0, sizeof sh->calibration);
+            strncpy(sh->school.pending, "controlword", sizeof sh->school.pending - 1);
+            LeoWonderEpisode *control_ep =
+                leo_wonder_open(sh, "controlword", water, fire);
+            uint64_t control_id = leo_wonder_episode_id(control_ep);
+            sh->school.turn_clock = 1;
+            leo_flow_observe(sh, "What is controlword? Water or fire?", "Controlword?",
+                             NULL, NULL, NULL, LEO_FLOW_WONDER_BORN, control_id);
+            leo_shadow_calibrate(sh, "What is controlword? Water or fire?");
+            leo_shadow_observe(sh);
+            sh->school.turn_clock = 2;
+            leo_flow_observe(sh, "A small room is quiet", "Controlword?",
+                             NULL, NULL, NULL, LEO_FLOW_WONDER_REASKED, control_id);
+            leo_shadow_calibrate(sh, "A small room is quiet");
+            const LeoCalibrationReceipt *autonomous_return =
+                leo_calibration_at(&sh->calibration, 0);
+            CHECK(autonomous_return &&
+                  autonomous_return->verdict == LEO_CALIB_FALSE_PRESSURE &&
+                  autonomous_return->brier > 0.0f,
+                  "shadow-calibration: an unrelated prompt leaves autonomous pressure scorable");
+
+            const char *semantic_state = "/tmp/leo_shadow_semantic_invite_v17.state";
+            leo_free(compat); leo_init(compat);
+            strncpy(compat->school.pending, "sleepfield",
+                    sizeof compat->school.pending - 1);
+            LeoWonderEpisode *sleepfield_ep =
+                leo_wonder_open(compat, "sleepfield", water, fire);
+            uint64_t sleepfield_id = leo_wonder_episode_id(sleepfield_ep);
+            compat->school.turn_clock = 1;
+            leo_flow_observe(compat, "What is sleepfield? Water or fire?",
+                             "Sleepfield?", NULL, NULL, NULL,
+                             LEO_FLOW_WONDER_BORN, sleepfield_id);
+            leo_shadow_calibrate(compat, "What is sleepfield? Water or fire?");
+            leo_shadow_observe(compat);
+            int semantic_saved = leo_save_state(compat, semantic_state);
+            leo_free(cut); leo_init(cut);
+            int semantic_loaded = semantic_saved &&
+                                  leo_load_state(cut, semantic_state);
+            cut->school.turn_clock = 2;
+            leo_flow_observe(cut, "The rain water is here again", "Sleepfield?",
+                             NULL, NULL, NULL, LEO_FLOW_WONDER_REASKED,
+                             sleepfield_id);
+            leo_shadow_calibrate(cut, "The rain water is here again");
+            const LeoCalibrationReceipt *semantic_after_sleep =
+                leo_calibration_at(&cut->calibration, 0);
+            CHECK(semantic_loaded && semantic_after_sleep &&
+                  semantic_after_sleep->verdict == LEO_CALIB_UNSCORABLE &&
+                  semantic_after_sleep->brier == 0.0f,
+                  "shadow-calibration: semantic invitation survives sleep with its episode");
 
             memset(&sh->flow, 0, sizeof sh->flow);
             memset(&sh->shadow, 0, sizeof sh->shadow);


### PR DESCRIPTION
Resolve each shadow proposal to its exact persisted Wonder episode and treat either the literal title or one of that episode's offered glyphs as a human invitation. Keep unrelated reasks scorable, preserve state v17, and prove the boundary across save/load and the full nine-life resonance matrix without changing any transcript.

Quote: "Meaning can call a question by a name it never says." - Sol

Method: The Arianna Method asks whether a return was caused through the question's lived field before calling it pressure.