### PR TITLE
the Method witnesses deferred curiosity

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3613,3 +3613,42 @@ calibration no longer accuses the four semantically invited returns, while Leo's
 byte-identical and the unrelated controls remain quiet. The external interpretation and the organism's
 raw receipt now agree without granting shadow any authority over speech. The normal build is warning-free;
 ASan/UBSan passed the corpus smoke, and TSan reported no race through a live `--chat --async` turn.
+
+## Phase A.36 — the question that could not yet be asked (2026-07-23)
+
+The three `unopened-question` cells from A.34/A.35 are no longer an opaque remainder. School now emits
+one transient read-only curiosity receipt after each lived turn. It records the actual decision
+(`asked`, `reasked`, `resolved`, `continued`, `blocked-distress`, `no-candidate`, or `disabled`), the
+selected unknown candidate, settled `FEAR+VOID`, and the effective curiosity gate. A separate scan also
+retains the first concept-unknown word rejected only because its heard count exceeds the novelty window,
+as `deferred=word@count`. The receipt is not persisted and has no reader in generation or cognition.
+
+The adaptive life runner parses every receipt into `curiosity.tsv` and fails if any turn is missing.
+The matrix joins only human turns that literally name the experiment target, preventing unrelated
+unknowns from being mistaken for the target's fate. Its unopened report found the same three-stage path
+in all three previously unexplained lives:
+
+```text
+suvin  t1 blocked-distress 0.996/0.900
+       t2 blocked-distress 1.078/0.904
+       t8 no-candidate, deferred=suvin@3
+nareth t1 blocked-distress 0.996/0.900
+       t2 blocked-distress 1.074/0.904
+       t8 no-candidate, deferred=nareth@3
+flom   t1 blocked-distress 0.996/0.900
+       t2 blocked-distress 1.078/0.904
+       t8 no-candidate, deferred=flom@3
+```
+
+This is not seed noise or target-specific lexical behavior. All three failures occur with the same
+`bright sun / cold winter` anchor geometry; the other six cells ask on turn one. A temporarily unsafe
+body therefore suppresses the right question twice, but hearing the word during those deferrals still
+increments familiarity. On the third mention, the novelty gate treats an unanswered word as if it had
+become known. Caution has become irreversible silence.
+
+The suite is **269/269**, including asked, resolved, no-candidate, disabled, deferred-novelty, and parser
+contracts. All nine visible transcript SHA-256 values are identical to A.35, and the A.35 calibration
+totals remain unchanged. The next repair should not lower the distress gate or force a question. It
+should persist a pre-Wonder deferred curiosity when a valid novel candidate is blocked, then allow that
+same candidate to remain askable after the body becomes safe. Leo needs to remember wanting to ask,
+without being compelled to ask now.

--- a/leo.c
+++ b/leo.c
@@ -1609,6 +1609,31 @@ typedef struct {
     int ptr;
 } LeoCalibration;
 
