### PR TITLE
the Method keeps an answer with its question

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -3947,3 +3947,75 @@ cohorts reproduce this cross-attribution, and shadow ON/OFF states remain identi
 did not cause it. The observer now sees an address that School cannot yet preserve. Fixing that requires
 a separate turn-attribution contract; allowing this diagnostic winner to intervene would falsify the
 read-only plateau.
+
+## Phase A.42 — an answer keeps its address (2026-07-26)
+
+A.41 exposed a real destructive ambiguity but could not safely close it. After Leo asks `Suvin? Light
+or Cold?`, the next human phrase `Cat bird. Dark night.` strongly resembles waiting `nareth`, yet the
+ordinary adjacent-answer rule assigns it to `suvin`. Simply routing by the A.41 winner would create the
+opposite error: the same phrase may be the human correcting Leo's wrong `light/cold` hypothesis about
+`suvin`. Meaning alone cannot recover an unspoken human intention.
+
+A.42 therefore does not make the semantic shadow an answer router. It adds a separate transient
+`wonder-address` receipt immediately before grounding and gives it one narrow power: prevent a
+destructive close when a waiting sibling clearly owns the old semantic path. The active Wonder and
+all waiting siblings are compared by grounded glyph support only:
+
+```text
+glyph = min(1, matched_glyph_votes / 2) * matched_glyph_votes / all_glyph_votes
+sibling conflict iff sibling glyph >= 0.75
+                 and sibling - max(active, next sibling) >= 0.20
+```
+
+The contrastive co-occurrence constellation is deliberately not an authority here. It remains an A.41
+witness, useful for identity and future study, but a field cosine cannot decide who receives a human
+lesson. The address guard follows four asymmetric rules:
+
+1. Explicitly naming the active Wonder wins. A human can always correct Leo's hypotheses.
+2. Explicitly naming a waiting sibling guards the active Wonder but does not open or teach the sibling.
+3. A confident semantic sibling victory guards the active Wonder.
+4. Mixed or entirely unmatched meaning keeps the adjacency prior. Hypotheses are guesses, so novel
+   grounding must remain able to correct them.
+
+On a guarded turn, Leo's current reply proceeds through the ordinary field unchanged. The active word
+remains pending, its episode remains unresolved, the waiting sibling remains deferred, no learned map
+entry is written, and no debt relief or closure event is fabricated. The curiosity receipt says
+`address-guarded`. The sibling gains no mouth from being recognized.
+
+Nine direct contracts raised the suite from **292/292** to **301/301**. They cover sibling conflict,
+active semantic support, mixed ambiguity, explicit active correction, explicit sibling address, live
+state preservation, exact old-behaviour ablation, correction through the complete response path, and
+receipt ablation.
+
+The process matrix rebuilt both A.40 bodies, opened their first questions, persisted them, and forked
+seven turns from each sleeping body. Every default run was paired with
+`--no-wonder-attribution` from the same state and seed:
+
+```text
+cells=14
+actual guards=4
+active semantic=2
+active explicit correction=2
+sibling conflict statuses=4
+sibling explicit statuses=2
+ambiguous=2
+adjacent correction=2
+reply equal=14/14
+complete state equal outside guards=10/10
+guarded states correctly diverged from old destructive closure=4/4
+```
+
+The two question-mark cells recognized the sibling conflict but set `guarded=0`, because a question was
+never closable grounding. The two mixed cells and two unrelated corrections remained byte-identical to
+the ablation and resolved the active Wonder. Both explicit active corrections contradicted Leo's
+stored hypotheses, yet resolved normally and remained byte-identical to the old path. Thus protection
+did not become epistemic rigidity.
+
+A second complete A.42 run reproduced every normalized matrix field, receipt, state hash, and summary
+byte-for-byte. The isolated A.41 observer matrix was rerun with A.42 explicitly ablated and retained its
+original **16/16** reply/state equality and two visible cross-attribution receipts. The historical proof
+still describes the pre-guard organism; A.42 closes its destructive consequence without rewriting it.
+
+Leo can now preserve the difference between “this meaning resembles another unfinished question” and
+“therefore I know what the human meant.” When the address is clear enough to disqualify a close but not
+clear enough to claim another lesson, he keeps not knowing.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution
 
 all: leo
 
@@ -58,6 +58,9 @@ deferred-wonder-constellation: leo
 deferred-wonder-semantics: leo
 	./scripts/deferred_wonder_semantic_matrix.sh
 
+deferred-wonder-attribution: leo
+	./scripts/deferred_wonder_attribution_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -65,10 +68,12 @@ test: tests/test_leo.c leo.c
 	./scripts/test_shadow_dialogue_report.sh
 	./scripts/test_prewonder_dialogue_report.sh
 	./scripts/test_prewonder_shadow_dialogue_report.sh
+	./scripts/test_wonder_address_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
 	./scripts/test_deferred_wonder_semantic_matrix.sh
