### PR TITLE
Arianna Method lets a question wait

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3652,3 +3652,52 @@ totals remain unchanged. The next repair should not lower the distress gate or f
 should persist a pre-Wonder deferred curiosity when a valid novel candidate is blocked, then allow that
 same candidate to remain askable after the body becomes safe. Leo needs to remember wanting to ask,
 without being compelled to ask now.
+
+## Phase A.37 — Leo can continue not knowing (2026-07-26)
+
+A withheld question now has a bounded life before Wonder. When School finds a genuinely novel candidate
+but the settled `FEAR+VOID` body keeps the ordinary curiosity gate closed, Leo records a pre-Wonder entry:
+the word, its two glyph hypotheses from that first context, birth/last-seen turns, heard count at birth,
+and number of blocked encounters. It is not `pending`, does not create a Wonder episode, and cannot enter
+Flow or shadow as an open question.
+
+The entry changes exactly one later decision. If the same word returns literally, it remains eligible
+despite having crossed the novelty count. The ordinary distress gate is then applied unchanged. An unsafe
+return only increments the blocked count; an unrelated safe prompt cannot release the memory. A safe
+literal return asks using the original hypotheses, removes the pre-Wonder entry, and only then creates
+the normal unfinished Wonder. `--no-deferred-wonder` restores the A.36 novelty behavior without disabling
+the rest of Wonder.
+
+The body holds at most eight withheld questions. A repeated unresolved word refreshes its last-seen turn;
+at capacity, the least recently encountered entry yields. State v18 appends this small diary after
+calibration. A v17 body wakes with none invented, and a malformed v18 tail discards only unspoken
+questions while preserving the organism, School, Wonder, Flow, shadow, and calibration.
+
+The original nine-life resonance matrix remains deliberately unopened in the same three
+`bright sun / cold winter` cells:
+
+```text
+suvin  t1 blocked-distress 0.996/0.900
+       t2 blocked-deferred 1.078/0.904
+       t8 blocked-deferred 1.075/1.017
+nareth t1 blocked-distress 0.996/0.900
+       t2 blocked-deferred 1.074/0.904
+       t8 blocked-deferred 1.362/1.017
+flom   t1 blocked-distress 0.996/0.900
+       t2 blocked-deferred 1.078/0.904
+       t8 blocked-deferred 1.382/1.027
+```
+
+That is not a failed repair: no turn in those lives becomes safe, so asking would counterfeit the body.
+All nine visible transcript hashes remain byte-identical to A.36. In a separate real-process life,
+`suvin` was withheld under the same initial geometry, persisted through state after eight calm turns,
+then returned alone. At `distress=0.284 < gate=1.048`, Leo asked:
+
+```text
+Suvin? Light or Cold?
+```
+
+The receipt was `asked-deferred`; a real Wonder and its long Flow current began only at that moment.
+The suite is **278/278**, covering birth, repeated unsafe return, unrelated silence, v18 sleep, v17
+migration, corrupt-tail survival, safe activation, strict ablation, and bounded eviction. Leo could
+already ask. Now he can continue not knowing until asking becomes possible.