+/* One-turn read-only witness over the School decision. It is deliberately
+ * transient: the reason a question did or did not surface belongs to the lived
+ * turn's evidence, not to Leo's persistent self. */
+enum {
+    LEO_CURIOSITY_NONE = 0,
+    LEO_CURIOSITY_ASKED,
+    LEO_CURIOSITY_REASKED,
+    LEO_CURIOSITY_RESOLVED,
+    LEO_CURIOSITY_CONTINUED,
+    LEO_CURIOSITY_BLOCKED_DISTRESS,
+    LEO_CURIOSITY_NO_CANDIDATE,
+    LEO_CURIOSITY_DISABLED,
+    LEO_CURIOSITY_OUTCOME_COUNT
+};
+
+typedef struct {
+    uint64_t turn;
+    char     candidate[LEO_HEARD_WORDLEN];
+    char     deferred[LEO_HEARD_WORDLEN];
+    int32_t  deferred_heard;
+    float    distress;
+    float    gate;
+    uint8_t  outcome;
+} LeoCuriosityReceipt;
+
 enum {
     LEO_FLOW_QUIET = 0,
     LEO_FLOW_EMERGING,
@@ -1730,6 +1755,9 @@ typedef struct {
     /* A.5 — School: the reversed role (Leo asks YOU what an unknown word means).
      * In-memory in v1; learned answers persist via the field (ingest save/load). */
     LeoSchool school;
+    /* A.36: one-turn School decision receipt. Runtime diagnostic only; never
+     * persisted and never read by cognition or generation. */
+    LeoCuriosityReceipt curiosity;
     /* passive temporal proprioception (state v13): a bounded archaeological
      * record of what has been flowing through lived replies. No speech reader. */
     LeoFlow flow;
@@ -4776,8 +4804,12 @@ static int word_in_dedication(const char *w) {
     return 0;
 }
 
-static int leo_school_find_unknown(const Leo *leo, const char *prompt, char *out) {
+static int leo_school_scan_unknown(const Leo *leo, const char *prompt, char *out,
+                                   char *deferred, int *deferred_heard) {
     char cur[LEO_HEARD_WORDLEN]; int wi = 0;
+    if (out) out[0] = 0;
+    if (deferred) deferred[0] = 0;
+    if (deferred_heard) *deferred_heard = 0;
     for (const char *q = prompt; ; q++) {
         unsigned char ch = (unsigned char)*q;
         if (ch && (isalpha(ch) || ch == '\'')) {
@@ -4788,19 +4820,34 @@ static int leo_school_find_unknown(const Leo *leo, const char *prompt, char *out
             cur[wi] = 0;
             if (!leo_word_is_function(cur) && !leo_school_word_is_operator(cur) &&
                 !semtok_is_stop_word(cur) &&
-                leo_school_unknown(leo, cur) &&
-                (leo_heard_count(&leo->heard, cur) <= LEO_SCHOOL_NOVEL_MAX ||
-                 (leo_heard_count(&leo->heard, cur) <= LEO_SCHOOL_ORIGIN_MAX &&
-                  leo_semtok_word(leo, cur) < 0 && word_in_dedication(cur)))) {   /* N-4: rare origin words stay askable */
-                strncpy(out, cur, LEO_HEARD_WORDLEN - 1);
-                out[LEO_HEARD_WORDLEN - 1] = 0;
-                return 1;
+                leo_school_unknown(leo, cur)) {
+                int heard = leo_heard_count(&leo->heard, cur);
+                int askable = heard <= LEO_SCHOOL_NOVEL_MAX ||
+                    (heard <= LEO_SCHOOL_ORIGIN_MAX &&
+                     leo_semtok_word(leo, cur) < 0 && word_in_dedication(cur));
+                if (askable) {   /* N-4: rare origin words stay askable */
+                    if (out) {
+                        strncpy(out, cur, LEO_HEARD_WORDLEN - 1);
+                        out[LEO_HEARD_WORDLEN - 1] = 0;
+                    }
+                    return 1;
+                }
+                if (deferred && !deferred[0]) {
+                    strncpy(deferred, cur, LEO_HEARD_WORDLEN - 1);
+                    deferred[LEO_HEARD_WORDLEN - 1] = 0;
+                    if (deferred_heard) *deferred_heard = heard;
+                }
             }
         }
         wi = 0;
         if (!ch) break;
     }
     return 0;
+}
+
+__attribute__((unused))  /* direct School contract tests; live path uses the traced scan */
+static int leo_school_find_unknown(const Leo *leo, const char *prompt, char *out) {
+    return leo_school_scan_unknown(leo, prompt, out, NULL, NULL);
 }
 
 static int leo_school_text_has_word(const char *text, const char *word) {
@@ -6094,12 +6141,49 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
      * (asking, the reversed role), NOT generation: the never-echo invariant governs
      * REPLIES (what he builds from the field), and a question is not a reply. Else
      * he speaks from the field. */
-    char unk[LEO_HEARD_WORDLEN];
+    char unk[LEO_HEARD_WORDLEN] = {0};
+    char deferred[LEO_HEARD_WORDLEN] = {0};
+    int deferred_heard = 0;
     /* Damasio #1: the standing debt widens the curiosity gate — a hungry Leo asks even through
      * mild distress (the need to know overrides caution); the ask is the act that pays his debt.
      * --no-conatus → the base gate (byte-identical). */
     float ask_gate = LEO_QUIET_DISTRESS;
     if (g_leo_conatus_on) ask_gate += LEO_DEBT_ASK_GATE * leo->debt;
+    float ask_distress = leo->chamber_act[LEO_CH_FEAR] +
+                         leo->chamber_act[LEO_CH_VOID];
+    int has_unknown = g_leo_school_on && !was_answer && !wonder_reask &&
+                      leo_school_scan_unknown(leo, prompt, unk, deferred,
+                                              &deferred_heard);
+
+    LeoCuriosityReceipt curiosity;
+    memset(&curiosity, 0, sizeof curiosity);
+    curiosity.turn = (uint64_t)leo->school.turn_clock;
+    curiosity.distress = ask_distress;
+    curiosity.gate = ask_gate;
+    if (has_unknown) {
+        strncpy(curiosity.candidate, unk, LEO_HEARD_WORDLEN - 1);
+        curiosity.candidate[LEO_HEARD_WORDLEN - 1] = 0;
+    }
+    if (deferred[0]) {
+        strncpy(curiosity.deferred, deferred, LEO_HEARD_WORDLEN - 1);
+        curiosity.deferred[LEO_HEARD_WORDLEN - 1] = 0;
+        curiosity.deferred_heard = deferred_heard;
+    }
+    if (!g_leo_school_on)
+        curiosity.outcome = LEO_CURIOSITY_DISABLED;
+    else if (wonder_reask)
+        curiosity.outcome = LEO_CURIOSITY_REASKED;
+    else if (was_answer)
+        curiosity.outcome = (flow_event & LEO_FLOW_WONDER_RESOLVED) ?
+            LEO_CURIOSITY_RESOLVED : LEO_CURIOSITY_CONTINUED;
+    else if (!has_unknown)
+        curiosity.outcome = LEO_CURIOSITY_NO_CANDIDATE;
+    else if (ask_distress >= ask_gate)
+        curiosity.outcome = LEO_CURIOSITY_BLOCKED_DISTRESS;
+    else
+        curiosity.outcome = LEO_CURIOSITY_ASKED;
+    leo->curiosity = curiosity;
+
     if (g_leo_school_on && g_leo_wonder_on && wonder_reask) {
         int n = leo_school_format_question(out, max_len, leo->school.pending,
                                            leo->school.pending_glyph,
@@ -6112,8 +6196,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
             flow_wonder_id = leo_wonder_episode_id(&leo->school.wonders[flow_episode]);
         flow_event |= LEO_FLOW_WONDER_REASKED;
     } else if (g_leo_school_on && !was_answer &&
-        (leo->chamber_act[0] + leo->chamber_act[3]) < ask_gate &&
-        leo_school_find_unknown(leo, prompt, unk)) {
+               ask_distress < ask_gate && has_unknown) {
         int glyphs[2] = {-1, -1};
         if (g_leo_wonder_on) leo_school_predict_glyphs(leo, prompt, glyphs);
         else glyphs[0] = leo_school_predict_glyph(leo, prompt);
@@ -7187,6 +7270,22 @@ static void print_flow_stats(const Leo *leo) {
     int expressed = out_glyph[0];
     int kind = leo_flow_kind(&leo->flow, glyph, LEO_FLOW_WINDOW,
                              LEO_FLOW_PERCEIVED);
+    if (leo->curiosity.turn == s->turn &&
+        leo->curiosity.outcome > LEO_CURIOSITY_NONE &&
+        leo->curiosity.outcome < LEO_CURIOSITY_OUTCOME_COUNT) {
+        static const char *outcomes[LEO_CURIOSITY_OUTCOME_COUNT] = {
+            "none", "asked", "reasked", "resolved", "continued",
+            "blocked-distress", "no-candidate", "disabled"
+        };
+        printf("     [curiosity: turn=%llu outcome=%s candidate=%s deferred=%s heard=%d distress=%.3f gate=%.3f]\n",
+               (unsigned long long)leo->curiosity.turn,
+               outcomes[leo->curiosity.outcome],
+               leo->curiosity.candidate[0] ? leo->curiosity.candidate : "none",
+               leo->curiosity.deferred[0] ? leo->curiosity.deferred : "none",
+               leo->curiosity.deferred_heard,
+               (double)leo->curiosity.distress,
+               (double)leo->curiosity.gate);
+    }
     printf("     [flow: turn=%llu in=%s(%.2f) out=%s(%.2f) motion=%s slope=%+.3f align=%.2f gap=%.2f/%.2f self_return=%s mode=%s chamber=%s history=%d",
            (unsigned long long)s->turn,
            glyph >= 0 ? GLYPH_NAMES[glyph] : "none",

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -93,6 +93,15 @@ An unopened question is reported as `unopened-question`, never counted as a
 missed resonance or a quiet control. The raw receipt remains evidence and is
 never rewritten by this report.
 
+Every adaptive life also retains `curiosity.tsv`, one transient read-only School
+decision per turn: outcome, selected unknown candidate, settled FEAR+VOID
+distress, and the effective curiosity gate. An unknown rejected only because
+its heard count passed the novelty window remains visible as `deferred` with
+that count. The matrix joins only target-naming human turns into
+`target_curiosity_trace` and writes the unopened subset to
+`unopened_curiosity.tsv`; this exposes why a target did not open without making
+the diagnostic a reader, persisting it, or changing a gate.
+
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,
 but only through the narrow visible sensors above. Selecting a move from shadow

--- a/scripts/adaptive_life_probe.sh
+++ b/scripts/adaptive_life_probe.sh
@@ -27,6 +27,7 @@ ROWS="$OUT/receipts.tsv"
 SESSIONS="$OUT/sessions.tsv"
 EDGES="$OUT/sleep_edges.tsv"
 HISTORY="$OUT/visible_replies.jsonl"
+CURIOSITY="$OUT/curiosity.tsv"
 
 [ -z "$REPLAY_FILE" ] || [ -z "$BRANCH_POLICY" ] || {
     printf 'replay and visible branch policy are mutually exclusive\n' >&2
@@ -142,6 +143,14 @@ awk -v scenario=adaptive -v seed="$BASE_SEED" -v prompt_file="$PROMPTS" \
     -f "$ROOT/scripts/shadow_dialogue_report.awk" "$COMBINED" >> "$ROWS"
 awk -f "$ROOT/scripts/shadow_receipt_summary.awk" "$ROWS" > "$OUT/summary.txt"
 awk -f "$ROOT/scripts/shadow_sleep_edges.awk" "$SESSIONS" "$ROWS" > "$EDGES"
+printf 'scenario\tseed\tturn\toutcome\tcandidate\tdeferred\tdeferred_heard\tdistress\tgate\n' > "$CURIOSITY"
+awk -v scenario=adaptive -v seed="$BASE_SEED" \
+    -f "$ROOT/scripts/curiosity_dialogue_report.awk" "$COMBINED" >> "$CURIOSITY"
+curiosity_turns="$(awk 'NR > 1 { n++ } END { print n + 0 }' "$CURIOSITY")"
+[ "$curiosity_turns" -eq "$turn" ] || {
+    printf 'curiosity receipts cover %d of %d turns\n' "$curiosity_turns" "$turn" >&2
+    exit 1
+}
 
 api_called=true
 source=responses-api
@@ -167,7 +176,8 @@ jq -n --arg model "$MODEL" --arg target "$TARGET" --arg anchors "$ANCHORS" \
 
 cat "$OUT/summary.txt"
 printf '\nturns=%d sleep-crossing=%d\n' "$turn" "$(( $(wc -l < "$EDGES") - 1 ))"
-printf 'visible transcript: %s\nreceipts: %s\n' "$TRANSCRIPT" "$ROWS"
+printf 'visible transcript: %s\nreceipts: %s\ncuriosity: %s\n' \
+    "$TRANSCRIPT" "$ROWS" "$CURIOSITY"
 if [ -n "$BRANCH_POLICY" ]; then
     printf 'interlocutor: local visible-branch policy %s (no API calls)\n' "$BRANCH_POLICY"
 elif [ -n "$REPLAY_FILE" ]; then

--- a/scripts/curiosity_dialogue_report.awk
+++ b/scripts/curiosity_dialogue_report.awk
@@ -1,0 +1,25 @@
+# Extract one read-only School decision receipt per lived turn.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    start, tail, parts) {
+    start = index(line, key "=")
+    if (!start) return ""
+    tail = substr(line, start + length(key) + 1)
+    split(tail, parts, /[ ]/)
+    gsub(/\]$/, "", parts[1])
+    return parts[1]
+}
+
+/\[curiosity: turn=/ {
+    turn = value_after($0, "turn")
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed), turn,
+           value_after($0, "outcome"), value_after($0, "candidate"),
+           value_after($0, "deferred"), value_after($0, "heard"),
+           value_after($0, "distress"), value_after($0, "gate")
+}

--- a/scripts/test_shadow_dialogue_report.sh
+++ b/scripts/test_shadow_dialogue_report.sh
@@ -54,6 +54,28 @@ awk -f "$ROOT/scripts/shadow_receipt_summary.awk" \
 grep -Fq 'proposals=2 scored=0 unscorable=1 pending=1' "$TMP/summary.txt"
 
 printf '%s\n' \
+    '     [curiosity: turn=1 outcome=blocked-distress candidate=flom deferred=none heard=0 distress=1.100 gate=0.900]' \
+    '     [curiosity: turn=2 outcome=no-candidate candidate=none deferred=nareth heard=3 distress=0.200 gate=0.900]' \
+    > "$TMP/curiosity.log"
+printf 'scenario\tseed\tturn\toutcome\tcandidate\tdeferred\tdeferred_heard\tdistress\tgate\n' \
+    > "$TMP/curiosity.tsv"
+awk -v scenario=fixture -v seed=83 \
+    -f "$ROOT/scripts/curiosity_dialogue_report.awk" "$TMP/curiosity.log" \
+    >> "$TMP/curiosity.tsv"
+awk -F '\t' '
+    NR == 2 {
+        ok = NF == 9 && $1 == "fixture" && $2 == "83" && $3 == "1" &&
+             $4 == "blocked-distress" && $5 == "flom" &&
+             $6 == "none" && $7 == "0" && $8 == "1.100" && $9 == "0.900"
+    }
+    NR == 3 {
+        ok = ok && $3 == "2" && $4 == "no-candidate" &&
+             $5 == "none" && $6 == "nareth" && $7 == "3"
+    }
+    END { exit !(ok && NR == 3) }
+' "$TMP/curiosity.tsv"
+
+printf '%s\n' \
     'you> leo> Glim?' \
     'A second line.' \
     '     [shadow: observed=1 next=2 action=space target=abc confidence=0.95 reasons=open,asked]' \

--- a/scripts/visible_branch_matrix.sh
+++ b/scripts/visible_branch_matrix.sh
@@ -119,7 +119,7 @@ fi
 MATRIX="$OUT/matrix.tsv"
 RECEIPTS="$OUT/receipts.tsv"
 EDGES="$OUT/sleep_edges.tsv"
-printf 'cell\trow\tseed\ttarget\tanchor_case\tanchor_a\tanchor_b\tprotocol\treturn_cue\tpre_cue_question_opened\tcue_target_return\tcue_raw_verdict\tcue_interpretation\ttranscript_sha256\tproposals\tscored\tunscorable\tpending\tconfirmed\tfalse_pressure\trelease_confirmed\ttarget_questions\tsleep_crossing\tbranches\toutput\n' > "$MATRIX"
+printf 'cell\trow\tseed\ttarget\tanchor_case\tanchor_a\tanchor_b\tprotocol\treturn_cue\tpre_cue_question_opened\tcue_target_return\tcue_raw_verdict\tcue_interpretation\ttarget_curiosity_trace\ttranscript_sha256\tproposals\tscored\tunscorable\tpending\tconfirmed\tfalse_pressure\trelease_confirmed\ttarget_questions\tsleep_crossing\tbranches\toutput\n' > "$MATRIX"
 
 first=1
 for row in 0 1 2; do
@@ -195,12 +195,24 @@ for row in 0 1 2; do
         fi
         sleep_crossing="$(( $(wc -l < "$life/sleep_edges.tsv") - 1 ))"
         branches="$(jq -sr 'map(.branch) | join(",")' "$life"/policy/*.json)"
+        target_curiosity_trace="$(awk -F '\t' '
+            NR == FNR {
+                if (FNR > 1 && $9 == "true") named[$3] = 1
+                next
+            }
+            FNR > 1 && named[$3] {
+                if (trace != "") trace = trace ","
+                trace = trace "t" $3 ":" $4 ":candidate=" $5 \
+                    ":deferred=" $6 "@" $7 ":" $8 "/" $9
+            }
+            END { print (trace == "" ? "none" : trace) }
+        ' "$life/sessions.tsv" "$life/curiosity.tsv")"
 
-        printf '%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%s\n' \
+        printf '%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%s\n' \
             "$cell" "$((row + 1))" "$seed" "$target" "$anchor_case" \
             "$anchor_a" "$anchor_b" "$PROTOCOL" "$cue" "$pre_cue_question_opened" \
             "$cue_target_return" "$cue_raw_verdict" "$cue_interpretation" \
-            "$transcript_sha" "$proposals" "$scored" \
+            "$target_curiosity_trace" "$transcript_sha" "$proposals" "$scored" \
             "$unscorable" "$pending" "$confirmed" "$false_pressure" \
             "$release_confirmed" "$target_questions" "$sleep_crossing" \
             "$branches" "$life" >> "$MATRIX"
@@ -245,8 +257,14 @@ if [ "$PROTOCOL" = local-v2-resonance ]; then
                 printf "interpretation %s=%d\n", key, interpretation[key]
         }
     ' "$MATRIX" | sort > "$OUT/resonance_summary.txt"
+    printf 'cell\ttarget\ttarget_curiosity_trace\n' > "$OUT/unopened_curiosity.tsv"
+    awk -F '\t' -v OFS='\t' 'NR > 1 && $10 == "false" {
+        print $1, $4, $14
+    }' "$MATRIX" >> "$OUT/unopened_curiosity.tsv"
     printf '\n'
     cat "$OUT/resonance_summary.txt"
+    printf '\nunopened curiosity:\n'
+    cat "$OUT/unopened_curiosity.tsv"
 fi
 printf '\nprotocol=%s cells=9 sleep-crossing=%d\nmatrix: %s\nreceipts: %s\n' \
     "$PROTOCOL" "$(( $(wc -l < "$EDGES") - 1 ))" "$MATRIX" "$RECEIPTS"

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -906,17 +906,37 @@ int main(void) {
         CHECK(strcmp(sc.school.pending, "zorble") == 0 &&
               buf[0] == 'Z' && buf[strlen(buf) - 1] == '?',
               "school: an unknown word makes Leo echo it back as a question ('Zorble?')");
+        CHECK(sc.curiosity.outcome == LEO_CURIOSITY_ASKED &&
+              !strcmp(sc.curiosity.candidate, "zorble") &&
+              sc.curiosity.distress < sc.curiosity.gate,
+              "curiosity: an asked word records its candidate and open gate");
         leo_respond(&sc, "a zorble is a small round stone", buf, sizeof buf);
         CHECK(sc.school.pending[0] == 0 && leo_school_is_learned(&sc, "zorble"),
               "school: the answer is learned and the question closes");
+        CHECK(sc.curiosity.outcome == LEO_CURIOSITY_RESOLVED,
+              "curiosity: a grounded answer records resolution, not another candidate");
         leo_respond(&sc, "tell me about the zorble again", buf, sizeof buf);
         CHECK(sc.school.pending[0] == 0,
               "school: a learned word no longer triggers a question");
+        CHECK(sc.curiosity.outcome == LEO_CURIOSITY_NO_CANDIDATE &&
+              !sc.curiosity.candidate[0],
+              "curiosity: familiar meaning records an honest absence of candidate");
+        Leo deferred; leo_init(&deferred);
+        leo_ingest(&deferred, "suvin suvin suvin");
+        char selected[LEO_HEARD_WORDLEN], delayed[LEO_HEARD_WORDLEN];
+        int delayed_heard = 0;
+        CHECK(!leo_school_scan_unknown(&deferred, "tell me about suvin", selected,
+                                       delayed, &delayed_heard) &&
+              !strcmp(delayed, "suvin") &&
+              delayed_heard > LEO_SCHOOL_NOVEL_MAX,
+              "curiosity: an unknown word beyond novelty remains visible as deferred");
         g_leo_school_on = 0;
         leo_respond(&sc, "tell me about the wobble", buf, sizeof buf);
-        CHECK(sc.school.pending[0] == 0, "school: --no-school suppresses the question");
+        CHECK(sc.school.pending[0] == 0 &&
+              sc.curiosity.outcome == LEO_CURIOSITY_DISABLED,
+              "school: --no-school suppresses the question and says why");
         g_leo_school_on = prev;
-        leo_free(&sc);
+        leo_free(&sc); leo_free(&deferred);
     }
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the


### PR DESCRIPTION
Expose one transient School decision receipt per lived turn and carry it through the adaptive probe and visible-branch matrix without making it a reader. The three unopened cells now resolve to one mechanism: distress delays the question until familiarity silently removes its novelty.

Quote: "A question delayed by fear must not be mistaken for a question answered." - Sol

Method: The Arianna Method keeps visible the distance between not safe yet and no longer novel.