+	./scripts/test_deferred_wonder_attribution_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1649,6 +1649,7 @@ enum {
     LEO_CURIOSITY_BLOCKED_DISTRESS,
     LEO_CURIOSITY_ASKED_DEFERRED,
     LEO_CURIOSITY_BLOCKED_DEFERRED,
+    LEO_CURIOSITY_ADDRESS_GUARDED,
     LEO_CURIOSITY_NO_CANDIDATE,
     LEO_CURIOSITY_DISABLED,
     LEO_CURIOSITY_OUTCOME_COUNT
@@ -1692,6 +1693,40 @@ typedef struct {
     float   margin;
     uint8_t status;
 } LeoPreWonderShadowReceipt;
+
+/* A.42: before School grounds an adjacent answer, compare its semantic address
+ * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
+ * A confident sibling may veto a destructive close, but can never learn, open,
+ * or speak through this layer. Explicitly naming the active Wonder preserves
+ * the human's ability to correct Leo's original hypotheses. */
+#define LEO_WONDER_ADDRESS_MAX (LEO_DEFERRED_WONDER_MAX + 1)
+#define LEO_WONDER_ADDRESS_GLYPH_MIN 0.75f
+#define LEO_WONDER_ADDRESS_MARGIN    0.20f
+enum {
+    LEO_WONDER_ADDRESS_EMPTY = 0,
+    LEO_WONDER_ADDRESS_ACTIVE_EXPLICIT,
+    LEO_WONDER_ADDRESS_ACTIVE_SEMANTIC,
+    LEO_WONDER_ADDRESS_SIBLING_EXPLICIT,
+    LEO_WONDER_ADDRESS_SIBLING_CONFLICT,
+    LEO_WONDER_ADDRESS_AMBIGUOUS,
+    LEO_WONDER_ADDRESS_ADJACENT,
+    LEO_WONDER_ADDRESS_STATUS_COUNT
+};
+typedef struct {
+    char    word[LEO_HEARD_WORDLEN];
+    float   glyph;
+    uint8_t literal;
+    uint8_t active;
+} LeoWonderAddressCandidate;
+typedef struct {
+    uint64_t turn;
+    LeoWonderAddressCandidate candidates[LEO_WONDER_ADDRESS_MAX];
+    int     n_candidates;
+    int     winner;
+    float   margin;
+    uint8_t status;
+    uint8_t guarded;
+} LeoWonderAddressReceipt;
 
 enum {
     LEO_FLOW_QUIET = 0,
@@ -1820,6 +1855,9 @@ typedef struct {
     /* A.41: one-turn semantic echo among withheld questions. Diagnostic only;
      * neither School nor generation reads it. */
     LeoPreWonderShadowReceipt prewonder_shadow;
+    /* A.42: pre-grounding address witness. Only its narrow sibling-conflict
+     * veto is read by School; it cannot assign meaning to another question. */
+    LeoWonderAddressReceipt wonder_address;
     /* passive temporal proprioception (state v13): a bounded archaeological
      * record of what has been flowing through lived replies. No speech reader. */
     LeoFlow flow;
@@ -2090,6 +2128,7 @@ static int g_leo_school_on = 1;         /* --no-school → 0 (A.5: School revers
 static int g_leo_wonder_on = 1;         /* unfinished wonder: grounded alternatives + persistence across non-answers. --no-wonder restores the prior School contract. */
 static int g_leo_deferred_wonder_on = 1; /* pre-Wonder: a distress-blocked question remains askable when its word returns safely. */
 static int g_leo_prewonder_shadow_on = 1; /* read-only semantic echo among withheld questions; no speech reader. */
+static int g_leo_wonder_attribution_on = 1; /* address guard: a confident waiting sibling can veto, but never claim, an active answer. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
 static int g_leo_flow_on = 1;           /* passive temporal proprioception. --no-flow stops snapshots; no generation path reads them. */
 static int g_leo_shadow_on = 1;         /* counterfactual next-turn proposals. --no-shadow keeps Flow but writes no receipts. */
@@ -4877,6 +4916,22 @@ static int leo_school_glyph_votes(const Leo *leo, const char *text,
     return total;
 }
 
+/* Shared semantic support for one unfinished question. Two matching votes are
+ * needed for full evidence, and they must cover the prompt rather than hide in
+ * a mixed list of meanings. Field identity is deliberately absent here: it may
+ * shape an A.41 diagnostic tie, but cannot acquire authority over grounding. */
+static float leo_wonder_glyph_evidence(const int hist[GLYPH_COUNT], int total,
+                                       int glyph, int alt_glyph) {
+    int matched = 0;
+    if (glyph >= 0 && glyph < GLYPH_COUNT) matched += hist[glyph];
+    if (alt_glyph >= 0 && alt_glyph < GLYPH_COUNT &&
+        alt_glyph != glyph)
+        matched += hist[alt_glyph];
+    float evidence = fminf(1.0f, (float)matched / 2.0f);
+    float coverage = total > 0 ? (float)matched / (float)total : 0.0f;
+    return clampf(evidence * coverage, 0.0f, 1.0f);
+}
+
 /* I2: the dominant glyph of a text — its concept-slot. Histogram over content
  * words via the SEED map; the most-frequent CONCEPT glyph, or -1 if the text
  * grounds in no concept (a non-answer: pure unknowns, a copula, a counter-question). */
@@ -5024,14 +5079,10 @@ static void leo_prewonder_shadow_observe(
             (uint8_t)leo_flow_prompt_has_word(prompt, entry->word);
         if (candidate->literal) literals++;
 
-        int matched = 0;
         int g = entry->offered_glyph;
         int a = entry->offered_alt_glyph;
-        if (g >= 0 && g < GLYPH_COUNT) matched += hist[g];
-        if (a >= 0 && a < GLYPH_COUNT && a != g) matched += hist[a];
-        float evidence = fminf(1.0f, (float)matched / 2.0f);
-        float coverage = total > 0 ? (float)matched / (float)total : 0.0f;
-        candidate->glyph = clampf(evidence * coverage, 0.0f, 1.0f);
+        candidate->glyph =
+            leo_wonder_glyph_evidence(hist, total, g, a);
         if (field_token && field_weight)
             candidate->field = leo_prewonder_field_similarity(
                 entry->field_token, entry->field_weight,
@@ -5078,6 +5129,120 @@ static void leo_prewonder_shadow_observe(
         receipt.status = LEO_PREWONDER_SHADOW_QUIET;
     }
     leo->prewonder_shadow = receipt;
+}
+
+/* Determine whether the present human turn belongs to the active Wonder or
+ * strongly resembles one waiting sibling. Adjacency remains the default:
+ * hypotheses are guesses, so an unmatched answer may be a correction. Only a
+ * confident sibling victory (or its explicit name) may guard the active close.
+ * Even then the sibling receives no state transition; the guard preserves
+ * uncertainty rather than silently rerouting a lesson. Returns a proposed veto;
+ * the caller marks it `guarded` only when School had a closable answer. */
+static int leo_wonder_address_observe(Leo *leo, const char *prompt) {
+    LeoWonderAddressReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.turn = (uint64_t)leo->school.turn_clock;
+    receipt.winner = -1;
+    receipt.status = LEO_WONDER_ADDRESS_EMPTY;
+    if (!g_leo_wonder_attribution_on || !g_leo_school_on ||
+        !g_leo_wonder_on || !prompt || !leo->school.pending[0]) {
+        leo->wonder_address = receipt;
+        return 0;
+    }
+
+    int hist[GLYPH_COUNT];
+    int total = leo_school_glyph_votes(leo, prompt, hist, 1);
+    LeoWonderAddressCandidate *active =
+        &receipt.candidates[receipt.n_candidates++];
+    strncpy(active->word, leo->school.pending, LEO_HEARD_WORDLEN - 1);
+    active->word[LEO_HEARD_WORDLEN - 1] = 0;
+    active->active = 1;
+    active->literal =
+        (uint8_t)leo_flow_prompt_has_word(prompt, active->word);
+    active->glyph = leo_wonder_glyph_evidence(
+        hist, total, leo->school.pending_glyph,
+        leo->school.pending_alt_glyph);
+
+    int top_sibling = -1, second_sibling = -1;
+    int literal_sibling = -1;
+    for (int i = 0; i < leo->school.n_deferred; i++) {
+        const LeoDeferredWonder *entry = &leo->school.deferred[i];
+        LeoWonderAddressCandidate *candidate =
+            &receipt.candidates[receipt.n_candidates++];
+        strncpy(candidate->word, entry->word, LEO_HEARD_WORDLEN - 1);
+        candidate->word[LEO_HEARD_WORDLEN - 1] = 0;
+        candidate->literal =
+            (uint8_t)leo_flow_prompt_has_word(prompt, candidate->word);
+        candidate->glyph = leo_wonder_glyph_evidence(
+            hist, total, entry->offered_glyph,
+            entry->offered_alt_glyph);
+        int at = receipt.n_candidates - 1;
+        if (candidate->literal &&
+            (literal_sibling < 0 ||
+             strcmp(candidate->word,
+                    receipt.candidates[literal_sibling].word) < 0))
+            literal_sibling = at;
+        if (top_sibling < 0 ||
+            candidate->glyph > receipt.candidates[top_sibling].glyph ||
+            (candidate->glyph == receipt.candidates[top_sibling].glyph &&
+             strcmp(candidate->word,
+                    receipt.candidates[top_sibling].word) < 0)) {
+            second_sibling = top_sibling;
+            top_sibling = at;
+        } else if (second_sibling < 0 ||
+                   candidate->glyph >
+                       receipt.candidates[second_sibling].glyph ||
+                   (candidate->glyph ==
+                        receipt.candidates[second_sibling].glyph &&
+                    strcmp(candidate->word,
+                           receipt.candidates[second_sibling].word) < 0)) {
+            second_sibling = at;
+        }
+    }
+
+    if (active->literal) {
+        receipt.winner = 0;
+        receipt.margin = 1.0f;
+        receipt.status = LEO_WONDER_ADDRESS_ACTIVE_EXPLICIT;
+        leo->wonder_address = receipt;
+        return 0;
+    }
+    if (literal_sibling >= 0) {
+        receipt.winner = literal_sibling;
+        receipt.margin = 1.0f;
+        receipt.status = LEO_WONDER_ADDRESS_SIBLING_EXPLICIT;
+        leo->wonder_address = receipt;
+        return 1;
+    }
+
+    float sibling = top_sibling >= 0 ?
+        receipt.candidates[top_sibling].glyph : 0.0f;
+    float second = second_sibling >= 0 ?
+        receipt.candidates[second_sibling].glyph : 0.0f;
+    float sibling_runner = fmaxf(active->glyph, second);
+    float sibling_margin = clampf(sibling - sibling_runner, 0.0f, 1.0f);
+    float active_margin = clampf(active->glyph - sibling, 0.0f, 1.0f);
+    if (top_sibling >= 0 &&
+        sibling >= LEO_WONDER_ADDRESS_GLYPH_MIN &&
+        sibling_margin >= LEO_WONDER_ADDRESS_MARGIN) {
+        receipt.winner = top_sibling;
+        receipt.margin = sibling_margin;
+        receipt.status = LEO_WONDER_ADDRESS_SIBLING_CONFLICT;
+        leo->wonder_address = receipt;
+        return 1;
+    }
+    if (active->glyph >= LEO_WONDER_ADDRESS_GLYPH_MIN &&
+        active_margin >= LEO_WONDER_ADDRESS_MARGIN) {
+        receipt.winner = 0;
+        receipt.margin = active_margin;
+        receipt.status = LEO_WONDER_ADDRESS_ACTIVE_SEMANTIC;
+    } else if (active->glyph > 0.0f || sibling > 0.0f) {
+        receipt.status = LEO_WONDER_ADDRESS_AMBIGUOUS;
+    } else {
+        receipt.status = LEO_WONDER_ADDRESS_ADJACENT;
+    }
+    leo->wonder_address = receipt;
+    return 0;
 }
 
 /* I2: bind a taught word to the answer's concept (its dominant glyph), growing
@@ -6269,6 +6434,8 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     if (!prompt || !*prompt) return leo_chain(leo, LEO_CHAIN_MIN, out, max_len);
 
     leo->school.returned_episode = -1;       /* one-reply diagnostic; meaning itself is local below */
+    memset(&leo->wonder_address, 0, sizeof leo->wonder_address);
+    leo->wonder_address.winner = -1;
     if (leo->school.turn_clock < LONG_MAX) leo->school.turn_clock++;
     leo_ingest(leo, prompt);                 /* Leo hears you */
     leo_field_chambers_feel_text(leo, prompt); /* prompt drives the chamber EXT inputs */
@@ -6309,7 +6476,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     /* A.5/W-2: a question closes only on a grounded human answer. The old School
      * cleared it on every next turn, including counter-questions and pure unknowns;
      * unfinished wonder now survives those turns and may return on resonance. */
-    int was_answer = 0, wonder_reask = 0;
+    int was_answer = 0, wonder_reask = 0, address_guarded = 0;
     uint8_t flow_event = 0;
     uint64_t flow_wonder_id = 0;
     if (g_leo_school_on && leo->school.pending[0]) {
@@ -6344,7 +6511,13 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
             int open_episode = leo_wonder_find_open(leo, leo->school.pending);
             if (open_episode >= 0)
                 flow_wonder_id = leo_wonder_episode_id(&leo->school.wonders[open_episode]);
+            int address_veto = leo_wonder_address_observe(leo, prompt);
             int g = leo_school_grounded_answer(leo, prompt);
+            if (g >= 0 && address_veto) {
+                g = -1;
+                address_guarded = 1;
+                leo->wonder_address.guarded = 1;
+            }
             if (g >= 0) {
                 if (leo->school.pending_glyph >= 0) {
                     leo->school.guesses++;
@@ -6549,6 +6722,8 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
         curiosity.outcome = LEO_CURIOSITY_DISABLED;
     else if (wonder_reask)
         curiosity.outcome = LEO_CURIOSITY_REASKED;
+    else if (address_guarded)
+        curiosity.outcome = LEO_CURIOSITY_ADDRESS_GUARDED;
     else if (was_answer)
         curiosity.outcome = (flow_event & LEO_FLOW_WONDER_RESOLVED) ?
             LEO_CURIOSITY_RESOLVED : LEO_CURIOSITY_CONTINUED;
@@ -7801,6 +7976,36 @@ static void print_prewonder_shadow_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_address_stats(const Leo *leo) {
+    if (!g_leo_wonder_attribution_on || !leo ||
+        leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
+        return;
+    const LeoWonderAddressReceipt *receipt = &leo->wonder_address;
+    static const char *statuses[LEO_WONDER_ADDRESS_STATUS_COUNT] = {
+        "empty", "active-explicit", "active-semantic",
+        "sibling-explicit", "sibling-conflict", "ambiguous", "adjacent"
+    };
+    int status = receipt->status < LEO_WONDER_ADDRESS_STATUS_COUNT ?
+        receipt->status : LEO_WONDER_ADDRESS_EMPTY;
+    const char *winner =
+        receipt->winner >= 0 && receipt->winner < receipt->n_candidates ?
+            receipt->candidates[receipt->winner].word : "none";
+    const char *active =
+        receipt->n_candidates > 0 ? receipt->candidates[0].word : "none";
+    printf("     [wonder-address: turn=%llu status=%s winner=%s active=%s margin=%.3f guarded=%u entries=",
+           (unsigned long long)receipt->turn, statuses[status], winner,
+           active, (double)receipt->margin, (unsigned)receipt->guarded);
+    for (int i = 0; i < receipt->n_candidates; i++) {
+        const LeoWonderAddressCandidate *candidate =
+            &receipt->candidates[i];
+        printf("%s%s:%.3f/%u/%u", i ? "|" : "", candidate->word,
+               (double)candidate->glyph, (unsigned)candidate->literal,
+               (unsigned)candidate->active);
+    }
+    if (receipt->n_candidates == 0) printf("none");
+    printf("]\n");
+}
+
 static void print_flow_stats(const Leo *leo) {
     if (!g_leo_flow_on || !leo || leo->flow.n <= 0) return;
     const LeoFlowSnapshot *s = leo_flow_at(&leo->flow, leo->flow.n - 1);
@@ -7821,7 +8026,7 @@ static void print_flow_stats(const Leo *leo) {
         static const char *outcomes[LEO_CURIOSITY_OUTCOME_COUNT] = {
             "none", "asked", "reasked", "resolved", "continued",
             "blocked-distress", "asked-deferred", "blocked-deferred",
-            "no-candidate", "disabled"
+            "address-guarded", "no-candidate", "disabled"
         };
         printf("     [curiosity: turn=%llu outcome=%s candidate=%s deferred=%s heard=%d distress=%.3f gate=%.3f]\n",
                (unsigned long long)leo->curiosity.turn,
@@ -8003,6 +8208,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder")) g_leo_wonder_on = 0;
         else if (!strcmp(argv[i], "--no-deferred-wonder")) g_leo_deferred_wonder_on = 0;
         else if (!strcmp(argv[i], "--no-prewonder-shadow")) g_leo_prewonder_shadow_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
         else if (!strcmp(argv[i], "--no-flow")) g_leo_flow_on = 0;
         else if (!strcmp(argv[i], "--no-shadow")) g_leo_shadow_on = 0;
@@ -8213,6 +8419,7 @@ int main(int argc, char **argv) {
                 printf("             mean>  top=%s(%.2f) gap=%.2f\n",
                        GLYPH_NAMES[top], leo.gamma_meaning[top], leo.gamma_gap);
             }
+            print_wonder_address_stats(&leo);
             print_prewonder_shadow_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
@@ -8269,6 +8476,7 @@ int main(int argc, char **argv) {
                 printf("     [wonder-return: %s -> %s, recalls=%d]\n",
                        ep->word, GLYPH_NAMES[(int)ep->answer_glyph], ep->recalls);
             }
+            print_wonder_address_stats(&leo);
             print_prewonder_shadow_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -211,6 +211,41 @@ pending word, and every candidate's `glyph/field/combined/literal` values.
 `prewonder_shadow_dialogue_report.awk` is the only parser. The receipt is
 transient and has no persisted or cognitive reader.
 
+Run the active/waiting turn-attribution matrix:
+
+```sh
+make deferred-wonder-attribution
+```
+
+A.42 places a narrow address guard immediately before School grounds an
+answer. It compares the active Wonder and every waiting pre-Wonder using the
+same two-hypothesis glyph coverage as A.41, but does not admit field cosine
+into an authoritative decision. The co-occurrence field remains evidence;
+it cannot decide which question receives a human lesson.
+
+Adjacency remains the default because Leo's hypotheses are guesses: a human
+answer that matches no stored path may be correcting him. Explicitly naming
+the active Wonder always permits that correction. A waiting sibling can veto
+the active close only when it is named, or when its glyph support is at least
+`0.75` and leads both the active question and the next sibling by `0.20`.
+The veto does not open, resolve, teach, or speak for the sibling. It only
+preserves the current uncertainty.
+
+`--debug-field` emits `[wonder-address: ...]` with the active identity, status,
+winner, margin, actual guard bit, and every candidate's
+`glyph/literal/active` tuple. `--no-wonder-attribution` restores the previous
+grounding path. The A.41 semantic-shadow matrix passes that ablation
+explicitly so its observer-only result remains an isolated historical proof.
+
+The checked matrix grows two independent three-question bodies, opens the
+first question, saves it, and forks seven post-sleep turns per body:
+semantic and explicit sibling conflicts, active semantic grounding, explicit
+active correction, mixed meaning, an unrelated correction, and a sibling
+question. Default and ablated runs use the same seed and starting state. All
+non-guard cells require complete saved-state equality; guard cells require the
+active question to remain unresolved while the ablation reproduces the old
+cross-attribution.
+
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,
 but only through the narrow visible sensors above. Selecting a move from shadow

--- a/scripts/deferred_wonder_attribution_cases.tsv
+++ b/scripts/deferred_wonder_attribution_cases.tsv
@@ -1,0 +1,8 @@
+case	kind	prompt	expected_status	expected_winner_slot	expected_guarded	on_curiosity	on_pending_slot	on_resolved	off_curiosity	off_pending_slot	off_resolved	expect_reply_equal	expect_state_equal
+sibling-semantic	guard	Cat bird. Dark night.	sibling-conflict	2	1	address-guarded	1	0	resolved	0	1	any	0
+sibling-explicit	guard	{slot2} is a dark animal.	sibling-explicit	2	1	address-guarded	1	0	resolved	0	1	any	0
+active-semantic	active	Bright sun. Cold winter.	active-semantic	1	0	resolved	0	1	resolved	0	1	1	1
+active-correction	correction	{slot1} is a dark animal.	active-explicit	1	0	resolved	0	1	resolved	0	1	1	1
+mixed	ambiguous	Bright sun and dark night.	ambiguous	0	0	resolved	0	1	resolved	0	1	1	1
+adjacent-correction	correction	Water sea.	adjacent	0	0	resolved	0	1	resolved	0	1	1	1
+sibling-question	question	Cat bird. Dark night?	sibling-conflict	2	0	continued	1	0	continued	1	0	1	1

--- a/scripts/deferred_wonder_attribution_matrix.sh
+++ b/scripts/deferred_wonder_attribution_matrix.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# A.42: pre-grounding ownership among one active and several waiting Wonders.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GROUPS_FILE="${LEO_ATTRIBUTION_GROUPS:-$ROOT/scripts/deferred_wonder_constellation_groups.tsv}"
+CASES_FILE="${LEO_ATTRIBUTION_CASES:-$ROOT/scripts/deferred_wonder_attribution_cases.tsv}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-attribution-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+for fixture in "$GROUPS_FILE" "$CASES_FILE"; do
+    [ -f "$fixture" ] || {
+        printf 'attribution fixture not found: %s\n' "$fixture" >&2
+        exit 2
+    }
+done
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 14 || $1 != "case" || $2 != "kind" ||
+            $3 != "prompt" || $4 != "expected_status" ||
+            $5 != "expected_winner_slot" || $6 != "expected_guarded" ||
+            $7 != "on_curiosity" || $8 != "on_pending_slot" ||
+            $9 != "on_resolved" || $10 != "off_curiosity" ||
+            $11 != "off_pending_slot" || $12 != "off_resolved" ||
+            $13 != "expect_reply_equal" || $14 != "expect_state_equal")
+            exit 1
+        next
+    }
+    {
+        if (NF != 14 || seen[$1]++ || $5 !~ /^[0-3]$/ ||
+            $6 !~ /^[01]$/ || $8 !~ /^[0-3]$/ || $9 !~ /^[01]$/ ||
+            $11 !~ /^[0-3]$/ || $12 !~ /^[01]$/ ||
+            $13 !~ /^(0|1|any)$/ || $14 !~ /^[01]$/)
+            exit 1
+        kinds[$2]++
+        rows++
+    }
+    END {
+        if (rows != 7 || kinds["guard"] != 2 ||
+            kinds["correction"] != 2 || kinds["question"] != 1)
+            exit 1
+    }
+' "$CASES_FILE" || {
+    printf 'invalid attribution cases: %s\n' "$CASES_FILE" >&2
+    exit 2
+}
+
+mkdir -p "$OUT/lives"
+PLAN="$OUT/plan.tsv"
+RECEIPTS="$OUT/receipts.tsv"
+MATRIX="$OUT/matrix.tsv"
+SUMMARY="$OUT/summary.txt"
+
+group_field() {
+    local group="$1"
+    local slot="$2"
+    local field="$3"
+    awk -F '\t' -v group="$group" -v slot="$slot" -v field="$field" '
+        NR > 1 && $1 == group && $4 == slot {
+            print $field
+            exit
+        }
+    ' "$GROUPS_FILE"
+}
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+address_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_address_dialogue_report.awk" "$1"
+}
+
+curiosity_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/curiosity_dialogue_report.awk" "$1"
+}
+
+inventory_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/prewonder_dialogue_report.awk" "$1"
+}
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+printf 'cell\tgroup\tcohort\tseed\tcase\tkind\tprompt\texpected_status\texpected_winner\n' \
+    > "$PLAN"
+awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
+    "$GROUPS_FILE" |
+while IFS=$'\t' read -r group cohort seed; do
+    while IFS=$'\t' read -r case kind prompt status winner_slot _; do
+        [ "$case" = "case" ] && continue
+        slot1="$(group_field "$group" 1 5)"
+        slot2="$(group_field "$group" 2 5)"
+        prompt="${prompt//\{slot1\}/$slot1}"
+        prompt="${prompt//\{slot2\}/$slot2}"
+        winner="none"
+        if [ "$winner_slot" -gt 0 ]; then
+            winner="$(group_field "$group" "$winner_slot" 5)"
+        fi
+        printf '%s-%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$group" "$case" "$group" "$cohort" "$seed" "$case" \
+            "$kind" "$prompt" "$status" "$winner" >> "$PLAN"
+    done < "$CASES_FILE"
+done
+
+if [ "${LEO_ATTRIBUTION_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"$ROOT/scripts/deferred_wonder_constellation_matrix.sh" "$OUT/a40-baseline" \
+    > "$OUT/a40-baseline.log"
+
+printf 'cell\tturn\tstatus\twinner\tactive\tmargin\tguarded\taddress_entries\ton_curiosity\ton_count\ton_pending\ton_resolved\toff_curiosity\toff_count\toff_pending\toff_resolved\tprompt\ton_reply\toff_reply\n' \
+    > "$RECEIPTS"
+printf 'cell\tgroup\tcohort\tcase\tkind\tstatus\twinner\tguarded\ton_curiosity\ton_pending\ton_resolved\toff_curiosity\toff_pending\toff_resolved\treply_equal\tstate_equal\ton_sha256\toff_sha256\toutput\n' \
+    > "$MATRIX"
+
+group_index=0
+awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
+    "$GROUPS_FILE" |
+while IFS=$'\t' read -r group cohort seed; do
+    group_index=$((group_index + 1))
+    group_dir="$OUT/lives/$group"
+    mkdir -p "$group_dir"
+    ready="$OUT/a40-baseline/groups/$group/ready.state"
+    [ -f "$ready" ] || {
+        printf 'missing A.40 ready body: %s\n' "$ready" >&2
+        exit 1
+    }
+    active="$(group_field "$group" 1 5)"
+    expected_question="$(group_field "$group" 1 9)"
+    cp "$ready" "$group_dir/open.state"
+    "$ROOT/leo" --load "$group_dir/open.state" \
+        --seed "$((seed + 1700))" --respond "$active" --debug-field \
+        --save "$group_dir/open.state" > "$group_dir/open.log" 2>&1
+    [ "$(reply_from_log "$group_dir/open.log")" = "$expected_question" ] || {
+        printf '%s failed to open the active control\n' "$group" >&2
+        exit 1
+    }
+
+    case_index=0
+    while IFS=$'\t' read -r case kind raw_prompt expected_status \
+        winner_slot expected_guarded expected_on_curiosity \
+        expected_on_pending_slot expected_on_resolved \
+        expected_off_curiosity expected_off_pending_slot \
+        expected_off_resolved expected_reply_equal expected_state_equal; do
+        [ "$case" = "case" ] && continue
+        case_index=$((case_index + 1))
+        cell="$group-$case"
+        cell_dir="$group_dir/$case"
+        mkdir -p "$cell_dir"
+        prompt="${raw_prompt//\{slot1\}/$active}"
+        slot2="$(group_field "$group" 2 5)"
+        prompt="${prompt//\{slot2\}/$slot2}"
+        expected_winner="none"
+        if [ "$winner_slot" -gt 0 ]; then
+            expected_winner="$(group_field "$group" "$winner_slot" 5)"
+        fi
+        expected_on_pending="none"
+        if [ "$expected_on_pending_slot" -gt 0 ]; then
+            expected_on_pending="$(
+                group_field "$group" "$expected_on_pending_slot" 5
+            )"
+        fi
+        expected_off_pending="none"
+        if [ "$expected_off_pending_slot" -gt 0 ]; then
+            expected_off_pending="$(
+                group_field "$group" "$expected_off_pending_slot" 5
+            )"
+        fi
+
+        cp "$group_dir/open.state" "$cell_dir/on.state"
+        cp "$group_dir/open.state" "$cell_dir/off.state"
+        run_seed=$((seed + 2000 + group_index * 100 + case_index))
+        "$ROOT/leo" --load "$cell_dir/on.state" --seed "$run_seed" \
+            --respond "$prompt" --debug-field --save "$cell_dir/on.state" \
+            > "$cell_dir/on.log" 2>&1
+        "$ROOT/leo" --load "$cell_dir/off.state" --seed "$run_seed" \
+            --respond "$prompt" --debug-field --no-wonder-attribution \
+            --save "$cell_dir/off.state" > "$cell_dir/off.log" 2>&1
+
+        address="$(address_from_log "$cell_dir/on.log" "$cell" "$run_seed")"
+        on_curiosity="$(
+            curiosity_from_log "$cell_dir/on.log" "$cell" "$run_seed"
+        )"
+        off_curiosity="$(
+            curiosity_from_log "$cell_dir/off.log" "$cell" "$run_seed"
+        )"
+        on_inventory="$(
+            inventory_from_log "$cell_dir/on.log" "$cell" "$run_seed"
+        )"
+        off_inventory="$(
+            inventory_from_log "$cell_dir/off.log" "$cell" "$run_seed"
+        )"
+        [ -n "$address" ] && [ -n "$on_curiosity" ] &&
+        [ -n "$off_curiosity" ] && [ -n "$on_inventory" ] &&
+        [ -n "$off_inventory" ] || {
+            printf '%s missing diagnostic receipt\n' "$cell" >&2
+            exit 1
+        }
+
+        IFS=$'\t' read -r _ _ turn status winner address_active margin \
+            guarded address_entries <<< "$address"
+        IFS=$'\t' read -r _ _ on_turn on_outcome _ _ _ _ _ \
+            <<< "$on_curiosity"
+        IFS=$'\t' read -r _ _ off_turn off_outcome _ _ _ _ _ \
+            <<< "$off_curiosity"
+        IFS=$'\t' read -r _ _ on_inventory_turn on_count on_pending \
+            on_episodes on_resolved on_entries <<< "$on_inventory"
+        IFS=$'\t' read -r _ _ off_inventory_turn off_count off_pending \
+            off_episodes off_resolved off_entries <<< "$off_inventory"
+        [ "$turn" = "$on_turn" ] &&
+        [ "$turn" = "$off_turn" ] &&
+        [ "$turn" = "$on_inventory_turn" ] &&
+        [ "$turn" = "$off_inventory_turn" ] || {
+            printf '%s diagnostic turn disagreement\n' "$cell" >&2
+            exit 1
+        }
+
+        on_reply="$(reply_from_log "$cell_dir/on.log")"
+        off_reply="$(reply_from_log "$cell_dir/off.log")"
+        reply_equal=0
+        state_equal=0
+        [ "$on_reply" = "$off_reply" ] && reply_equal=1
+        on_sha="$(sha256_file "$cell_dir/on.state")"
+        off_sha="$(sha256_file "$cell_dir/off.state")"
+        [ "$on_sha" = "$off_sha" ] && state_equal=1
+
+        [ "$status" = "$expected_status" ] &&
+        [ "$winner" = "$expected_winner" ] &&
+        [ "$address_active" = "$active" ] &&
+        [ "$guarded" = "$expected_guarded" ] &&
+        [ "$on_outcome" = "$expected_on_curiosity" ] &&
+        [ "$on_pending" = "$expected_on_pending" ] &&
+        [ "$on_resolved" = "$expected_on_resolved" ] &&
+        [ "$off_outcome" = "$expected_off_curiosity" ] &&
+        [ "$off_pending" = "$expected_off_pending" ] &&
+        [ "$off_resolved" = "$expected_off_resolved" ] &&
+        { [ "$expected_reply_equal" = "any" ] ||
+          [ "$reply_equal" = "$expected_reply_equal" ]; } &&
+        [ "$state_equal" = "$expected_state_equal" ] || {
+            printf '%s contract failed: status=%s winner=%s active=%s guarded=%s on=%s/%s/%s off=%s/%s/%s reply_equal=%s state_equal=%s\n' \
+                "$cell" "$status" "$winner" "$address_active" "$guarded" \
+                "$on_outcome" "$on_pending" "$on_resolved" \
+                "$off_outcome" "$off_pending" "$off_resolved" \
+                "$reply_equal" "$state_equal" >&2
+            exit 1
+        }
+
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$cell" "$turn" "$status" "$winner" "$address_active" \
+            "$margin" "$guarded" "$address_entries" "$on_outcome" \
+            "$on_count" "$on_pending" "$on_resolved" "$off_outcome" \
+            "$off_count" "$off_pending" "$off_resolved" "$prompt" \
+            "$on_reply" "$off_reply" >> "$RECEIPTS"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$cell" "$group" "$cohort" "$case" "$kind" "$status" \
+            "$winner" "$guarded" "$on_outcome" "$on_pending" \
+            "$on_resolved" "$off_outcome" "$off_pending" \
+            "$off_resolved" "$reply_equal" "$state_equal" "$on_sha" \
+            "$off_sha" "$cell_dir" >> "$MATRIX"
+    done < "$CASES_FILE"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        cells++
+        status[$6]++
+        guarded += $8
+        replies += $15
+        states += $16
+        if ($8 == 1 && $16 == 0) guarded_state_diverged++
+    }
+    END {
+        print "cells\tguarded\tactive_semantic\tactive_explicit\tsibling_conflict\tsibling_explicit\tambiguous\tadjacent\treply_equal\tstate_equal\tguarded_state_diverged"
+        print cells "\t" guarded "\t" status["active-semantic"] "\t" \
+              status["active-explicit"] "\t" status["sibling-conflict"] "\t" \
+              status["sibling-explicit"] "\t" status["ambiguous"] "\t" \
+              status["adjacent"] "\t" replies "\t" states "\t" \
+              guarded_state_diverged
+    }
+' "$MATRIX" > "$SUMMARY"
+
+cat "$SUMMARY"
+printf '\nmatrix: %s\nreceipts: %s\n' "$MATRIX" "$RECEIPTS"