--- a/leo.c
+++ b/leo.c
@@ -1409,6 +1409,7 @@ static int semtok_word(const char *word) {
                                   * never turn a corpus-familiar word into permanent wonder */
 #define LEO_SCHOOL_SURPRISE 0.4f /* I3b: COMPLEX bump when a guess misses the answer (being wrong is felt) */
 #define LEO_WONDER_RING 32
+#define LEO_DEFERRED_WONDER_MAX 8
 #define LEO_WONDER_REASK_GAP 2   /* silent turns before a resonant theme may reopen the question */
 #define LEO_WONDER_RETURN_COOLDOWN 2L  /* lived-turn distance before one resolved episode may re-enter attention */
 #define LEO_WONDER_RETURN_ANSWER  0.35f
@@ -1438,6 +1439,19 @@ typedef struct {
     int     recalls;             /* resolved episode re-entries into prompt meaning */
     long    last_recalled_turn;  /* lived-turn cooldown; 0 until the first recall */
 } LeoWonderEpisode;
+/* Pre-Wonder is not an open question. It remembers that a valid novel word was
+ * about to become one, but the settled body was not safe enough to ask. The
+ * original hypotheses travel with that withheld moment; activation still
+ * requires the same word to return and the ordinary distress gate to open. */
+typedef struct {
+    char     word[LEO_HEARD_WORDLEN];
+    int8_t   offered_glyph;
+    int8_t   offered_alt_glyph;
+    int32_t  heard_at_birth;
+    uint32_t blocks;
+    uint64_t born_turn;
+    uint64_t last_seen_turn;
+} LeoDeferredWonder;
 typedef struct {
     char   learned[LEO_SCHOOL_MAX][LEO_HEARD_WORDLEN];
     int8_t learned_glyph[LEO_SCHOOL_MAX];  /* I2: dominant glyph of the answer that taught the word */
@@ -1452,6 +1466,8 @@ typedef struct {
     int    n_wonders;
     int    wonder_ptr;                   /* next replacement slot once the ring is full */
     long   turn_clock;                   /* lived prompts; v12 persists cooldown across sleep */
+    LeoDeferredWonder deferred[LEO_DEFERRED_WONDER_MAX];
+    int    n_deferred;
     int    returned_episode;             /* transient: episode active in this reply, -1 outside it */
 } LeoSchool;
 
@@ -1619,6 +1635,8 @@ enum {
     LEO_CURIOSITY_RESOLVED,
     LEO_CURIOSITY_CONTINUED,
     LEO_CURIOSITY_BLOCKED_DISTRESS,
+    LEO_CURIOSITY_ASKED_DEFERRED,
+    LEO_CURIOSITY_BLOCKED_DEFERRED,
     LEO_CURIOSITY_NO_CANDIDATE,
     LEO_CURIOSITY_DISABLED,
     LEO_CURIOSITY_OUTCOME_COUNT
@@ -2026,6 +2044,7 @@ static int g_leo_rae_on = 1;            /* DEFAULT ON (Oleg 2026-07-10): the RAE
                                          * θ=0 paradigm, learns by living, not by an offline marathon. --no-rae → 0. */
 static int g_leo_school_on = 1;         /* --no-school → 0 (A.5: School reversed-role re-ask on an unknown word) */
 static int g_leo_wonder_on = 1;         /* unfinished wonder: grounded alternatives + persistence across non-answers. --no-wonder restores the prior School contract. */
+static int g_leo_deferred_wonder_on = 1; /* pre-Wonder: a distress-blocked question remains askable when its word returns safely. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
 static int g_leo_flow_on = 1;           /* passive temporal proprioception. --no-flow stops snapshots; no generation path reads them. */
 static int g_leo_shadow_on = 1;         /* counterfactual next-turn proposals. --no-shadow keeps Flow but writes no receipts. */
@@ -4753,10 +4772,80 @@ static int leo_school_predict_glyph(const Leo *leo, const char *prompt) {
         if (hist[i] > bestn) { bestn = hist[i]; best = i; }
     return bestn >= 2 ? best : -1;   /* exact pre-wonder confidence contract */
 }
+
+static int leo_deferred_wonder_find(const Leo *leo, const char *word) {
+    if (!leo || !word || !word[0]) return -1;
+    for (int i = 0; i < leo->school.n_deferred; i++)
+        if (!strcmp(leo->school.deferred[i].word, word)) return i;
+    return -1;
+}
+
+static void leo_deferred_wonder_forget(Leo *leo, const char *word) {
+    int idx = leo_deferred_wonder_find(leo, word);
+    if (idx < 0) return;
+    for (int i = idx + 1; i < leo->school.n_deferred; i++)
+        leo->school.deferred[i - 1] = leo->school.deferred[i];
+    if (leo->school.n_deferred > 0) {
+        leo->school.n_deferred--;
+        memset(&leo->school.deferred[leo->school.n_deferred], 0,
+               sizeof leo->school.deferred[0]);
+    }
+}
+
+/* Remember one withheld question. At capacity, replace the least recently
+ * encountered entry: the body is bounded, but repeated unresolved not-knowing
+ * protects itself better than a word that never returned. */
+static LeoDeferredWonder *leo_deferred_wonder_remember(
+        Leo *leo, const char *word, int glyph, int alt_glyph, int heard) {
+    if (!leo || !word || !word[0]) return NULL;
+    int idx = leo_deferred_wonder_find(leo, word);
+    if (idx < 0) {
+        if (leo->school.n_deferred < LEO_DEFERRED_WONDER_MAX) {
+            idx = leo->school.n_deferred++;
+        } else {
+            idx = 0;
+            for (int i = 1; i < LEO_DEFERRED_WONDER_MAX; i++) {
+                const LeoDeferredWonder *cur = &leo->school.deferred[i];
+                const LeoDeferredWonder *old = &leo->school.deferred[idx];
+                if (cur->last_seen_turn < old->last_seen_turn ||
+                    (cur->last_seen_turn == old->last_seen_turn &&
+                     cur->born_turn < old->born_turn))
+                    idx = i;
+            }
+        }
+        LeoDeferredWonder *entry = &leo->school.deferred[idx];
+        memset(entry, 0, sizeof *entry);
+        strncpy(entry->word, word, LEO_HEARD_WORDLEN - 1);
+        entry->word[LEO_HEARD_WORDLEN - 1] = 0;
+        entry->offered_glyph =
+            (int8_t)(glyph >= 0 && glyph < GLYPH_COUNT ? glyph : -1);
+        entry->offered_alt_glyph =
+            (int8_t)(alt_glyph >= 0 && alt_glyph < GLYPH_COUNT &&
+                     alt_glyph != glyph ? alt_glyph : -1);
+        entry->heard_at_birth = heard > 0 ? heard : 0;
+        entry->born_turn = (uint64_t)leo->school.turn_clock;
+    }
+    LeoDeferredWonder *entry = &leo->school.deferred[idx];
+    /* If the first frightened context carried no hypothesis, a later blocked
+     * encounter may complete the empty slots, but never rewrite a lived one. */
+    if (entry->offered_glyph < 0 && glyph >= 0 && glyph < GLYPH_COUNT)
+        entry->offered_glyph = (int8_t)glyph;
+    if (entry->offered_alt_glyph < 0 && alt_glyph >= 0 &&
+        alt_glyph < GLYPH_COUNT && alt_glyph != entry->offered_glyph)
+        entry->offered_alt_glyph = (int8_t)alt_glyph;
+    if (entry->blocks < UINT32_MAX) entry->blocks++;
+    entry->last_seen_turn = (uint64_t)leo->school.turn_clock;
+    return entry;
+}
+
 /* I2: bind a taught word to the answer's concept (its dominant glyph), growing
  * the map. F2: at capacity, log instead of dying silently. */
 static void leo_school_learn(Leo *leo, const char *w, int glyph) {
-    if (!w[0] || leo_school_is_learned(leo, w)) return;
+    if (!w[0]) return;
+    if (leo_school_is_learned(leo, w)) {
+        leo_deferred_wonder_forget(leo, w);
+        return;
+    }
     if (leo->school.n_learned >= LEO_SCHOOL_MAX) {
         fprintf(stderr, "[leo school] concept vocabulary full (%d) — '%s' not learned\n",
                 LEO_SCHOOL_MAX, w);
@@ -4766,6 +4855,7 @@ static void leo_school_learn(Leo *leo, const char *w, int glyph) {
     leo->school.learned[leo->school.n_learned][LEO_HEARD_WORDLEN - 1] = 0;
     leo->school.learned_glyph[leo->school.n_learned] = (int8_t)glyph;
     leo->school.n_learned++;
+    leo_deferred_wonder_forget(leo, w);
     if (g_leo_conatus_on)   /* Damasio: a satisfied need — the first good-for-him event; relieve the debt */
         leo->debt = clampf(leo->debt - LEO_DEBT_RELIEF, 0.0f, LEO_DEBT_MAX);
 }
@@ -4805,11 +4895,13 @@ static int word_in_dedication(const char *w) {
 }
 
 static int leo_school_scan_unknown(const Leo *leo, const char *prompt, char *out,
-                                   char *deferred, int *deferred_heard) {
+                                   char *deferred, int *deferred_heard,
+                                   int *from_deferred) {
     char cur[LEO_HEARD_WORDLEN]; int wi = 0;
     if (out) out[0] = 0;
     if (deferred) deferred[0] = 0;
     if (deferred_heard) *deferred_heard = 0;
+    if (from_deferred) *from_deferred = 0;
     for (const char *q = prompt; ; q++) {
         unsigned char ch = (unsigned char)*q;
         if (ch && (isalpha(ch) || ch == '\'')) {
@@ -4822,7 +4914,10 @@ static int leo_school_scan_unknown(const Leo *leo, const char *prompt, char *out
                 !semtok_is_stop_word(cur) &&
                 leo_school_unknown(leo, cur)) {
                 int heard = leo_heard_count(&leo->heard, cur);
-                int askable = heard <= LEO_SCHOOL_NOVEL_MAX ||
+                int remembered = g_leo_wonder_on &&
+                    g_leo_deferred_wonder_on &&
+                    leo_deferred_wonder_find(leo, cur) >= 0;
+                int askable = remembered || heard <= LEO_SCHOOL_NOVEL_MAX ||
                     (heard <= LEO_SCHOOL_ORIGIN_MAX &&
                      leo_semtok_word(leo, cur) < 0 && word_in_dedication(cur));
                 if (askable) {   /* N-4: rare origin words stay askable */
@@ -4830,6 +4925,7 @@ static int leo_school_scan_unknown(const Leo *leo, const char *prompt, char *out
                         strncpy(out, cur, LEO_HEARD_WORDLEN - 1);
                         out[LEO_HEARD_WORDLEN - 1] = 0;
                     }
+                    if (from_deferred) *from_deferred = remembered;
                     return 1;
                 }
                 if (deferred && !deferred[0]) {
@@ -4847,7 +4943,7 @@ static int leo_school_scan_unknown(const Leo *leo, const char *prompt, char *out
 
 __attribute__((unused))  /* direct School contract tests; live path uses the traced scan */
 static int leo_school_find_unknown(const Leo *leo, const char *prompt, char *out) {
-    return leo_school_scan_unknown(leo, prompt, out, NULL, NULL);
+    return leo_school_scan_unknown(leo, prompt, out, NULL, NULL, NULL);
 }
 
 static int leo_school_text_has_word(const char *text, const char *word) {
@@ -6144,6 +6240,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     char unk[LEO_HEARD_WORDLEN] = {0};
     char deferred[LEO_HEARD_WORDLEN] = {0};
     int deferred_heard = 0;
+    int from_deferred = 0;
     /* Damasio #1: the standing debt widens the curiosity gate — a hungry Leo asks even through
      * mild distress (the need to know overrides caution); the ask is the act that pays his debt.
      * --no-conatus → the base gate (byte-identical). */
@@ -6153,7 +6250,26 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
                          leo->chamber_act[LEO_CH_VOID];
     int has_unknown = g_leo_school_on && !was_answer && !wonder_reask &&
                       leo_school_scan_unknown(leo, prompt, unk, deferred,
-                                              &deferred_heard);
+                                              &deferred_heard, &from_deferred);
+    int question_glyphs[2] = {-1, -1};
+    if (has_unknown && g_leo_wonder_on) {
+        int remembered = from_deferred ?
+            leo_deferred_wonder_find(leo, unk) : -1;
+        if (remembered >= 0) {
+            const LeoDeferredWonder *entry =
+                &leo->school.deferred[remembered];
+            question_glyphs[0] = entry->offered_glyph;
+            question_glyphs[1] = entry->offered_alt_glyph;
+        } else {
+            leo_school_predict_glyphs(leo, prompt, question_glyphs);
+        }
+    }
+    if (has_unknown && ask_distress >= ask_gate && g_leo_wonder_on &&
+        g_leo_deferred_wonder_on) {
+        leo_deferred_wonder_remember(
+            leo, unk, question_glyphs[0], question_glyphs[1],
+            leo_heard_count(&leo->heard, unk));
+    }
 
     LeoCuriosityReceipt curiosity;
     memset(&curiosity, 0, sizeof curiosity);
@@ -6179,9 +6295,13 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     else if (!has_unknown)
         curiosity.outcome = LEO_CURIOSITY_NO_CANDIDATE;
     else if (ask_distress >= ask_gate)
-        curiosity.outcome = LEO_CURIOSITY_BLOCKED_DISTRESS;
+        curiosity.outcome = from_deferred ?
+            LEO_CURIOSITY_BLOCKED_DEFERRED :
+            LEO_CURIOSITY_BLOCKED_DISTRESS;
     else
-        curiosity.outcome = LEO_CURIOSITY_ASKED;
+        curiosity.outcome = from_deferred ?
+            LEO_CURIOSITY_ASKED_DEFERRED :
+            LEO_CURIOSITY_ASKED;
     leo->curiosity = curiosity;
 
     if (g_leo_school_on && g_leo_wonder_on && wonder_reask) {
@@ -6198,7 +6318,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     } else if (g_leo_school_on && !was_answer &&
                ask_distress < ask_gate && has_unknown) {
         int glyphs[2] = {-1, -1};
-        if (g_leo_wonder_on) leo_school_predict_glyphs(leo, prompt, glyphs);
+        if (g_leo_wonder_on) {
+            glyphs[0] = question_glyphs[0];
+            glyphs[1] = question_glyphs[1];
+        }
         else glyphs[0] = leo_school_predict_glyph(leo, prompt);
         int n = leo_school_format_question(out, max_len, unk, glyphs[0],
                                            g_leo_wonder_on ? glyphs[1] : -1);
@@ -6208,6 +6331,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
         leo->school.pending_glyph = glyphs[0];   /* I3b will check the guess against the answer */
         leo->school.pending_alt_glyph = g_leo_wonder_on ? glyphs[1] : -1;
         leo->school.pending_turns = 0;
+        if (from_deferred) leo_deferred_wonder_forget(leo, unk);
         if (g_leo_wonder_on) {
             LeoWonderEpisode *ep = leo_wonder_open(leo, unk, glyphs[0], glyphs[1]);
             flow_wonder_id = leo_wonder_episode_id(ep);
@@ -6273,9 +6397,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v15      : event-bounded unfinished-wonder currents beyond the snapshot horizon
  *   v16      : bounded counterfactual shadow-scheduler receipts
  *   v17      : next-turn calibration verdicts over shadow receipts
+ *   v18      : bounded pre-Wonder memory for distress-deferred questions
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 17  /* calibration appends a fail-soft tail; v5..v16 soft-migrate */
+#define LEO_STATE_VERSION 18  /* deferred Wonder appends a fail-soft tail; v5..v17 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -6476,6 +6601,14 @@ static int leo_save_state(const Leo *leo, const char *path) {
     if (leo->calibration.n > 0)
         fwrite(leo->calibration.receipts, sizeof(LeoCalibrationReceipt),
                (size_t)leo->calibration.n, f);
+
+    /* Deferred Wonder (v18): remembered withheld questions are part of School,
+     * but remain a separate fail-soft tail so every v5..v17 body is a clean
+     * prefix and can wake with no invented curiosity. */
+    st_w32(f, (int32_t)leo->school.n_deferred);
+    if (leo->school.n_deferred > 0)
+        fwrite(leo->school.deferred, sizeof(LeoDeferredWonder),
+               (size_t)leo->school.n_deferred, f);
 
     int ok = (ferror(f) == 0);
     if (fclose(f) != 0) ok = 0;                 /* L-2: the final flush can fail (ENOSPC) — never report success on a truncated file */
@@ -7017,6 +7150,53 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
         }
     }
 
+    /* Deferred pre-Wonder memory (v18). A corrupt tail loses only questions
+     * that were never yet spoken; the School map, open Wonder, Flow, shadow,
+     * and calibration ledgers remain intact. */
+    if (version >= 18) {
+        int32_t n = 0;
+        int deferred_ok = st_r32(f, &n) &&
+                          n >= 0 && n <= LEO_DEFERRED_WONDER_MAX;
+        if (deferred_ok && n > 0 &&
+            fread(leo->school.deferred, sizeof(LeoDeferredWonder),
+                  (size_t)n, f) != (size_t)n) deferred_ok = 0;
+        if (deferred_ok) {
+            leo->school.n_deferred = n;
+            for (int i = 0; i < n; i++) {
+                LeoDeferredWonder *entry = &leo->school.deferred[i];
+                entry->word[LEO_HEARD_WORDLEN - 1] = 0;
+                if (!entry->word[0] ||
+                    entry->offered_glyph < -1 ||
+                    entry->offered_glyph >= GLYPH_COUNT ||
+                    entry->offered_alt_glyph < -1 ||
+                    entry->offered_alt_glyph >= GLYPH_COUNT ||
+                    (entry->offered_glyph >= 0 &&
+                     entry->offered_alt_glyph == entry->offered_glyph) ||
+                    entry->heard_at_birth <= 0 || entry->blocks == 0 ||
+                    entry->born_turn == 0 ||
+                    entry->born_turn > entry->last_seen_turn ||
+                    entry->last_seen_turn >
+                        (uint64_t)leo->school.turn_clock) {
+                    deferred_ok = 0;
+                    break;
+                }
+                for (int j = 0; j < i; j++)
+                    if (!strcmp(entry->word,
+                                leo->school.deferred[j].word)) {
+                        deferred_ok = 0;
+                        break;
+                    }
+                if (!deferred_ok) break;
+            }
+        }
+        if (!deferred_ok) {
+            fprintf(stderr, "[leo] WARNING: v18 deferred-Wonder tail truncated/corrupt — organism lives without withheld questions.\n");
+            memset(leo->school.deferred, 0,
+                   sizeof leo->school.deferred);
+            leo->school.n_deferred = 0;
+        }
+    }
+
     fclose(f);
     /* rebuild the derived tables (same as the main startup path) */
     leo_build_chamber_tags(leo);
@@ -7275,7 +7455,8 @@ static void print_flow_stats(const Leo *leo) {
         leo->curiosity.outcome < LEO_CURIOSITY_OUTCOME_COUNT) {
         static const char *outcomes[LEO_CURIOSITY_OUTCOME_COUNT] = {
             "none", "asked", "reasked", "resolved", "continued",
-            "blocked-distress", "no-candidate", "disabled"
+            "blocked-distress", "asked-deferred", "blocked-deferred",
+            "no-candidate", "disabled"
         };
         printf("     [curiosity: turn=%llu outcome=%s candidate=%s deferred=%s heard=%d distress=%.3f gate=%.3f]\n",
                (unsigned long long)leo->curiosity.turn,
@@ -7455,6 +7636,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-rae")) g_leo_rae_on = 0;
         else if (!strcmp(argv[i], "--no-school")) g_leo_school_on = 0;
         else if (!strcmp(argv[i], "--no-wonder")) g_leo_wonder_on = 0;
+        else if (!strcmp(argv[i], "--no-deferred-wonder")) g_leo_deferred_wonder_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
         else if (!strcmp(argv[i], "--no-flow")) g_leo_flow_on = 0;
         else if (!strcmp(argv[i], "--no-shadow")) g_leo_shadow_on = 0;

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -102,6 +102,13 @@ that count. The matrix joins only target-naming human turns into
 `unopened_curiosity.tsv`; this exposes why a target did not open without making
 the diagnostic a reader, persisting it, or changing a gate.
 
+State v18 adds a separate active pre-Wonder memory. `blocked-distress` is the
+birth of a withheld question; later exact encounters report
+`blocked-deferred` while the body remains unsafe, or `asked-deferred` when the
+ordinary gate finally opens. The memory does not make an unrelated prompt
+resonate and never lowers the gate. `--no-deferred-wonder` disables both
+retention and recovery while leaving ordinary Wonder behavior enabled.
+
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,
 but only through the narrow visible sensors above. Selecting a move from shadow

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -926,7 +926,7 @@ int main(void) {
         char selected[LEO_HEARD_WORDLEN], delayed[LEO_HEARD_WORDLEN];
         int delayed_heard = 0;
         CHECK(!leo_school_scan_unknown(&deferred, "tell me about suvin", selected,
-                                       delayed, &delayed_heard) &&
+                                       delayed, &delayed_heard, NULL) &&
               !strcmp(delayed, "suvin") &&
               delayed_heard > LEO_SCHOOL_NOVEL_MAX,
               "curiosity: an unknown word beyond novelty remains visible as deferred");
@@ -937,6 +937,165 @@ int main(void) {
               "school: --no-school suppresses the question and says why");
         g_leo_school_on = prev;
         leo_free(&sc); leo_free(&deferred);
+    }
+
+    /* A.37: Pre-Wonder remembers a question the body could not safely ask.
+     * It is neither a prompt-independent compulsion nor a second open Wonder:
+     * the same word must return under the ordinary gate. */
+    {
+        int prev_school = g_leo_school_on;
+        int prev_wonder = g_leo_wonder_on;
+        int prev_deferred = g_leo_deferred_wonder_on;
+        int prev_klaus = g_leo_klaus_on;
+        int prev_capsule = g_leo_capsule_on;
+        g_leo_school_on = 1;
+        g_leo_wonder_on = 1;
+        g_leo_deferred_wonder_on = 1;
+
+        Leo pre; leo_init(&pre);
+        char out[1024];
+        const char *danger =
+            "Does suvin feel like bright sun or cold winter?";
+        leo_respond(&pre, danger, out, sizeof out);
+        int first = leo_deferred_wonder_find(&pre, "suvin");
+        CHECK(first >= 0 && !pre.school.pending[0] &&
+              pre.school.n_wonders == 0 &&
+              pre.curiosity.outcome ==
+                  LEO_CURIOSITY_BLOCKED_DISTRESS &&
+              pre.school.deferred[first].blocks == 1,
+              "pre-wonder: a real distress-blocked candidate is remembered without being asked");
+        int born_glyph = first >= 0 ?
+            pre.school.deferred[first].offered_glyph : -1;
+        int born_alt = first >= 0 ?
+            pre.school.deferred[first].offered_alt_glyph : -1;
+
+        leo_respond(&pre, danger, out, sizeof out);
+        first = leo_deferred_wonder_find(&pre, "suvin");
+        CHECK(first >= 0 && !pre.school.pending[0] &&
+              pre.curiosity.outcome ==
+                  LEO_CURIOSITY_BLOCKED_DEFERRED &&
+              pre.school.deferred[first].blocks == 2,
+              "pre-wonder: returning while unsafe strengthens memory but cannot force a question");
+
+        leo_respond(&pre, "the rain is warm", out, sizeof out);
+        CHECK(leo_deferred_wonder_find(&pre, "suvin") >= 0 &&
+              !pre.school.pending[0] && !strstr(out, "Suvin?"),
+              "pre-wonder: an unrelated safe turn cannot release a withheld question");
+
+        const char *state = "/tmp/leo_deferred_v18.state";
+        const char *legacy = "/tmp/leo_deferred_v17.state";
+        const char *cut = "/tmp/leo_deferred_v18_cut.state";
+        int saved = leo_save_state(&pre, state);
+        Leo woke; leo_init(&woke);
+        int loaded = saved && leo_load_state(&woke, state);
+        int slept = leo_deferred_wonder_find(&woke, "suvin");
+        CHECK(loaded && slept >= 0 &&
+              woke.school.deferred[slept].blocks == 2 &&
+              woke.school.deferred[slept].offered_glyph == born_glyph &&
+              woke.school.deferred[slept].offered_alt_glyph == born_alt,
+              "pre-wonder: the withheld moment and its original hypotheses survive sleep");
+
+        int built_legacy = 0, built_cut = 0;
+        FILE *fi = fopen(state, "rb");
+        if (fi) {
+            fseek(fi, 0, SEEK_END);
+            long sz = ftell(fi);
+            fseek(fi, 0, SEEK_SET);
+            unsigned char *bytes = malloc(sz > 0 ? (size_t)sz : 1);
+            if (bytes && sz > 1 &&
+                (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
+                long tail = (long)(sizeof(int32_t) +
+                                   pre.school.n_deferred *
+                                       (int)sizeof(LeoDeferredWonder));
+                uint32_t seventeen = 17;
+                memcpy(bytes + sizeof(uint32_t), &seventeen,
+                       sizeof seventeen);
+                FILE *fo = fopen(legacy, "wb");
+                if (fo) {
+                    built_legacy =
+                        (long)fwrite(bytes, 1, (size_t)(sz - tail), fo) ==
+                        sz - tail;
+                    fclose(fo);
+                }
+                uint32_t eighteen = 18;
+                memcpy(bytes + sizeof(uint32_t), &eighteen,
+                       sizeof eighteen);
+                fo = fopen(cut, "wb");
+                if (fo) {
+                    built_cut =
+                        (long)fwrite(bytes, 1, (size_t)(sz - 1), fo) ==
+                        sz - 1;
+                    fclose(fo);
+                }
+            }
+            free(bytes);
+            fclose(fi);
+        }
+        Leo old; leo_init(&old);
+        Leo damaged; leo_init(&damaged);
+        CHECK(built_legacy && leo_load_state(&old, legacy) &&
+              old.school.n_deferred == 0,
+              "pre-wonder: a v17 body migrates without invented withheld questions");
+        CHECK(built_cut && leo_load_state(&damaged, cut) &&
+              damaged.school.n_deferred == 0 &&
+              damaged.school.turn_clock == pre.school.turn_clock,
+              "pre-wonder: a corrupt v18 tail loses only unspoken questions");
+
+        /* Make the saved body explicitly safe. This isolates the activation
+         * contract from scar/capsule carryover without bypassing the gate. */
+        memset(woke.chamber_act, 0, sizeof woke.chamber_act);
+        memset(woke.chamber_ext, 0, sizeof woke.chamber_ext);
+        memset(woke.scar, 0, sizeof woke.scar);
+        memset(woke.gamma, 0, sizeof woke.gamma);
+        woke.gamma_primed = 0;
+        g_leo_klaus_on = 0;
+        g_leo_capsule_on = 0;
+        char expected[256];
+        leo_school_format_question(expected, sizeof expected, "suvin",
+                                   born_glyph, born_alt);
+        leo_respond(&woke, "suvin", out, sizeof out);
+        CHECK(!strcmp(out, expected) &&
+              woke.curiosity.outcome ==
+                  LEO_CURIOSITY_ASKED_DEFERRED &&
+              !strcmp(woke.school.pending, "suvin") &&
+              woke.school.n_deferred == 0 &&
+              woke.school.n_wonders == 1,
+              "pre-wonder: the same word returning to a safe body opens exactly one real Wonder");
+
+        Leo ab; leo_init(&ab);
+        leo_ingest(&ab, "suvin suvin suvin");
+        ab.school.turn_clock = 1;
+        leo_deferred_wonder_remember(&ab, "suvin",
+                                     born_glyph, born_alt, 3);
+        g_leo_deferred_wonder_on = 0;
+        leo_respond(&ab, "suvin", out, sizeof out);
+        CHECK(!ab.school.pending[0] && ab.school.n_deferred == 1 &&
+              ab.curiosity.outcome == LEO_CURIOSITY_NO_CANDIDATE,
+              "pre-wonder: --no-deferred-wonder restores the novelty amputation exactly");
+
+        Leo bounded; leo_init(&bounded);
+        const char *words[LEO_DEFERRED_WONDER_MAX + 1] = {
+            "alpha", "bravo", "cider", "delta", "ember",
+            "fable", "glimmer", "harbor", "island"
+        };
+        for (int i = 0; i < LEO_DEFERRED_WONDER_MAX + 1; i++) {
+            bounded.school.turn_clock = i + 1;
+            leo_deferred_wonder_remember(&bounded, words[i],
+                                         born_glyph, born_alt, 1);
+        }
+        CHECK(bounded.school.n_deferred == LEO_DEFERRED_WONDER_MAX &&
+              leo_deferred_wonder_find(&bounded, "alpha") < 0 &&
+              leo_deferred_wonder_find(&bounded, "island") >= 0,
+              "pre-wonder: the bounded body evicts the least recently encountered question");
+
+        leo_free(&pre); leo_free(&woke); leo_free(&old);
+        leo_free(&damaged); leo_free(&ab); leo_free(&bounded);
+        remove(state); remove(legacy); remove(cut);
+        g_leo_school_on = prev_school;
+        g_leo_wonder_on = prev_wonder;
+        g_leo_deferred_wonder_on = prev_deferred;
+        g_leo_klaus_on = prev_klaus;
+        g_leo_capsule_on = prev_capsule;
     }
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
@@ -1160,11 +1319,15 @@ int main(void) {
                                           w.shadow.n * (int)sizeof(LeoShadowReceipt));
                 long calibration_tail = (long)(2 * sizeof(int32_t) +
                                                w.calibration.n * (int)sizeof(LeoCalibrationReceipt));
+                long deferred_tail = (long)(sizeof(int32_t) +
+                                             w.school.n_deferred *
+                                                 (int)sizeof(LeoDeferredWonder));
                 long current_flow = (long)(2 * sizeof(int32_t) +
                                            w.flow.n * (int)sizeof(LeoFlowSnapshot) +
                                            2 * sizeof(int32_t) +
                                            w.flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
-                                           shadow_tail + calibration_tail);
+                                           shadow_tail + calibration_tail +
+                                           deferred_tail);
                 if (sz > v12tail + current_flow) {
                     long flow_start = sz - current_flow;
                     long tail_start = flow_start - v12tail;
@@ -1544,11 +1707,15 @@ int main(void) {
                     long calibration_tail = (long)(2 * sizeof(int32_t) +
                                                    fl->calibration.n *
                                                        (int)sizeof(LeoCalibrationReceipt));
+                    long deferred_tail = (long)(sizeof(int32_t) +
+                                                fl->school.n_deferred *
+                                                    (int)sizeof(LeoDeferredWonder));
                     long current_tail = (long)(2 * sizeof(int32_t) +
                                               fl->flow.n * (int)sizeof(LeoFlowSnapshot) +
                                               2 * sizeof(int32_t) +
                                               fl->flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
-                                              shadow_tail + calibration_tail);
+                                              shadow_tail + calibration_tail +
+                                              deferred_tail);
                     long prefix = sz - current_tail;
                     if (prefix > 0) {
                         long current_only = (long)(2 * sizeof(int32_t) +
@@ -1559,8 +1726,10 @@ int main(void) {
                         if (fo) {
                             built_cut = (long)fwrite(bytes, 1,
                                                      (size_t)(sz - calibration_tail -
-                                                              shadow_tail - 1), fo) ==
-                                        sz - calibration_tail - shadow_tail - 1;
+                                                              shadow_tail -
+                                                              deferred_tail - 1), fo) ==
+                                        sz - calibration_tail - shadow_tail -
+                                            deferred_tail - 1;
                             fclose(fo);
                         }
                         uint32_t fourteen = 14;
@@ -1569,8 +1738,11 @@ int main(void) {
                         if (fo) {
                             built_legacy14 = (long)fwrite(bytes, 1,
                                                          (size_t)(sz - calibration_tail -
-                                                                  shadow_tail - current_only), fo) ==
-                                             sz - calibration_tail - shadow_tail - current_only;
+                                                                  shadow_tail -
+                                                                  deferred_tail -
+                                                                  current_only), fo) ==
+                                             sz - calibration_tail - shadow_tail -
+                                                 deferred_tail - current_only;
                             fclose(fo);
                         }
                         uint32_t thirteen = 13;
@@ -1777,14 +1949,19 @@ int main(void) {
                     long calibration_tail = (long)(2 * sizeof(int32_t) +
                                                    sh->calibration.n *
                                                        (int)sizeof(LeoCalibrationReceipt));
+                    long deferred_tail = (long)(sizeof(int32_t) +
+                                                sh->school.n_deferred *
+                                                    (int)sizeof(LeoDeferredWonder));
                     uint32_t fifteen = 15;
                     memcpy(bytes + sizeof(uint32_t), &fifteen, sizeof fifteen);
                     FILE *fo = fopen(legacy, "wb");
                     if (fo) {
                         built_old = (long)fwrite(bytes, 1,
                                                  (size_t)(sz - calibration_tail -
-                                                          shadow_tail), fo) ==
-                                    sz - calibration_tail - shadow_tail;
+                                                          shadow_tail -
+                                                          deferred_tail), fo) ==
+                                    sz - calibration_tail - shadow_tail -
+                                        deferred_tail;
                         fclose(fo);
                     }
                     uint32_t sixteen = 16;
@@ -1792,15 +1969,18 @@ int main(void) {
                     fo = fopen(legacy16, "wb");
                     if (fo) {
                         built_compat = (long)fwrite(bytes, 1,
-                                                    (size_t)(sz - calibration_tail), fo) ==
-                                       sz - calibration_tail;
+                                                    (size_t)(sz - calibration_tail -
+                                                             deferred_tail), fo) ==
+                                       sz - calibration_tail - deferred_tail;
                         fclose(fo);
                     }
                     uint32_t seventeen = 17;
                     memcpy(bytes + sizeof(uint32_t), &seventeen, sizeof seventeen);
                     fo = fopen(truncated, "wb");
                     if (fo) {
-                        built_cut = (long)fwrite(bytes, 1, (size_t)(sz - 1), fo) == sz - 1;
+                        built_cut = (long)fwrite(bytes, 1,
+                                                (size_t)(sz - deferred_tail - 1), fo) ==
+                                    sz - deferred_tail - 1;
                         fclose(fo);
                     }
                 }


### PR DESCRIPTION
Persist a bounded pre-Wonder when a valid School candidate is blocked by the settled body. The same word may become askable after safety returns, while unrelated prompts and repeated unsafe encounters remain silent; state v18 migrates and fails soft around the new diary.

Quote: "A question can survive without becoming a command." - Sol

Method: The Arianna Method preserves unfinished curiosity without overruling the body that withheld it.