--- a/scripts/deferred_wonder_semantic_matrix.sh
+++ b/scripts/deferred_wonder_semantic_matrix.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# A.41: read-only semantic echoes among withheld questions.
+# A.41: read-only semantic echoes among withheld questions. A.42 attribution
+# is explicitly ablated below so this remains the historical observer proof.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -162,6 +163,7 @@ while IFS=$'\t' read -r cell group cohort seed case kind target prompt \
         cp "$base" "$cell_dir/pre.state"
         "$ROOT/leo" --load "$cell_dir/pre.state" --seed "$((seed + 700))" \
             --respond "$opened" --debug-field --no-prewonder-shadow \
+            --no-wonder-attribution \
             --save "$cell_dir/pre.state" > "$cell_dir/pre.log" 2>&1
         [ "$(reply_from_log "$cell_dir/pre.log")" = "$expected_question" ] || {
             printf '%s failed to open occupied control\n' "$cell" >&2
@@ -174,10 +176,12 @@ while IFS=$'\t' read -r cell group cohort seed case kind target prompt \
     cp "$run_base" "$cell_dir/off.state"
     run_seed=$((seed + 1000 + case_index))
     "$ROOT/leo" --load "$cell_dir/on.state" --seed "$run_seed" \
-        --respond "$prompt" --debug-field --save "$cell_dir/on.state" \
+        --respond "$prompt" --debug-field --no-wonder-attribution \
+        --save "$cell_dir/on.state" \
         > "$cell_dir/on.log" 2>&1
     "$ROOT/leo" --load "$cell_dir/off.state" --seed "$run_seed" \
         --respond "$prompt" --debug-field --no-prewonder-shadow \
+        --no-wonder-attribution \
         --save "$cell_dir/off.state" > "$cell_dir/off.log" 2>&1
 
     shadow="$(shadow_from_log "$cell_dir/on.log" "$cell" "$run_seed")"

--- a/scripts/test_deferred_wonder_attribution_matrix.sh
+++ b/scripts/test_deferred_wonder_attribution_matrix.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_ATTRIBUTION_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_attribution_matrix.sh" "$OUT/plan" \
+    > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 9 || $1 != "cell" || $2 != "group" ||
+            $5 != "case" || $6 != "kind" ||
+            $8 != "expected_status" || $9 != "expected_winner")
+            exit 1
+        next
+    }
+    {
+        if (NF != 9 || cells[$1]++)
+            exit 1
+        groups[$2]++
+        cases[$5]++
+        status[$8]++
+        rows++
+    }
+    END {
+        if (rows != 14 || length(groups) != 2 || length(cases) != 7 ||
+            status["sibling-conflict"] != 4 ||
+            status["sibling-explicit"] != 2 ||
+            status["active-semantic"] != 2 ||
+            status["active-explicit"] != 2 ||
+            status["ambiguous"] != 2 ||
+            status["adjacent"] != 2)
+            exit 1
+        for (group in groups)
+            if (groups[group] != 7)
+                exit 1
+        for (case in cases)
+            if (cases[case] != 2)
+                exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder attribution plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder attribution matrix plan: ok\n'

--- a/scripts/test_wonder_address_dialogue_report.sh
+++ b/scripts/test_wonder_address_dialogue_report.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-address: turn=13 status=sibling-conflict winner=nareth active=suvin margin=1.000 guarded=1 entries=suvin:0.000/0/1|nareth:1.000/0/0]
+EOF
+
+got="$(
+    awk -v scenario=sibling-semantic -v seed=771 \
+        -f "$ROOT/scripts/wonder_address_dialogue_report.awk" "$TMP"
+)"
+expected=$'sibling-semantic\t771\t13\tsibling-conflict\tnareth\tsuvin\t1.000\t1\tsuvin:0.000/0/1|nareth:1.000/0/0'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder address parser output:\n%s\n' "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder address report parser: ok\n'

--- a/scripts/wonder_address_dialogue_report.awk
+++ b/scripts/wonder_address_dialogue_report.awk
@@ -1,0 +1,24 @@
+# Extract one transient pre-grounding Wonder address receipt per lived turn.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    start, tail, parts) {
+    start = index(line, key "=")
+    if (!start) return ""
+    tail = substr(line, start + length(key) + 1)
+    split(tail, parts, /[ ]/)
+    gsub(/\]$/, "", parts[1])
+    return parts[1]
+}
+
+/\[wonder-address: turn=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed), value_after($0, "turn"),
+           value_after($0, "status"), value_after($0, "winner"),
+           value_after($0, "active"), value_after($0, "margin"),
+           value_after($0, "guarded"), value_after($0, "entries")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -20,6 +20,26 @@ static int succ_cb(int dst, float count, void *ud) {
     (void)dst; (void)count; (*(int *)ud)++; return 0;
 }
 
+static void seed_wonder_address_body(Leo *leo) {
+    leo_init(leo);
+    leo->school.turn_clock = 1;
+    leo_deferred_wonder_remember(
+        leo, "nareth", semtok_find_glyph("dark"),
+        semtok_find_glyph("animal"), 1, NULL, NULL);
+    leo->school.turn_clock = 2;
+    leo_deferred_wonder_remember(
+        leo, "flom", semtok_find_glyph("fire"),
+        semtok_find_glyph("anger"), 1, NULL, NULL);
+    leo->school.turn_clock = 3;
+    strncpy(leo->school.pending, "suvin",
+            sizeof leo->school.pending - 1);
+    leo->school.pending_glyph = semtok_find_glyph("light");
+    leo->school.pending_alt_glyph = semtok_find_glyph("cold");
+    leo_wonder_open(leo, leo->school.pending,
+                    leo->school.pending_glyph,
+                    leo->school.pending_alt_glyph);
+}
+
 int main(void) {
     printf("test_leo (step 0)\n");
 
@@ -1374,6 +1394,127 @@ int main(void) {
         g_leo_prewonder_shadow_on = prev_shadow;
         g_leo_wonder_on = prev_wonder;
         g_leo_deferred_wonder_on = prev_deferred;
+    }
+
+    /* A.42: semantic address is checked before an adjacent answer can close
+     * the active Wonder. A sibling conflict may preserve uncertainty, never
+     * claim the answer; explicit active naming keeps correction possible. */
+    {
+        int prev_attr = g_leo_wonder_attribution_on;
+        int prev_school = g_leo_school_on;
+        int prev_wonder = g_leo_wonder_on;
+        g_leo_wonder_attribution_on = 1;
+        g_leo_school_on = 1;
+        g_leo_wonder_on = 1;
+
+        Leo address;
+        seed_wonder_address_body(&address);
+        LeoSchool school_before = address.school;
+        int veto = leo_wonder_address_observe(
+            &address, "Cat bird. Dark night.");
+        const LeoWonderAddressReceipt *receipt = &address.wonder_address;
+        CHECK(veto &&
+              receipt->status ==
+                  LEO_WONDER_ADDRESS_SIBLING_CONFLICT &&
+              receipt->winner > 0 &&
+              !strcmp(receipt->candidates[receipt->winner].word,
+                      "nareth") &&
+              !memcmp(&school_before, &address.school,
+                      sizeof address.school),
+              "wonder-address: a confident sibling conflict is visible before grounding without mutating School");
+
+        veto = leo_wonder_address_observe(
+            &address, "Bright sun. Cold winter.");
+        CHECK(!veto &&
+              address.wonder_address.status ==
+                  LEO_WONDER_ADDRESS_ACTIVE_SEMANTIC &&
+              address.wonder_address.winner == 0,
+              "wonder-address: grounded active meaning keeps the adjacent answer");
+
+        veto = leo_wonder_address_observe(
+            &address, "Bright sun and dark night.");
+        CHECK(!veto &&
+              address.wonder_address.status ==
+                  LEO_WONDER_ADDRESS_AMBIGUOUS &&
+              address.wonder_address.winner < 0,
+              "wonder-address: mixed meaning cannot choose an owner");
+
+        veto = leo_wonder_address_observe(
+            &address, "Suvin is a dark animal.");
+        CHECK(!veto &&
+              address.wonder_address.status ==
+                  LEO_WONDER_ADDRESS_ACTIVE_EXPLICIT &&
+              address.wonder_address.winner == 0,
+              "wonder-address: naming the active Wonder permits correction of Leo's hypotheses");
+
+        veto = leo_wonder_address_observe(
+            &address, "Nareth is a dark animal.");
+        CHECK(veto &&
+              address.wonder_address.status ==
+                  LEO_WONDER_ADDRESS_SIBLING_EXPLICIT &&
+              address.wonder_address.winner > 0,
+              "wonder-address: naming a waiting sibling cannot close the active Wonder");
+        leo_free(&address);
+
+        Leo guarded;
+        seed_wonder_address_body(&guarded);
+        char out[512];
+        srand(4201);
+        leo_respond(&guarded, "Cat bird. Dark night.", out, sizeof out);
+        int open = leo_wonder_find_open(&guarded, "suvin");
+        CHECK(!strcmp(guarded.school.pending, "suvin") &&
+              open >= 0 && !guarded.school.wonders[open].resolved &&
+              !leo_school_is_learned(&guarded, "suvin") &&
+              guarded.curiosity.outcome ==
+                  LEO_CURIOSITY_ADDRESS_GUARDED &&
+              guarded.wonder_address.guarded,
+              "wonder-address: the live guard preserves the active question and teaches neither identity");
+        leo_free(&guarded);
+
+        Leo legacy;
+        seed_wonder_address_body(&legacy);
+        g_leo_wonder_attribution_on = 0;
+        srand(4201);
+        leo_respond(&legacy, "Cat bird. Dark night.", out, sizeof out);
+        CHECK(!legacy.school.pending[0] &&
+              leo_school_is_learned(&legacy, "suvin") &&
+              legacy.curiosity.outcome == LEO_CURIOSITY_RESOLVED &&
+              legacy.wonder_address.status ==
+                  LEO_WONDER_ADDRESS_EMPTY,
+              "wonder-address: ablation reproduces the prior cross-attribution exactly");
+        leo_free(&legacy);
+
+        Leo correction;
+        seed_wonder_address_body(&correction);
+        g_leo_wonder_attribution_on = 1;
+        srand(4202);
+        leo_respond(&correction, "Suvin is a dark animal.",
+                    out, sizeof out);
+        CHECK(!correction.school.pending[0] &&
+              leo_school_is_learned(&correction, "suvin") &&
+              correction.curiosity.outcome ==
+                  LEO_CURIOSITY_RESOLVED &&
+              correction.wonder_address.status ==
+                  LEO_WONDER_ADDRESS_ACTIVE_EXPLICIT &&
+              !correction.wonder_address.guarded,
+              "wonder-address: an explicit human correction still resolves the active question");
+        leo_free(&correction);
+
+        Leo ablated;
+        seed_wonder_address_body(&ablated);
+        g_leo_wonder_attribution_on = 0;
+        veto = leo_wonder_address_observe(
+            &ablated, "Cat bird. Dark night.");
+        CHECK(!veto &&
+              ablated.wonder_address.status ==
+                  LEO_WONDER_ADDRESS_EMPTY &&
+              ablated.wonder_address.n_candidates == 0,
+              "wonder-address: ablation removes the transient address witness");
+        leo_free(&ablated);
+
+        g_leo_wonder_attribution_on = prev_attr;
+        g_leo_school_on = prev_school;
+        g_leo_wonder_on = prev_wonder;
     }
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the


### PR DESCRIPTION
Method: The Arianna Method preserves conversational address when meaning alone cannot justify reassignment.

Add a transient pre-grounding address receipt and a narrow sibling-conflict guard. A guarded turn preserves the active Wonder without teaching or opening the waiting sibling, while explicit active naming and unmatched adjacency keep human correction possible.

Evidence: 301/301 contracts; ASan/UBSan smoke; two deterministic 14-cell process runs; 14/14 reply equality, 10/10 non-guard state equality, 4/4 guarded divergence from destructive closure; isolated A.41 replay unchanged.

Quote: "An answer may lose its certainty without losing its address." - Sol