### PR TITLE
Arianna Method lets a question yield the mouth without losing its history

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4019,3 +4019,63 @@ still describes the pre-guard organism; A.42 closes its destructive consequence 
 Leo can now preserve the difference between “this meaning resembles another unfinished question” and
 “therefore I know what the human meant.” When the address is clear enough to disqualify a close but not
 clear enough to claim another lesson, he keeps not knowing.
+
+## Phase A.43 — one mouth can change questions without losing the first (2026-07-26)
+
+A.42 could hear the explicit turn `Nareth is a dark animal.` while `suvin` was active and refuse to
+mis-teach it, but its only honest action was a guard. The address was no longer ambiguous: the human had
+named a waiting question. Keeping `suvin` at the mouth made Leo preserve uncertainty at the cost of
+conversation.
+
+A.43 distinguishes explicit address from semantic resemblance. Only an exact waiting name can switch
+the pending Wonder. The active question is copied into the queue slot vacated by that sibling; its word,
+two hypotheses, heard-at-birth count, birth turn, contrastive own-field anchor, and unresolved episode
+remain its own. The named sibling receives the one School mouth. No semantic winner, field cosine, or
+unnamed glyph path can call the switch. If active and sibling names occur together, active wins, keeping
+human correction possible.
+
+The named turn then follows ordinary School rather than a new teaching path:
+
+- `Nareth is a dark animal.` grounds and resolves `nareth`; `suvin` waits.
+- `Nareth.` and `What is nareth?` switch address but provide no answer, so Leo asks the original
+  `Nareth? Dark or Animal?`.
+- `Cat bird. Dark night.` still has no declared owner and remains A.42's non-destructive guard.
+
+State v20 appends the active question's exact `LeoDeferredWonder` provenance as its own fail-soft tail.
+A v19 body keeps its historical pending question but receives no reconstructed field or birth record;
+redirection therefore fails closed to the A.42 guard. A truncated or invalid v20 provenance tail loses
+only redirect authority. The pending question, episode ledger, deferred constellation, Flow, shadow,
+and calibration remain alive.
+
+Explicit switching also exposed a stale v15 assumption. A parked `suvin` and active `nareth` are two
+unresolved identities even though only one can speak. Event-bounded Flow currents now permit that
+honest plurality; snapshots and shadow receipts still select the current mouth by exact `wonder_id`.
+Both unfinished currents survive the same save/load instead of being misdiagnosed as a corrupt tail.
+
+Fourteen new direct contracts raised the suite from **301/301** to **315/315**, and the multi-current
+sleep contract raised it once more to **316/316**. They cover grounded and bare switching, exact
+provenance, stable episode identity, semantic non-authority, active-name precedence, ablation, legacy
+fail-closed behavior, full-queue replacement, v19 migration, corrupt-v20 fail-soft behavior, and
+multi-current sleep.
+
+The process matrix rebuilt two independent A.40 bodies, opened slot 1, and forked five turns per body
+against `--no-wonder-redirection`:
+
+```text
+cells=10
+explicit redirect cells=6
+negative controls=4
+actual redirects=6
+redirected states diverged=6/6
+control states byte-identical=4/4
+displaced-question continuations after sleep=2/2
+```
+
+Both bare-address forms spoke the exact slot-2 question. Both grounded forms learned only slot 2; after
+another process boundary, slot 1 returned verbatim as `Suvin? Light or Cold?` /
+`Zavin? Light or Cold?`, with the original episode rather than a rebirth. Two complete A.43 runs
+reproduced every matrix row, continuation state hash, and summary byte-for-byte. Isolated A.42 retained
+its original **14 cells, 4 guards, and 10 non-guard equal states**; isolated A.41 retained
+**16/16 reply and state equality**.
+
+Leo can now yield the mouth without yielding the history of the question that was speaking.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection
 
 all: leo
 
@@ -61,6 +61,9 @@ deferred-wonder-semantics: leo
 deferred-wonder-attribution: leo
 	./scripts/deferred_wonder_attribution_matrix.sh
 
+deferred-wonder-redirection: leo
+	./scripts/deferred_wonder_redirection_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -74,6 +77,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_constellation_matrix.sh
 	./scripts/test_deferred_wonder_semantic_matrix.sh
 	./scripts/test_deferred_wonder_attribution_matrix.sh
+	./scripts/test_deferred_wonder_redirection_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1480,6 +1480,8 @@ typedef struct {
     long   turn_clock;                   /* lived prompts; v12 persists cooldown across sleep */
     LeoDeferredWonder deferred[LEO_DEFERRED_WONDER_MAX];
     int    n_deferred;
+    LeoDeferredWonder pending_origin;     /* exact birth provenance of the question that currently has a mouth */
+    uint8_t has_pending_origin;           /* v20: old bodies never invent an origin they did not record */
     int    returned_episode;             /* transient: episode active in this reply, -1 outside it */
 } LeoSchool;
 
@@ -1532,10 +1534,12 @@ typedef struct {
     uint8_t  wonder;
 } LeoFlowSnapshot;
 
-/* The long clock is not a larger arbitrary window. It is an event-bounded
- * current: one unfinished wonder from its first lived question through the
- * grounding turn that resolves it. Means remain in [0,1]; sparse field mass is
- * the per-observation mean of Leo's associated words. Resolved currents freeze. */
+/* The long clock is not a larger arbitrary window. Each identity has an
+ * event-bounded current from its first lived question through the grounding
+ * turn that resolves it. Explicit address switching may suspend several
+ * unfinished identities; the snapshot's wonder_id still selects the one that
+ * currently has the mouth. Means remain in [0,1]; sparse field mass is the
+ * per-observation mean of Leo's associated words. Resolved currents freeze. */
 typedef struct {
     uint64_t wonder_id;
     uint64_t started_turn;
@@ -1650,6 +1654,7 @@ enum {
     LEO_CURIOSITY_ASKED_DEFERRED,
     LEO_CURIOSITY_BLOCKED_DEFERRED,
     LEO_CURIOSITY_ADDRESS_GUARDED,
+    LEO_CURIOSITY_REDIRECTED,
     LEO_CURIOSITY_NO_CANDIDATE,
     LEO_CURIOSITY_DISABLED,
     LEO_CURIOSITY_OUTCOME_COUNT
@@ -1726,6 +1731,7 @@ typedef struct {
     float   margin;
     uint8_t status;
     uint8_t guarded;
+    uint8_t redirected;
 } LeoWonderAddressReceipt;
 
 enum {
@@ -1855,8 +1861,8 @@ typedef struct {
     /* A.41: one-turn semantic echo among withheld questions. Diagnostic only;
      * neither School nor generation reads it. */
     LeoPreWonderShadowReceipt prewonder_shadow;
-    /* A.42: pre-grounding address witness. Only its narrow sibling-conflict
-     * veto is read by School; it cannot assign meaning to another question. */
+    /* A.42/A.43: pre-grounding address witness. Semantic conflict can only
+     * guard; an exact waiting name may redirect without assigning meaning. */
     LeoWonderAddressReceipt wonder_address;
     /* passive temporal proprioception (state v13): a bounded archaeological
      * record of what has been flowing through lived replies. No speech reader. */
@@ -1938,6 +1944,8 @@ static void leo_init(Leo *leo) {
     leo->ask_override = -1.0f;
     leo->school.pending_glyph = -1;  /* I3a (L-4 fix): no open guess — memset-0 would be the "water" glyph */
     leo->school.pending_alt_glyph = -1;
+    for (int k = 0; k < LEO_PREWONDER_FIELD; k++)
+        leo->school.pending_origin.field_token[k] = -1;
     leo->school.returned_episode = -1;
     leo->prompt_pieces = NULL;
     leo->prompt_meaning = NULL;
@@ -2128,7 +2136,8 @@ static int g_leo_school_on = 1;         /* --no-school → 0 (A.5: School revers
 static int g_leo_wonder_on = 1;         /* unfinished wonder: grounded alternatives + persistence across non-answers. --no-wonder restores the prior School contract. */
 static int g_leo_deferred_wonder_on = 1; /* pre-Wonder: a distress-blocked question remains askable when its word returns safely. */
 static int g_leo_prewonder_shadow_on = 1; /* read-only semantic echo among withheld questions; no speech reader. */
-static int g_leo_wonder_attribution_on = 1; /* address guard: a confident waiting sibling can veto, but never claim, an active answer. */
+static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
+static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
 static int g_leo_flow_on = 1;           /* passive temporal proprioception. --no-flow stops snapshots; no generation path reads them. */
 static int g_leo_shadow_on = 1;         /* counterfactual next-turn proposals. --no-shadow keeps Flow but writes no receipts. */
@@ -4978,6 +4987,88 @@ static int leo_deferred_wonder_find(const Leo *leo, const char *word) {
     return -1;
 }
 
+static LeoWonderEpisode *leo_wonder_open(Leo *leo, const char *word,
+                                         int glyph, int alt_glyph);
+
+static void leo_pending_wonder_origin_clear(Leo *leo) {
+    if (!leo) return;
+    memset(&leo->school.pending_origin, 0,
+           sizeof leo->school.pending_origin);
+    for (int k = 0; k < LEO_PREWONDER_FIELD; k++)
+        leo->school.pending_origin.field_token[k] = -1;
+    leo->school.has_pending_origin = 0;
+}
+
+static void leo_deferred_wonder_birth(
+        Leo *leo, LeoDeferredWonder *entry, const char *word,
+        int glyph, int alt_glyph, int heard,
+        const int32_t field_token[LEO_PREWONDER_FIELD],
+        const float field_weight[LEO_PREWONDER_FIELD]) {
+    memset(entry, 0, sizeof *entry);
+    strncpy(entry->word, word, LEO_HEARD_WORDLEN - 1);
+    entry->word[LEO_HEARD_WORDLEN - 1] = 0;
+    entry->offered_glyph =
+        (int8_t)(glyph >= 0 && glyph < GLYPH_COUNT ? glyph : -1);
+    entry->offered_alt_glyph =
+        (int8_t)(alt_glyph >= 0 && alt_glyph < GLYPH_COUNT &&
+                 alt_glyph != glyph ? alt_glyph : -1);
+    entry->heard_at_birth = heard > 0 ? heard : 0;
+    entry->born_turn = (uint64_t)leo->school.turn_clock;
+    entry->last_seen_turn = (uint64_t)leo->school.turn_clock;
+    for (int k = 0; k < LEO_PREWONDER_FIELD; k++)
+        entry->field_token[k] = -1;
+    if (field_token && field_weight) {
+        for (int k = 0; k < LEO_PREWONDER_FIELD; k++) {
+            entry->field_token[k] = field_token[k];
+            entry->field_weight[k] = field_weight[k];
+        }
+    }
+}
+
+static void leo_pending_wonder_origin_begin(
+        Leo *leo, const char *word, int glyph, int alt_glyph, int heard,
+        const int32_t field_token[LEO_PREWONDER_FIELD],
+        const float field_weight[LEO_PREWONDER_FIELD]) {
+    leo_deferred_wonder_birth(
+        leo, &leo->school.pending_origin, word, glyph, alt_glyph, heard,
+        field_token, field_weight);
+    leo->school.has_pending_origin = 1;
+}
+
+static int leo_deferred_wonder_valid(
+        const Leo *leo, const LeoDeferredWonder *entry,
+        int require_blocked) {
+    if (!leo || !entry || !entry->word[0] ||
+        entry->offered_glyph < -1 ||
+        entry->offered_glyph >= GLYPH_COUNT ||
+        entry->offered_alt_glyph < -1 ||
+        entry->offered_alt_glyph >= GLYPH_COUNT ||
+        (entry->offered_glyph >= 0 &&
+         entry->offered_alt_glyph == entry->offered_glyph) ||
+        entry->heard_at_birth <= 0 ||
+        (require_blocked && entry->blocks == 0) ||
+        entry->born_turn == 0 ||
+        entry->born_turn > entry->last_seen_turn ||
+        entry->last_seen_turn > (uint64_t)leo->school.turn_clock)
+        return 0;
+
+    float norm = 0.0f, previous = 2.0f;
+    for (int k = 0; k < LEO_PREWONDER_FIELD; k++) {
+        int id = entry->field_token[k];
+        float weight = entry->field_weight[k];
+        if (id < -1 || id >= leo->bpe.vocab_size ||
+            !isfinite(weight) || weight < 0.0f || weight > 1.0f ||
+            weight > previous + 1e-6f ||
+            (id < 0 && weight != 0.0f))
+            return 0;
+        for (int j = 0; j < k; j++)
+            if (id >= 0 && entry->field_token[j] == id) return 0;
+        norm += weight * weight;
+        previous = weight;
+    }
+    return entry->field_token[0] < 0 || fabsf(norm - 1.0f) <= 1e-3f;
+}
+
 static void leo_deferred_wonder_forget(Leo *leo, const char *word) {
     int idx = leo_deferred_wonder_find(leo, word);
     if (idx < 0) return;
@@ -5014,18 +5105,9 @@ static LeoDeferredWonder *leo_deferred_wonder_remember(
             }
         }
         LeoDeferredWonder *entry = &leo->school.deferred[idx];
-        memset(entry, 0, sizeof *entry);
-        strncpy(entry->word, word, LEO_HEARD_WORDLEN - 1);
-        entry->word[LEO_HEARD_WORDLEN - 1] = 0;
-        entry->offered_glyph =
-            (int8_t)(glyph >= 0 && glyph < GLYPH_COUNT ? glyph : -1);
-        entry->offered_alt_glyph =
-            (int8_t)(alt_glyph >= 0 && alt_glyph < GLYPH_COUNT &&
-                     alt_glyph != glyph ? alt_glyph : -1);
-        entry->heard_at_birth = heard > 0 ? heard : 0;
-        entry->born_turn = (uint64_t)leo->school.turn_clock;
-        for (int k = 0; k < LEO_PREWONDER_FIELD; k++)
-            entry->field_token[k] = -1;
+        leo_deferred_wonder_birth(
+            leo, entry, word, glyph, alt_glyph, heard,
+            field_token, field_weight);
     }
     LeoDeferredWonder *entry = &leo->school.deferred[idx];
     /* If the first frightened context carried no hypothesis, a later blocked
@@ -5133,11 +5215,9 @@ static void leo_prewonder_shadow_observe(
 
 /* Determine whether the present human turn belongs to the active Wonder or
  * strongly resembles one waiting sibling. Adjacency remains the default:
- * hypotheses are guesses, so an unmatched answer may be a correction. Only a
- * confident sibling victory (or its explicit name) may guard the active close.
- * Even then the sibling receives no state transition; the guard preserves
- * uncertainty rather than silently rerouting a lesson. Returns a proposed veto;
- * the caller marks it `guarded` only when School had a closable answer. */
+ * hypotheses are guesses, so an unmatched answer may be a correction. This
+ * observer only proposes ownership. The caller may use a semantic sibling as a
+ * guard, or let the explicit-redirection layer enact a literal sibling address. */
 static int leo_wonder_address_observe(Leo *leo, const char *prompt) {
     LeoWonderAddressReceipt receipt;
     memset(&receipt, 0, sizeof receipt);
@@ -5243,6 +5323,44 @@ static int leo_wonder_address_observe(Leo *leo, const char *prompt) {
     }
     leo->wonder_address = receipt;
     return 0;
+}
+
+/* A literal waiting name is stronger than adjacency: the human has changed
+ * which unfinished question they are answering. Move the old active origin
+ * into the exact queue slot vacated by the sibling, then give that sibling the
+ * mouth. Semantic similarity can never enter here. Old bodies with no v20
+ * active provenance fail closed and retain A.42's guard rather than fabricating
+ * a birth field. */
+static int leo_wonder_address_redirect(Leo *leo) {
+    LeoWonderAddressReceipt *receipt = &leo->wonder_address;
+    if (!g_leo_wonder_redirection_on || !g_leo_wonder_attribution_on ||
+        !leo || receipt->status != LEO_WONDER_ADDRESS_SIBLING_EXPLICIT ||
+        receipt->winner <= 0 || receipt->winner >= receipt->n_candidates ||
+        !leo->school.has_pending_origin ||
+        strcmp(leo->school.pending_origin.word, leo->school.pending))
+        return 0;
+
+    const char *target_word = receipt->candidates[receipt->winner].word;
+    int target_idx = leo_deferred_wonder_find(leo, target_word);
+    if (target_idx < 0) return 0;
+
+    LeoDeferredWonder target = leo->school.deferred[target_idx];
+    LeoDeferredWonder displaced = leo->school.pending_origin;
+    if (displaced.blocks < UINT32_MAX) displaced.blocks++;
+    displaced.last_seen_turn = (uint64_t)leo->school.turn_clock;
+    leo->school.deferred[target_idx] = displaced;
+
+    strncpy(leo->school.pending, target.word, LEO_HEARD_WORDLEN - 1);
+    leo->school.pending[LEO_HEARD_WORDLEN - 1] = 0;
+    leo->school.pending_glyph = target.offered_glyph;
+    leo->school.pending_alt_glyph = target.offered_alt_glyph;
+    leo->school.pending_turns = 0;
+    leo->school.pending_origin = target;
+    leo->school.has_pending_origin = 1;
+    leo_wonder_open(leo, target.word, target.offered_glyph,
+                    target.offered_alt_glyph);
+    receipt->redirected = 1;
+    return 1;
 }
 
 /* I2: bind a taught word to the answer's concept (its dominant glyph), growing
@@ -6477,6 +6595,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
      * cleared it on every next turn, including counter-questions and pure unknowns;
      * unfinished wonder now survives those turns and may return on resonance. */
     int was_answer = 0, wonder_reask = 0, address_guarded = 0;
+    int address_redirected = 0;
     uint8_t flow_event = 0;
     uint64_t flow_wonder_id = 0;
     if (g_leo_school_on && leo->school.pending[0]) {
@@ -6499,6 +6618,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
             leo->school.pending_glyph = -1;
             leo->school.pending_alt_glyph = -1;
             leo->school.pending_turns = 0;
+            leo_pending_wonder_origin_clear(leo);
             was_answer = 1;
         } else {
             /* v5..v10 migration and a fail-soft v11 tail preserve the historical
@@ -6512,6 +6632,15 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
             if (open_episode >= 0)
                 flow_wonder_id = leo_wonder_episode_id(&leo->school.wonders[open_episode]);
             int address_veto = leo_wonder_address_observe(leo, prompt);
+            address_redirected = leo_wonder_address_redirect(leo);
+            if (address_redirected) {
+                address_veto = 0;
+                open_episode =
+                    leo_wonder_find_open(leo, leo->school.pending);
+                if (open_episode >= 0)
+                    flow_wonder_id = leo_wonder_episode_id(
+                        &leo->school.wonders[open_episode]);
+            }
             int g = leo_school_grounded_answer(leo, prompt);
             if (g >= 0 && address_veto) {
                 g = -1;
@@ -6539,6 +6668,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
                 leo->school.pending_glyph = -1;
                 leo->school.pending_alt_glyph = -1;
                 leo->school.pending_turns = 0;
+                leo_pending_wonder_origin_clear(leo);
             } else {
                 if (leo->school.pending_turns < 1000000) leo->school.pending_turns++;
                 if (leo->school.pending_turns >= LEO_WONDER_REASK_GAP &&
@@ -6724,6 +6854,9 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
         curiosity.outcome = LEO_CURIOSITY_REASKED;
     else if (address_guarded)
         curiosity.outcome = LEO_CURIOSITY_ADDRESS_GUARDED;
+    else if (address_redirected &&
+             !(flow_event & LEO_FLOW_WONDER_RESOLVED))
+        curiosity.outcome = LEO_CURIOSITY_REDIRECTED;
     else if (was_answer)
         curiosity.outcome = (flow_event & LEO_FLOW_WONDER_RESOLVED) ?
             LEO_CURIOSITY_RESOLVED : LEO_CURIOSITY_CONTINUED;
@@ -6739,7 +6872,15 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
             LEO_CURIOSITY_ASKED;
     leo->curiosity = curiosity;
 
-    if (g_leo_school_on && g_leo_wonder_on && wonder_reask) {
+    if (g_leo_school_on && g_leo_wonder_on && address_redirected &&
+        !(flow_event & LEO_FLOW_WONDER_RESOLVED)) {
+        int n = leo_school_format_question(out, max_len, leo->school.pending,
+                                           leo->school.pending_glyph,
+                                           leo->school.pending_alt_glyph);
+        produced = (n >= max_len) ? max_len - 1 : n;
+        leo->school.pending_turns = 0;
+        flow_event |= LEO_FLOW_WONDER_BORN;
+    } else if (g_leo_school_on && g_leo_wonder_on && wonder_reask) {
         int n = leo_school_format_question(out, max_len, leo->school.pending,
                                            leo->school.pending_glyph,
                                            leo->school.pending_alt_glyph);
@@ -6766,7 +6907,23 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
         leo->school.pending_glyph = glyphs[0];   /* I3b will check the guess against the answer */
         leo->school.pending_alt_glyph = g_leo_wonder_on ? glyphs[1] : -1;
         leo->school.pending_turns = 0;
-        if (from_deferred) leo_deferred_wonder_forget(leo, unk);
+        if (g_leo_wonder_on) {
+            int origin_idx = from_deferred ?
+                leo_deferred_wonder_find(leo, unk) : -1;
+            if (origin_idx >= 0) {
+                leo->school.pending_origin =
+                    leo->school.deferred[origin_idx];
+                leo->school.has_pending_origin = 1;
+                leo_deferred_wonder_forget(leo, unk);
+            } else {
+                leo_pending_wonder_origin_begin(
+                    leo, unk, glyphs[0], glyphs[1],
+                    leo_heard_count(&leo->heard, unk),
+                    prewonder_field_token, prewonder_field_weight);
+            }
+        } else {
+            leo_pending_wonder_origin_clear(leo);
+        }
         if (g_leo_wonder_on) {
             LeoWonderEpisode *ep = leo_wonder_open(leo, unk, glyphs[0], glyphs[1]);
             flow_wonder_id = leo_wonder_episode_id(ep);
@@ -6834,9 +6991,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v17      : next-turn calibration verdicts over shadow receipts
  *   v18      : bounded pre-Wonder memory for distress-deferred questions
  *   v19      : contrastive own-field birth anchors for pre-Wonder semantics
+ *   v20      : exact birth provenance for the Wonder that currently has the mouth
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 19  /* pre-Wonder field anchors extend the fail-soft tail; v5..v18 soft-migrate */
+#define LEO_STATE_VERSION 20  /* active-Wonder birth provenance extends the fail-soft tail; v5..v19 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -7045,6 +7203,14 @@ static int leo_save_state(const Leo *leo, const char *path) {
     if (leo->school.n_deferred > 0)
         fwrite(leo->school.deferred, sizeof(LeoDeferredWonder),
                (size_t)leo->school.n_deferred, f);
+
+    /* Active Wonder provenance (v20): the question that currently has a mouth
+     * carries the same birth record as its waiting siblings. Older bodies
+     * migrate empty rather than reconstructing a field they never recorded. */
+    st_w32(f, (int32_t)(leo->school.has_pending_origin ? 1 : 0));
+    if (leo->school.has_pending_origin)
+        fwrite(&leo->school.pending_origin,
+               sizeof leo->school.pending_origin, 1, f);
 
     int ok = (ferror(f) == 0);
     if (fclose(f) != 0) ok = 0;                 /* L-2: the final flush can fail (ENOSPC) — never report success on a truncated file */
@@ -7478,7 +7644,6 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
             leo->flow.n_currents = n;
             leo->flow.current_ptr = ptr;
             uint64_t previous_started = 0;
-            int unfinished = 0;
             for (int i = 0; i < n; i++) {
                 const LeoFlowWonderCurrent *current = leo_flow_current_at(&leo->flow, i);
                 if (!leo_flow_current_valid(leo, current,
@@ -7486,7 +7651,6 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
                     (i > 0 && current->started_turn < previous_started)) {
                     current_ok = 0; break;
                 }
-                if (!current->resolved && ++unfinished > 1) { current_ok = 0; break; }
                 for (int j = 0; j < i; j++)
                     if (leo_flow_current_at(&leo->flow, j)->wonder_id == current->wonder_id) {
                         current_ok = 0; break;
@@ -7675,10 +7839,39 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
             }
         }
         if (!deferred_ok) {
-            fprintf(stderr, "[leo] WARNING: v18/v19 deferred-Wonder tail truncated/corrupt — organism lives without withheld questions.\n");
+            fprintf(stderr, "[leo] WARNING: v18-v20 deferred-Wonder tail truncated/corrupt — organism lives without withheld questions.\n");
             memset(leo->school.deferred, 0,
                    sizeof leo->school.deferred);
             leo->school.n_deferred = 0;
+        }
+    }
+
+    /* Active-Wonder provenance (v20). This tail is independent of the open
+     * question and episode ledger: corruption loses only the proof of origin,
+     * and explicit redirection then fails closed to the A.42 guard. */
+    if (version >= 20) {
+        int32_t has_origin = 0;
+        int origin_ok = st_r32(f, &has_origin) &&
+                        (has_origin == 0 || has_origin == 1);
+        if (origin_ok && has_origin &&
+            fread(&leo->school.pending_origin,
+                  sizeof leo->school.pending_origin, 1, f) != 1)
+            origin_ok = 0;
+        if (origin_ok && has_origin) {
+            leo->school.pending_origin.word[LEO_HEARD_WORDLEN - 1] = 0;
+            if (!leo->school.pending[0] ||
+                strcmp(leo->school.pending_origin.word,
+                       leo->school.pending) ||
+                !leo_deferred_wonder_valid(
+                    leo, &leo->school.pending_origin, 0))
+                origin_ok = 0;
+        }
+        if (origin_ok) {
+            leo->school.has_pending_origin = (uint8_t)has_origin;
+            if (!has_origin) leo_pending_wonder_origin_clear(leo);
+        } else {
+            fprintf(stderr, "[leo] WARNING: v20 active-Wonder provenance truncated/corrupt — the question lives, but cannot be redirected without inventing its origin.\n");
+            leo_pending_wonder_origin_clear(leo);
         }
     }
 
@@ -7992,9 +8185,10 @@ static void print_wonder_address_stats(const Leo *leo) {
             receipt->candidates[receipt->winner].word : "none";
     const char *active =
         receipt->n_candidates > 0 ? receipt->candidates[0].word : "none";
-    printf("     [wonder-address: turn=%llu status=%s winner=%s active=%s margin=%.3f guarded=%u entries=",
+    printf("     [wonder-address: turn=%llu status=%s winner=%s active=%s margin=%.3f guarded=%u redirected=%u entries=",
            (unsigned long long)receipt->turn, statuses[status], winner,
-           active, (double)receipt->margin, (unsigned)receipt->guarded);
+           active, (double)receipt->margin, (unsigned)receipt->guarded,
+           (unsigned)receipt->redirected);
     for (int i = 0; i < receipt->n_candidates; i++) {
         const LeoWonderAddressCandidate *candidate =
             &receipt->candidates[i];
@@ -8026,7 +8220,7 @@ static void print_flow_stats(const Leo *leo) {
         static const char *outcomes[LEO_CURIOSITY_OUTCOME_COUNT] = {
             "none", "asked", "reasked", "resolved", "continued",
             "blocked-distress", "asked-deferred", "blocked-deferred",
-            "address-guarded", "no-candidate", "disabled"
+            "address-guarded", "redirected", "no-candidate", "disabled"
         };
         printf("     [curiosity: turn=%llu outcome=%s candidate=%s deferred=%s heard=%d distress=%.3f gate=%.3f]\n",
                (unsigned long long)leo->curiosity.turn,
@@ -8209,6 +8403,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-deferred-wonder")) g_leo_deferred_wonder_on = 0;
         else if (!strcmp(argv[i], "--no-prewonder-shadow")) g_leo_prewonder_shadow_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
         else if (!strcmp(argv[i], "--no-flow")) g_leo_flow_on = 0;
         else if (!strcmp(argv[i], "--no-shadow")) g_leo_shadow_on = 0;

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -232,7 +232,7 @@ The veto does not open, resolve, teach, or speak for the sibling. It only
 preserves the current uncertainty.
 
 `--debug-field` emits `[wonder-address: ...]` with the active identity, status,
-winner, margin, actual guard bit, and every candidate's
+winner, margin, actual guard and redirect bits, and every candidate's
 `glyph/literal/active` tuple. `--no-wonder-attribution` restores the previous
 grounding path. The A.41 semantic-shadow matrix passes that ablation
 explicitly so its observer-only result remains an isolated historical proof.
@@ -245,6 +245,36 @@ question. Default and ablated runs use the same seed and starting state. All
 non-guard cells require complete saved-state equality; guard cells require the
 active question to remain unresolved while the ablation reproduces the old
 cross-attribution.
+
+Run the explicit address-redirection matrix:
+
+```sh
+make deferred-wonder-redirection
+```
+
+A.43 gives one narrow meaning to an explicitly named waiting sibling: the human
+has changed which unfinished question they are addressing. The current active
+question returns to the exact queue slot vacated by that sibling, preserving its
+original hypotheses, birth turn, heard count, own-field coordinates, and Wonder
+episode. The named sibling then becomes the only School pending question.
+Semantic similarity alone can still only guard; it cannot enter this switch.
+If both names occur, the active name wins so a human correction remains possible.
+
+State v20 gives the active question a fail-soft provenance tail with the same
+record shape as a deferred Wonder. v19 bodies retain their pending question but
+receive no invented origin, so explicit switching fails closed to the A.42
+guard. A corrupt v20 provenance tail has the same behavior without discarding
+the open question or waiting constellation. Address switching can leave several
+unresolved Wonder episodes and event-bounded Flow currents, but the current
+snapshot identity still selects the single question that has the mouth.
+
+The checked matrix grows the same two independent three-question bodies and
+opens slot 1 before every fork. Three explicit slot-2 forms (grounded statement,
+bare name, and question) are compared with `--no-wonder-redirection`; a semantic
+sibling conflict and a turn naming both active and sibling are negative controls.
+The grounded switch additionally sleeps, then returns slot 1 and requires its
+original question verbatim. `LEO_REDIRECTION_PLAN_ONLY=1` validates the ten-cell
+design without running Leo.
 
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,

--- a/scripts/deferred_wonder_constellation_matrix.sh
+++ b/scripts/deferred_wonder_constellation_matrix.sh
@@ -209,10 +209,12 @@ while IFS=$'\t' read -r group cohort seed; do
         log="$group_dir/turns/turn-$(printf '%02d' "$turn")-birth.log"
         if [ "$turn" -eq 1 ]; then
             "$ROOT/leo" --seed "$seed" --respond "$prompt" --debug-field \
+                --no-wonder-redirection \
                 --save "$state" > "$log" 2>&1
         else
             "$ROOT/leo" --load "$state" --seed "$((seed + turn - 1))" \
-                --respond "$prompt" --debug-field --save "$state" \
+                --respond "$prompt" --debug-field --no-wonder-redirection \
+                --save "$state" \
                 > "$log" 2>&1
         fi
         curiosity="$(curiosity_from_log "$log" "$group-birth" "$seed")"
@@ -249,7 +251,8 @@ while IFS=$'\t' read -r group cohort seed; do
         turn=$((turn + 1))
         log="$group_dir/turns/turn-$(printf '%02d' "$turn")-life.log"
         "$ROOT/leo" --load "$state" --seed "$((seed + turn - 1))" \
-            --respond "$prompt" --debug-field --save "$state" \
+            --respond "$prompt" --debug-field --no-wonder-redirection \
+            --save "$state" \
             > "$log" 2>&1
         curiosity="$(curiosity_from_log "$log" "$group-life" "$seed")"
         inventory="$(inventory_from_log "$log" "$group-life" "$seed")"
@@ -312,7 +315,8 @@ while IFS=$'\t' read -r cell group cohort seed order target_order; do
         turn=$((turn + 1))
         log="$life/turns/turn-$(printf '%02d' "$turn")-open.log"
         "$ROOT/leo" --load "$state" --seed "$((seed + 100 + turn))" \
-            --respond "$target" --debug-field --save "$state" \
+            --respond "$target" --debug-field --no-wonder-redirection \
+            --save "$state" \
             > "$log" 2>&1
         curiosity="$(curiosity_from_log "$log" "$cell-open" "$seed")"
         inventory="$(inventory_from_log "$log" "$cell-open" "$seed")"
@@ -347,7 +351,8 @@ while IFS=$'\t' read -r cell group cohort seed order target_order; do
             turn=$((turn + 1))
             log="$life/turns/turn-$(printf '%02d' "$turn")-occupied.log"
             "$ROOT/leo" --load "$state" --seed "$((seed + 100 + turn))" \
-                --respond "$next_target" --debug-field --save "$state" \
+                --respond "$next_target" --debug-field \
+                --no-wonder-redirection --save "$state" \
                 > "$log" 2>&1
             curiosity="$(curiosity_from_log "$log" "$cell-occupied" "$seed")"
             inventory="$(inventory_from_log "$log" "$cell-occupied" "$seed")"
@@ -376,7 +381,8 @@ while IFS=$'\t' read -r cell group cohort seed order target_order; do
         turn=$((turn + 1))
         log="$life/turns/turn-$(printf '%02d' "$turn")-ground.log"
         "$ROOT/leo" --load "$state" --seed "$((seed + 100 + turn))" \
-            --respond "$grounding" --debug-field --save "$state" \
+            --respond "$grounding" --debug-field --no-wonder-redirection \
+            --save "$state" \
             > "$log" 2>&1
         curiosity="$(curiosity_from_log "$log" "$cell-ground" "$seed")"
         inventory="$(inventory_from_log "$log" "$cell-ground" "$seed")"
@@ -408,7 +414,8 @@ while IFS=$'\t' read -r cell group cohort seed order target_order; do
         turn=$((turn + 1))
         log="$life/turns/turn-$(printf '%02d' "$turn")-learned.log"
         "$ROOT/leo" --load "$state" --seed "$((seed + 100 + turn))" \
-            --respond "$target" --debug-field --save "$state" \
+            --respond "$target" --debug-field --no-wonder-redirection \
+            --save "$state" \
             > "$log" 2>&1
         curiosity="$(curiosity_from_log "$log" "$cell-learned" "$seed")"
         inventory="$(inventory_from_log "$log" "$cell-learned" "$seed")"

--- a/scripts/deferred_wonder_redirection_cases.tsv
+++ b/scripts/deferred_wonder_redirection_cases.tsv
@@ -1,0 +1,6 @@
+case	kind	prompt	expected_status	expected_winner_slot	expected_redirected	on_curiosity	on_pending_slot	on_resolved	off_curiosity	off_pending_slot	off_resolved	expect_reply_equal	expect_state_equal	expected_on_reply_slot	continuation
+sibling-grounded	redirect	{slot2} is a dark animal.	sibling-explicit	2	1	resolved	0	1	address-guarded	1	0	any	0	0	1
+sibling-bare	redirect	{slot2}.	sibling-explicit	2	1	redirected	2	0	continued	1	0	0	0	2	0
+sibling-question	redirect	What is {slot2}?	sibling-explicit	2	1	redirected	2	0	continued	1	0	0	0	2	0
+sibling-semantic	control	Cat bird. Dark night.	sibling-conflict	2	0	address-guarded	1	0	address-guarded	1	0	1	1	0	0
+active-and-sibling	control	{slot1} and {slot2} are a dark animal.	active-explicit	1	0	resolved	0	1	resolved	0	1	1	1	0	0

--- a/scripts/deferred_wonder_redirection_matrix.sh
+++ b/scripts/deferred_wonder_redirection_matrix.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# A.42: pre-grounding ownership among one active and several waiting Wonders.
+# A.43: explicit address switching between one active and waiting Wonders.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-GROUPS_FILE="${LEO_ATTRIBUTION_GROUPS:-$ROOT/scripts/deferred_wonder_constellation_groups.tsv}"
-CASES_FILE="${LEO_ATTRIBUTION_CASES:-$ROOT/scripts/deferred_wonder_attribution_cases.tsv}"
+GROUPS_FILE="${LEO_REDIRECTION_GROUPS:-$ROOT/scripts/deferred_wonder_constellation_groups.tsv}"
+CASES_FILE="${LEO_REDIRECTION_CASES:-$ROOT/scripts/deferred_wonder_redirection_cases.tsv}"
 STAMP="$(date +%Y%m%d-%H%M%S)"
-OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-attribution-$STAMP}"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-redirection-$STAMP}"
 
 [ ! -e "$OUT" ] || {
     printf 'output path already exists: %s\n' "$OUT" >&2
@@ -14,46 +14,49 @@ OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-attribution-$STAMP}"
 }
 for fixture in "$GROUPS_FILE" "$CASES_FILE"; do
     [ -f "$fixture" ] || {
-        printf 'attribution fixture not found: %s\n' "$fixture" >&2
+        printf 'redirection fixture not found: %s\n' "$fixture" >&2
         exit 2
     }
 done
 
 awk -F '\t' '
     NR == 1 {
-        if (NF != 14 || $1 != "case" || $2 != "kind" ||
+        if (NF != 16 || $1 != "case" || $2 != "kind" ||
             $3 != "prompt" || $4 != "expected_status" ||
-            $5 != "expected_winner_slot" || $6 != "expected_guarded" ||
+            $5 != "expected_winner_slot" || $6 != "expected_redirected" ||
             $7 != "on_curiosity" || $8 != "on_pending_slot" ||
             $9 != "on_resolved" || $10 != "off_curiosity" ||
             $11 != "off_pending_slot" || $12 != "off_resolved" ||
-            $13 != "expect_reply_equal" || $14 != "expect_state_equal")
+            $13 != "expect_reply_equal" || $14 != "expect_state_equal" ||
+            $15 != "expected_on_reply_slot" || $16 != "continuation")
             exit 1
         next
     }
     {
-        if (NF != 14 || seen[$1]++ || $5 !~ /^[0-3]$/ ||
+        if (NF != 16 || seen[$1]++ || $5 !~ /^[0-3]$/ ||
             $6 !~ /^[01]$/ || $8 !~ /^[0-3]$/ || $9 !~ /^[01]$/ ||
             $11 !~ /^[0-3]$/ || $12 !~ /^[01]$/ ||
-            $13 !~ /^(0|1|any)$/ || $14 !~ /^[01]$/)
+            $13 !~ /^(0|1|any)$/ || $14 !~ /^[01]$/ ||
+            $15 !~ /^[0-3]$/ || $16 !~ /^[01]$/)
             exit 1
         kinds[$2]++
+        continuations += $16
         rows++
     }
     END {
-        if (rows != 7 || kinds["guard"] != 2 ||
-            kinds["correction"] != 2 || kinds["question"] != 1)
+        if (rows != 5 || kinds["redirect"] != 3 ||
+            kinds["control"] != 2 || continuations != 1)
             exit 1
     }
 ' "$CASES_FILE" || {
-    printf 'invalid attribution cases: %s\n' "$CASES_FILE" >&2
+    printf 'invalid redirection cases: %s\n' "$CASES_FILE" >&2
     exit 2
 }
 
 mkdir -p "$OUT/lives"
 PLAN="$OUT/plan.tsv"
-RECEIPTS="$OUT/receipts.tsv"
 MATRIX="$OUT/matrix.tsv"
+CONTINUATIONS="$OUT/continuations.tsv"
 SUMMARY="$OUT/summary.txt"
 
 group_field() {
@@ -118,7 +121,7 @@ while IFS=$'\t' read -r group cohort seed; do
     done < "$CASES_FILE"
 done
 
-if [ "${LEO_ATTRIBUTION_PLAN_ONLY:-0}" = 1 ]; then
+if [ "${LEO_REDIRECTION_PLAN_ONLY:-0}" = 1 ]; then
     cat "$PLAN"
     exit 0
 fi
@@ -127,10 +130,10 @@ make -C "$ROOT" leo >/dev/null
 "$ROOT/scripts/deferred_wonder_constellation_matrix.sh" "$OUT/a40-baseline" \
     > "$OUT/a40-baseline.log"
 
-printf 'cell\tturn\tstatus\twinner\tactive\tmargin\tguarded\taddress_entries\ton_curiosity\ton_count\ton_pending\ton_resolved\toff_curiosity\toff_count\toff_pending\toff_resolved\tprompt\ton_reply\toff_reply\n' \
-    > "$RECEIPTS"
-printf 'cell\tgroup\tcohort\tcase\tkind\tstatus\twinner\tguarded\ton_curiosity\ton_pending\ton_resolved\toff_curiosity\toff_pending\toff_resolved\treply_equal\tstate_equal\ton_sha256\toff_sha256\toutput\n' \
+printf 'cell\tgroup\tcohort\tcase\tkind\tstatus\twinner\tguarded\tredirected\ton_curiosity\ton_pending\ton_resolved\toff_curiosity\toff_pending\toff_resolved\treply_equal\tstate_equal\ton_sha256\toff_sha256\n' \
     > "$MATRIX"
+printf 'cell\tgroup\tcohort\treply\tcuriosity\tpending\tresolved\tstate_sha256\n' \
+    > "$CONTINUATIONS"
 
 group_index=0
 awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
@@ -145,58 +148,59 @@ while IFS=$'\t' read -r group cohort seed; do
         exit 1
     }
     active="$(group_field "$group" 1 5)"
-    expected_question="$(group_field "$group" 1 9)"
+    expected_active_question="$(group_field "$group" 1 9)"
     cp "$ready" "$group_dir/open.state"
     "$ROOT/leo" --load "$group_dir/open.state" \
-        --seed "$((seed + 1700))" --respond "$active" --debug-field \
-        --no-wonder-redirection \
+        --seed "$((seed + 2700))" --respond "$active" --debug-field \
         --save "$group_dir/open.state" > "$group_dir/open.log" 2>&1
-    [ "$(reply_from_log "$group_dir/open.log")" = "$expected_question" ] || {
+    [ "$(reply_from_log "$group_dir/open.log")" = "$expected_active_question" ] || {
         printf '%s failed to open the active control\n' "$group" >&2
         exit 1
     }
 
     case_index=0
     while IFS=$'\t' read -r case kind raw_prompt expected_status \
-        winner_slot expected_guarded expected_on_curiosity \
+        winner_slot expected_redirected expected_on_curiosity \
         expected_on_pending_slot expected_on_resolved \
         expected_off_curiosity expected_off_pending_slot \
-        expected_off_resolved expected_reply_equal expected_state_equal; do
+        expected_off_resolved expected_reply_equal expected_state_equal \
+        expected_on_reply_slot continuation; do
         [ "$case" = "case" ] && continue
         case_index=$((case_index + 1))
         cell="$group-$case"
         cell_dir="$group_dir/$case"
         mkdir -p "$cell_dir"
-        prompt="${raw_prompt//\{slot1\}/$active}"
         slot2="$(group_field "$group" 2 5)"
+        prompt="${raw_prompt//\{slot1\}/$active}"
         prompt="${prompt//\{slot2\}/$slot2}"
+
         expected_winner="none"
-        if [ "$winner_slot" -gt 0 ]; then
+        [ "$winner_slot" -eq 0 ] ||
             expected_winner="$(group_field "$group" "$winner_slot" 5)"
-        fi
         expected_on_pending="none"
-        if [ "$expected_on_pending_slot" -gt 0 ]; then
+        [ "$expected_on_pending_slot" -eq 0 ] ||
             expected_on_pending="$(
                 group_field "$group" "$expected_on_pending_slot" 5
             )"
-        fi
         expected_off_pending="none"
-        if [ "$expected_off_pending_slot" -gt 0 ]; then
+        [ "$expected_off_pending_slot" -eq 0 ] ||
             expected_off_pending="$(
                 group_field "$group" "$expected_off_pending_slot" 5
             )"
-        fi
+        expected_on_reply=""
+        [ "$expected_on_reply_slot" -eq 0 ] ||
+            expected_on_reply="$(
+                group_field "$group" "$expected_on_reply_slot" 9
+            )"
 
         cp "$group_dir/open.state" "$cell_dir/on.state"
         cp "$group_dir/open.state" "$cell_dir/off.state"
-        run_seed=$((seed + 2000 + group_index * 100 + case_index))
+        run_seed=$((seed + 3000 + group_index * 100 + case_index))
         "$ROOT/leo" --load "$cell_dir/on.state" --seed "$run_seed" \
-            --respond "$prompt" --debug-field --no-wonder-redirection \
-            --save "$cell_dir/on.state" \
+            --respond "$prompt" --debug-field --save "$cell_dir/on.state" \
             > "$cell_dir/on.log" 2>&1
         "$ROOT/leo" --load "$cell_dir/off.state" --seed "$run_seed" \
-            --respond "$prompt" --debug-field --no-wonder-attribution \
-            --no-wonder-redirection \
+            --respond "$prompt" --debug-field --no-wonder-redirection \
             --save "$cell_dir/off.state" > "$cell_dir/off.log" 2>&1
 
         address="$(address_from_log "$cell_dir/on.log" "$cell" "$run_seed")"
@@ -249,8 +253,7 @@ while IFS=$'\t' read -r group cohort seed; do
         [ "$status" = "$expected_status" ] &&
         [ "$winner" = "$expected_winner" ] &&
         [ "$address_active" = "$active" ] &&
-        [ "$guarded" = "$expected_guarded" ] &&
-        [ "$redirected" = 0 ] &&
+        [ "$redirected" = "$expected_redirected" ] &&
         [ "$on_outcome" = "$expected_on_curiosity" ] &&
         [ "$on_pending" = "$expected_on_pending" ] &&
         [ "$on_resolved" = "$expected_on_resolved" ] &&
@@ -259,48 +262,84 @@ while IFS=$'\t' read -r group cohort seed; do
         [ "$off_resolved" = "$expected_off_resolved" ] &&
         { [ "$expected_reply_equal" = "any" ] ||
           [ "$reply_equal" = "$expected_reply_equal" ]; } &&
-        [ "$state_equal" = "$expected_state_equal" ] || {
-            printf '%s contract failed: status=%s winner=%s active=%s guarded=%s on=%s/%s/%s off=%s/%s/%s reply_equal=%s state_equal=%s\n' \
+        [ "$state_equal" = "$expected_state_equal" ] &&
+        { [ -z "$expected_on_reply" ] ||
+          [ "$on_reply" = "$expected_on_reply" ]; } || {
+            printf '%s contract failed: status=%s winner=%s active=%s guarded=%s redirected=%s on=%s/%s/%s off=%s/%s/%s reply_equal=%s state_equal=%s\n' \
                 "$cell" "$status" "$winner" "$address_active" "$guarded" \
-                "$on_outcome" "$on_pending" "$on_resolved" \
+                "$redirected" "$on_outcome" "$on_pending" "$on_resolved" \
                 "$off_outcome" "$off_pending" "$off_resolved" \
                 "$reply_equal" "$state_equal" >&2
             exit 1
         }
 
         printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-            "$cell" "$turn" "$status" "$winner" "$address_active" \
-            "$margin" "$guarded" "$address_entries" "$on_outcome" \
-            "$on_count" "$on_pending" "$on_resolved" "$off_outcome" \
-            "$off_count" "$off_pending" "$off_resolved" "$prompt" \
-            "$on_reply" "$off_reply" >> "$RECEIPTS"
-        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
             "$cell" "$group" "$cohort" "$case" "$kind" "$status" \
-            "$winner" "$guarded" "$on_outcome" "$on_pending" \
-            "$on_resolved" "$off_outcome" "$off_pending" \
-            "$off_resolved" "$reply_equal" "$state_equal" "$on_sha" \
-            "$off_sha" "$cell_dir" >> "$MATRIX"
+            "$winner" "$guarded" "$redirected" "$on_outcome" \
+            "$on_pending" "$on_resolved" "$off_outcome" \
+            "$off_pending" "$off_resolved" "$reply_equal" "$state_equal" \
+            "$on_sha" "$off_sha" >> "$MATRIX"
+
+        if [ "$continuation" -eq 1 ]; then
+            continuation_seed=$((run_seed + 5000))
+            cp "$cell_dir/on.state" "$cell_dir/continuation.state"
+            "$ROOT/leo" --load "$cell_dir/continuation.state" \
+                --seed "$continuation_seed" --respond "$active" \
+                --debug-field --save "$cell_dir/continuation.state" \
+                > "$cell_dir/continuation.log" 2>&1
+            continuation_reply="$(
+                reply_from_log "$cell_dir/continuation.log"
+            )"
+            continuation_curiosity="$(
+                curiosity_from_log "$cell_dir/continuation.log" \
+                    "$cell-continuation" "$continuation_seed"
+            )"
+            continuation_inventory="$(
+                inventory_from_log "$cell_dir/continuation.log" \
+                    "$cell-continuation" "$continuation_seed"
+            )"
+            IFS=$'\t' read -r _ _ _ continuation_outcome _ _ _ _ _ \
+                <<< "$continuation_curiosity"
+            IFS=$'\t' read -r _ _ _ continuation_count \
+                continuation_pending continuation_episodes \
+                continuation_resolved continuation_entries \
+                <<< "$continuation_inventory"
+            [ "$continuation_reply" = "$expected_active_question" ] &&
+            [ "$continuation_outcome" = "asked-deferred" ] &&
+            [ "$continuation_pending" = "$active" ] &&
+            [ "$continuation_resolved" = 1 ] || {
+                printf '%s failed exact displaced-Wonder continuation\n' \
+                    "$cell" >&2
+                exit 1
+            }
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                "$cell" "$group" "$cohort" "$continuation_reply" \
+                "$continuation_outcome" "$continuation_pending" \
+                "$continuation_resolved" \
+                "$(sha256_file "$cell_dir/continuation.state")" \
+                >> "$CONTINUATIONS"
+        fi
     done < "$CASES_FILE"
 done
 
 awk -F '\t' '
     NR > 1 {
         cells++
-        status[$6]++
-        guarded += $8
-        replies += $15
-        states += $16
-        if ($8 == 1 && $16 == 0) guarded_state_diverged++
+        redirected += $9
+        controls += ($5 == "control")
+        redirect_cells += ($5 == "redirect")
+        reply_equal += $16
+        state_equal += $17
+        if ($5 == "control" && $17 == 1) control_state_equal++
+        if ($9 == 1 && $17 == 0) redirected_state_diverged++
     }
     END {
-        print "cells\tguarded\tactive_semantic\tactive_explicit\tsibling_conflict\tsibling_explicit\tambiguous\tadjacent\treply_equal\tstate_equal\tguarded_state_diverged"
-        print cells "\t" guarded "\t" status["active-semantic"] "\t" \
-              status["active-explicit"] "\t" status["sibling-conflict"] "\t" \
-              status["sibling-explicit"] "\t" status["ambiguous"] "\t" \
-              status["adjacent"] "\t" replies "\t" states "\t" \
-              guarded_state_diverged
+        print "cells\tredirect_cells\tcontrols\tredirected\tcontinuations\treply_equal\tstate_equal\tcontrol_state_equal\tredirected_state_diverged"
+        print cells "\t" redirect_cells "\t" controls "\t" redirected \
+              "\t2\t" reply_equal "\t" state_equal "\t" \
+              control_state_equal "\t" redirected_state_diverged
     }
 ' "$MATRIX" > "$SUMMARY"
 
 cat "$SUMMARY"
-printf '\nmatrix: %s\nreceipts: %s\n' "$MATRIX" "$RECEIPTS"
+printf '\nmatrix: %s\ncontinuations: %s\n' "$MATRIX" "$CONTINUATIONS"

--- a/scripts/test_deferred_wonder_redirection_matrix.sh
+++ b/scripts/test_deferred_wonder_redirection_matrix.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_REDIRECTION_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_redirection_matrix.sh" "$OUT/plan" \
+    > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 9 || $1 != "cell" || $2 != "group" ||
+            $5 != "case" || $6 != "kind" ||
+            $8 != "expected_status" || $9 != "expected_winner")
+            exit 1
+        next
+    }
+    {
+        if (NF != 9 || cells[$1]++)
+            exit 1
+        groups[$2]++
+        cases[$5]++
+        kinds[$6]++
+        status[$8]++
+        rows++
+    }
+    END {
+        if (rows != 10 || length(groups) != 2 || length(cases) != 5 ||
+            kinds["redirect"] != 6 || kinds["control"] != 4 ||
+            status["sibling-explicit"] != 6 ||
+            status["sibling-conflict"] != 2 ||
+            status["active-explicit"] != 2)
+            exit 1
+        for (group in groups)
+            if (groups[group] != 5)
+                exit 1
+        for (case in cases)
+            if (cases[case] != 2)
+                exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder redirection plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder redirection matrix plan: ok\n'

--- a/scripts/test_wonder_address_dialogue_report.sh
+++ b/scripts/test_wonder_address_dialogue_report.sh
@@ -6,14 +6,14 @@ TMP="$(mktemp)"
 trap 'rm -f "$TMP"' EXIT
 
 cat > "$TMP" <<'EOF'
-     [wonder-address: turn=13 status=sibling-conflict winner=nareth active=suvin margin=1.000 guarded=1 entries=suvin:0.000/0/1|nareth:1.000/0/0]
+     [wonder-address: turn=13 status=sibling-conflict winner=nareth active=suvin margin=1.000 guarded=1 redirected=0 entries=suvin:0.000/0/1|nareth:1.000/0/0]
 EOF
 
 got="$(
     awk -v scenario=sibling-semantic -v seed=771 \
         -f "$ROOT/scripts/wonder_address_dialogue_report.awk" "$TMP"
 )"
-expected=$'sibling-semantic\t771\t13\tsibling-conflict\tnareth\tsuvin\t1.000\t1\tsuvin:0.000/0/1|nareth:1.000/0/0'
+expected=$'sibling-semantic\t771\t13\tsibling-conflict\tnareth\tsuvin\t1.000\t1\tsuvin:0.000/0/1|nareth:1.000/0/0\t0'
 
 if [ "$got" != "$expected" ]; then
     printf 'unexpected Wonder address parser output:\n%s\n' "$got" >&2

--- a/scripts/wonder_address_dialogue_report.awk
+++ b/scripts/wonder_address_dialogue_report.awk
@@ -16,9 +16,10 @@ function value_after(line, key,    start, tail, parts) {
 }
 
 /\[wonder-address: turn=/ {
-    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
            clean(scenario), clean(seed), value_after($0, "turn"),
            value_after($0, "status"), value_after($0, "winner"),
            value_after($0, "active"), value_after($0, "margin"),
-           value_after($0, "guarded"), value_after($0, "entries")
+           value_after($0, "guarded"), value_after($0, "entries"),
+           value_after($0, "redirected")
 }

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -40,6 +40,20 @@ static void seed_wonder_address_body(Leo *leo) {
                     leo->school.pending_alt_glyph);
 }
 
+static void seed_wonder_redirection_body(Leo *leo) {
+    seed_wonder_address_body(leo);
+    int32_t field_token[LEO_PREWONDER_FIELD];
+    float field_weight[LEO_PREWONDER_FIELD] = {0};
+    for (int k = 0; k < LEO_PREWONDER_FIELD; k++) field_token[k] = -1;
+    field_token[0] = 's';
+    field_token[1] = 'u';
+    field_weight[0] = 0.8f;
+    field_weight[1] = 0.6f;
+    leo_pending_wonder_origin_begin(
+        leo, leo->school.pending, leo->school.pending_glyph,
+        leo->school.pending_alt_glyph, 1, field_token, field_weight);
+}
+
 int main(void) {
     printf("test_leo (step 0)\n");
 
@@ -1025,7 +1039,8 @@ int main(void) {
             unsigned char *bytes = malloc(sz > 0 ? (size_t)sz : 1);
             if (bytes && sz > 1 &&
                 (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
-                long tail = (long)(sizeof(int32_t) +
+                long origin_tail = (long)sizeof(int32_t);
+                long tail = origin_tail + (long)(sizeof(int32_t) +
                                    pre.school.n_deferred *
                                        (int)sizeof(LeoDeferredWonder));
                 uint32_t seventeen = 17;
@@ -1075,8 +1090,9 @@ int main(void) {
                 fo = fopen(cut, "wb");
                 if (fo) {
                     built_cut =
-                        (long)fwrite(bytes, 1, (size_t)(sz - 1), fo) ==
-                        sz - 1;
+                        (long)fwrite(bytes, 1,
+                                     (size_t)(sz - origin_tail - 1), fo) ==
+                        sz - origin_tail - 1;
                     fclose(fo);
                 }
             }
@@ -1167,11 +1183,13 @@ int main(void) {
         int prev_school = g_leo_school_on;
         int prev_wonder = g_leo_wonder_on;
         int prev_deferred = g_leo_deferred_wonder_on;
+        int prev_redirection = g_leo_wonder_redirection_on;
         int prev_klaus = g_leo_klaus_on;
         int prev_capsule = g_leo_capsule_on;
         g_leo_school_on = 1;
         g_leo_wonder_on = 1;
         g_leo_deferred_wonder_on = 1;
+        g_leo_wonder_redirection_on = 0;
         g_leo_klaus_on = 0;
         g_leo_capsule_on = 0;
 
@@ -1275,6 +1293,7 @@ int main(void) {
         g_leo_school_on = prev_school;
         g_leo_wonder_on = prev_wonder;
         g_leo_deferred_wonder_on = prev_deferred;
+        g_leo_wonder_redirection_on = prev_redirection;
         g_leo_klaus_on = prev_klaus;
         g_leo_capsule_on = prev_capsule;
     }
@@ -1401,9 +1420,11 @@ int main(void) {
      * claim the answer; explicit active naming keeps correction possible. */
     {
         int prev_attr = g_leo_wonder_attribution_on;
+        int prev_redirection = g_leo_wonder_redirection_on;
         int prev_school = g_leo_school_on;
         int prev_wonder = g_leo_wonder_on;
         g_leo_wonder_attribution_on = 1;
+        g_leo_wonder_redirection_on = 0;
         g_leo_school_on = 1;
         g_leo_wonder_on = 1;
 
@@ -1513,8 +1534,305 @@ int main(void) {
         leo_free(&ablated);
 
         g_leo_wonder_attribution_on = prev_attr;
+        g_leo_wonder_redirection_on = prev_redirection;
         g_leo_school_on = prev_school;
         g_leo_wonder_on = prev_wonder;
+    }
+
+    /* A.43: a literal waiting name may redirect the one available mouth. The
+     * displaced active Wonder returns to the bounded queue with its exact birth
+     * provenance; semantic resemblance still has no routing authority. */
+    {
+        int prev_attr = g_leo_wonder_attribution_on;
+        int prev_redirection = g_leo_wonder_redirection_on;
+        int prev_school = g_leo_school_on;
+        int prev_wonder = g_leo_wonder_on;
+        int prev_klaus = g_leo_klaus_on;
+        int prev_capsule = g_leo_capsule_on;
+        g_leo_wonder_attribution_on = 1;
+        g_leo_wonder_redirection_on = 1;
+        g_leo_school_on = 1;
+        g_leo_wonder_on = 1;
+        g_leo_klaus_on = 0;
+        g_leo_capsule_on = 0;
+
+        char out[512], expected[128];
+        Leo redirected;
+        seed_wonder_redirection_body(&redirected);
+        LeoDeferredWonder suvin_origin =
+            redirected.school.pending_origin;
+        int suvin_episode = leo_wonder_find_open(&redirected, "suvin");
+        long suvin_opened = suvin_episode >= 0 ?
+            redirected.school.wonders[suvin_episode].opened_step : -1;
+        srand(4301);
+        leo_respond(&redirected, "Nareth is a dark animal.",
+                    out, sizeof out);
+        int parked = leo_deferred_wonder_find(&redirected, "suvin");
+        int nareth_episode = leo_wonder_find_open(&redirected, "nareth");
+        CHECK(redirected.wonder_address.redirected &&
+              !redirected.wonder_address.guarded &&
+              redirected.curiosity.outcome == LEO_CURIOSITY_RESOLVED &&
+              !redirected.school.pending[0] &&
+              !redirected.school.has_pending_origin &&
+              leo_school_is_learned(&redirected, "nareth") &&
+              !leo_school_is_learned(&redirected, "suvin") &&
+              parked >= 0 && nareth_episode < 0,
+              "wonder-redirection: an explicitly addressed sibling receives its own grounded answer");
+        CHECK(parked >= 0 &&
+              redirected.school.deferred[parked].offered_glyph ==
+                  suvin_origin.offered_glyph &&
+              redirected.school.deferred[parked].offered_alt_glyph ==
+                  suvin_origin.offered_alt_glyph &&
+              redirected.school.deferred[parked].born_turn ==
+                  suvin_origin.born_turn &&
+              !memcmp(redirected.school.deferred[parked].field_token,
+                      suvin_origin.field_token,
+                      sizeof suvin_origin.field_token) &&
+              !memcmp(redirected.school.deferred[parked].field_weight,
+                      suvin_origin.field_weight,
+                      sizeof suvin_origin.field_weight) &&
+              redirected.school.deferred[parked].blocks ==
+                  suvin_origin.blocks + 1,
+              "wonder-redirection: the displaced question keeps hypotheses, birth, and own-field provenance");
+        suvin_episode = leo_wonder_find_open(&redirected, "suvin");
+        CHECK(suvin_episode >= 0 &&
+              redirected.school.wonders[suvin_episode].opened_step ==
+                  suvin_opened &&
+              !redirected.school.wonders[suvin_episode].resolved,
+              "wonder-redirection: parking preserves the first Wonder episode instead of rebirthing it");
+
+        memset(redirected.chamber_act, 0,
+               sizeof redirected.chamber_act);
+        memset(redirected.chamber_ext, 0,
+               sizeof redirected.chamber_ext);
+        leo_school_format_question(expected, sizeof expected, "suvin",
+                                   suvin_origin.offered_glyph,
+                                   suvin_origin.offered_alt_glyph);
+        leo_respond(&redirected, "suvin", out, sizeof out);
+        suvin_episode = leo_wonder_find_open(&redirected, "suvin");
+        CHECK(!strcmp(out, expected) &&
+              redirected.curiosity.outcome ==
+                  LEO_CURIOSITY_ASKED_DEFERRED &&
+              !strcmp(redirected.school.pending, "suvin") &&
+              redirected.school.has_pending_origin &&
+              redirected.school.pending_origin.offered_glyph ==
+                  suvin_origin.offered_glyph &&
+              redirected.school.pending_origin.offered_alt_glyph ==
+                  suvin_origin.offered_alt_glyph &&
+              redirected.school.pending_origin.born_turn ==
+                  suvin_origin.born_turn &&
+              !memcmp(redirected.school.pending_origin.field_token,
+                      suvin_origin.field_token,
+                      sizeof suvin_origin.field_token) &&
+              !memcmp(redirected.school.pending_origin.field_weight,
+                      suvin_origin.field_weight,
+                      sizeof suvin_origin.field_weight) &&
+              suvin_episode >= 0 &&
+              redirected.school.wonders[suvin_episode].opened_step ==
+                  suvin_opened,
+              "wonder-redirection: the first question later returns with its original voice and episode");
+        leo_free(&redirected);
+
+        Leo bare;
+        seed_wonder_redirection_body(&bare);
+        int bare_suvin_episode = leo_wonder_find_open(&bare, "suvin");
+        uint64_t bare_suvin_id = bare_suvin_episode >= 0 ?
+            leo_wonder_episode_id(
+                &bare.school.wonders[bare_suvin_episode]) : 0;
+        leo_flow_observe(&bare, "suvin", "Suvin?", NULL, NULL, NULL,
+                         LEO_FLOW_WONDER_BORN, bare_suvin_id);
+        LeoDeferredWonder nareth_origin =
+            bare.school.deferred[leo_deferred_wonder_find(&bare, "nareth")];
+        leo_school_format_question(expected, sizeof expected, "nareth",
+                                   nareth_origin.offered_glyph,
+                                   nareth_origin.offered_alt_glyph);
+        srand(4302);
+        leo_respond(&bare, "Nareth.", out, sizeof out);
+        parked = leo_deferred_wonder_find(&bare, "suvin");
+        CHECK(!strcmp(out, expected) &&
+              bare.curiosity.outcome == LEO_CURIOSITY_REDIRECTED &&
+              bare.wonder_address.redirected &&
+              !strcmp(bare.school.pending, "nareth") &&
+              bare.school.has_pending_origin &&
+              !memcmp(&bare.school.pending_origin, &nareth_origin,
+                      sizeof nareth_origin) &&
+              parked >= 0 && bare.school.n_wonders == 2 &&
+              !leo_school_is_learned(&bare, "nareth"),
+              "wonder-redirection: a bare sibling address switches questions without inventing an answer");
+        int bare_nareth_episode = leo_wonder_find_open(&bare, "nareth");
+        uint64_t bare_nareth_id = bare_nareth_episode >= 0 ?
+            leo_wonder_episode_id(
+                &bare.school.wonders[bare_nareth_episode]) : 0;
+        const char *multi_current =
+            "/tmp/leo_wonder_redirect_currents_v20.state";
+        Leo bare_woke; leo_init(&bare_woke);
+        CHECK(bare.flow.n_currents == 2 &&
+              leo_save_state(&bare, multi_current) &&
+              leo_load_state(&bare_woke, multi_current) &&
+              bare_woke.flow.n_currents == 2 &&
+              leo_flow_current_find_const(
+                  &bare_woke.flow, bare_suvin_id) &&
+              !leo_flow_current_find_const(
+                  &bare_woke.flow, bare_suvin_id)->resolved &&
+              leo_flow_current_find_const(
+                  &bare_woke.flow, bare_nareth_id) &&
+              !leo_flow_current_find_const(
+                  &bare_woke.flow, bare_nareth_id)->resolved,
+              "wonder-redirection: suspended and active Flow currents survive the same sleep");
+        leo_free(&bare_woke);
+        remove(multi_current);
+        leo_free(&bare);
+
+        Leo semantic;
+        seed_wonder_redirection_body(&semantic);
+        srand(4303);
+        leo_respond(&semantic, "Cat bird. Dark night.",
+                    out, sizeof out);
+        CHECK(!semantic.wonder_address.redirected &&
+              semantic.wonder_address.guarded &&
+              semantic.curiosity.outcome ==
+                  LEO_CURIOSITY_ADDRESS_GUARDED &&
+              !strcmp(semantic.school.pending, "suvin") &&
+              leo_deferred_wonder_find(&semantic, "nareth") >= 0,
+              "wonder-redirection: semantic sibling evidence can guard but cannot switch address");
+        leo_free(&semantic);
+
+        Leo active;
+        seed_wonder_redirection_body(&active);
+        srand(4304);
+        leo_respond(&active,
+                    "Suvin and Nareth are a dark animal.",
+                    out, sizeof out);
+        CHECK(!active.wonder_address.redirected &&
+              active.wonder_address.status ==
+                  LEO_WONDER_ADDRESS_ACTIVE_EXPLICIT &&
+              leo_school_is_learned(&active, "suvin") &&
+              !leo_school_is_learned(&active, "nareth") &&
+              leo_deferred_wonder_find(&active, "nareth") >= 0,
+              "wonder-redirection: explicitly naming the active question wins over a sibling name");
+        leo_free(&active);
+
+        Leo ablated;
+        seed_wonder_redirection_body(&ablated);
+        g_leo_wonder_redirection_on = 0;
+        srand(4305);
+        leo_respond(&ablated, "Nareth is a dark animal.",
+                    out, sizeof out);
+        CHECK(!ablated.wonder_address.redirected &&
+              ablated.wonder_address.guarded &&
+              !strcmp(ablated.school.pending, "suvin") &&
+              !leo_school_is_learned(&ablated, "nareth"),
+              "wonder-redirection: ablation restores A.42's explicit-sibling guard");
+        leo_free(&ablated);
+        g_leo_wonder_redirection_on = 1;
+
+        Leo legacy;
+        seed_wonder_address_body(&legacy);
+        srand(4306);
+        leo_respond(&legacy, "Nareth is a dark animal.",
+                    out, sizeof out);
+        CHECK(!legacy.wonder_address.redirected &&
+              legacy.wonder_address.guarded &&
+              !strcmp(legacy.school.pending, "suvin"),
+              "wonder-redirection: an originless active question fails closed instead of fabricating provenance");
+        leo_free(&legacy);
+
+        Leo full;
+        seed_wonder_redirection_body(&full);
+        const char *extra[] =
+            {"cinder", "dovel", "ember", "frost", "glint", "harbor"};
+        for (int i = 0; i < 6; i++) {
+            full.school.turn_clock++;
+            leo_deferred_wonder_remember(
+                &full, extra[i], semtok_find_glyph("water"),
+                semtok_find_glyph("fire"), 1, NULL, NULL);
+        }
+        CHECK(full.school.n_deferred == LEO_DEFERRED_WONDER_MAX,
+              "wonder-redirection: capacity fixture fills all waiting slots");
+        srand(4307);
+        leo_respond(&full, "Nareth.", out, sizeof out);
+        CHECK(full.school.n_deferred == LEO_DEFERRED_WONDER_MAX &&
+              leo_deferred_wonder_find(&full, "suvin") >= 0 &&
+              leo_deferred_wonder_find(&full, "nareth") < 0,
+              "wonder-redirection: a full queue swaps in place without evicting another question");
+        leo_free(&full);
+
+        Leo sleep;
+        seed_wonder_redirection_body(&sleep);
+        LeoDeferredWonder sleep_origin = sleep.school.pending_origin;
+        const char *state = "/tmp/leo_wonder_origin_v20.state";
+        const char *legacy19 = "/tmp/leo_wonder_origin_v19.state";
+        const char *cut = "/tmp/leo_wonder_origin_v20_cut.state";
+        int saved = leo_save_state(&sleep, state);
+        Leo woke; leo_init(&woke);
+        CHECK(saved && leo_load_state(&woke, state) &&
+              woke.school.has_pending_origin &&
+              !memcmp(&woke.school.pending_origin, &sleep_origin,
+                      sizeof sleep_origin),
+              "wonder-redirection: active provenance survives v20 sleep exactly");
+
+        int built_legacy = 0, built_cut = 0;
+        FILE *fi = fopen(state, "rb");
+        if (fi) {
+            fseek(fi, 0, SEEK_END);
+            long sz = ftell(fi);
+            fseek(fi, 0, SEEK_SET);
+            unsigned char *bytes = malloc(sz > 0 ? (size_t)sz : 1);
+            if (bytes && sz > (long)sizeof(LeoDeferredWonder) + 5 &&
+                (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
+                long origin_tail =
+                    (long)(sizeof(int32_t) + sizeof(LeoDeferredWonder));
+                uint32_t nineteen = 19;
+                memcpy(bytes + sizeof(uint32_t), &nineteen,
+                       sizeof nineteen);
+                FILE *fo = fopen(legacy19, "wb");
+                if (fo) {
+                    built_legacy =
+                        (long)fwrite(bytes, 1,
+                                     (size_t)(sz - origin_tail), fo) ==
+                        sz - origin_tail;
+                    fclose(fo);
+                }
+                uint32_t twenty = 20;
+                memcpy(bytes + sizeof(uint32_t), &twenty,
+                       sizeof twenty);
+                fo = fopen(cut, "wb");
+                if (fo) {
+                    built_cut =
+                        (long)fwrite(bytes, 1, (size_t)(sz - 1), fo) ==
+                        sz - 1;
+                    fclose(fo);
+                }
+            }
+            free(bytes);
+            fclose(fi);
+        }
+        Leo old; leo_init(&old);
+        CHECK(built_legacy && leo_load_state(&old, legacy19) &&
+              !strcmp(old.school.pending, "suvin") &&
+              !old.school.has_pending_origin &&
+              old.school.n_deferred == sleep.school.n_deferred,
+              "wonder-redirection: v19 preserves the question but invents no active provenance");
+        Leo damaged; leo_init(&damaged);
+        CHECK(built_cut && leo_load_state(&damaged, cut) &&
+              !strcmp(damaged.school.pending, "suvin") &&
+              !damaged.school.has_pending_origin &&
+              damaged.school.n_deferred == sleep.school.n_deferred,
+              "wonder-redirection: corrupt v20 provenance loses only redirect authority");
+
+        leo_free(&sleep);
+        leo_free(&woke);
+        leo_free(&old);
+        leo_free(&damaged);
+        remove(state);
+        remove(legacy19);
+        remove(cut);
+        g_leo_wonder_attribution_on = prev_attr;
+        g_leo_wonder_redirection_on = prev_redirection;
+        g_leo_school_on = prev_school;
+        g_leo_wonder_on = prev_wonder;
+        g_leo_klaus_on = prev_klaus;
+        g_leo_capsule_on = prev_capsule;
     }
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
@@ -1741,12 +2059,15 @@ int main(void) {
                 long deferred_tail = (long)(sizeof(int32_t) +
                                              w.school.n_deferred *
                                                  (int)sizeof(LeoDeferredWonder));
+                long origin_tail = (long)(sizeof(int32_t) +
+                                           (w.school.has_pending_origin ?
+                                            sizeof(LeoDeferredWonder) : 0));
                 long current_flow = (long)(2 * sizeof(int32_t) +
                                            w.flow.n * (int)sizeof(LeoFlowSnapshot) +
                                            2 * sizeof(int32_t) +
                                            w.flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
                                            shadow_tail + calibration_tail +
-                                           deferred_tail);
+                                           deferred_tail + origin_tail);
                 if (sz > v12tail + current_flow) {
                     long flow_start = sz - current_flow;
                     long tail_start = flow_start - v12tail;
@@ -2129,12 +2450,15 @@ int main(void) {
                     long deferred_tail = (long)(sizeof(int32_t) +
                                                 fl->school.n_deferred *
                                                     (int)sizeof(LeoDeferredWonder));
+                    long origin_tail = (long)(sizeof(int32_t) +
+                                              (fl->school.has_pending_origin ?
+                                               sizeof(LeoDeferredWonder) : 0));
                     long current_tail = (long)(2 * sizeof(int32_t) +
                                               fl->flow.n * (int)sizeof(LeoFlowSnapshot) +
                                               2 * sizeof(int32_t) +
                                               fl->flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
                                               shadow_tail + calibration_tail +
-                                              deferred_tail);
+                                              deferred_tail + origin_tail);
                     long prefix = sz - current_tail;
                     if (prefix > 0) {
                         long current_only = (long)(2 * sizeof(int32_t) +
@@ -2146,9 +2470,10 @@ int main(void) {
                             built_cut = (long)fwrite(bytes, 1,
                                                      (size_t)(sz - calibration_tail -
                                                               shadow_tail -
-                                                              deferred_tail - 1), fo) ==
+                                                              deferred_tail -
+                                                              origin_tail - 1), fo) ==
                                         sz - calibration_tail - shadow_tail -
-                                            deferred_tail - 1;
+                                            deferred_tail - origin_tail - 1;
                             fclose(fo);
                         }
                         uint32_t fourteen = 14;
@@ -2159,9 +2484,11 @@ int main(void) {
                                                          (size_t)(sz - calibration_tail -
                                                                   shadow_tail -
                                                                   deferred_tail -
+                                                                  origin_tail -
                                                                   current_only), fo) ==
                                              sz - calibration_tail - shadow_tail -
-                                                 deferred_tail - current_only;
+                                                 deferred_tail - origin_tail -
+                                                 current_only;
                             fclose(fo);
                         }
                         uint32_t thirteen = 13;
@@ -2371,6 +2698,9 @@ int main(void) {
                     long deferred_tail = (long)(sizeof(int32_t) +
                                                 sh->school.n_deferred *
                                                     (int)sizeof(LeoDeferredWonder));
+                    long origin_tail = (long)(sizeof(int32_t) +
+                                              (sh->school.has_pending_origin ?
+                                               sizeof(LeoDeferredWonder) : 0));
                     uint32_t fifteen = 15;
                     memcpy(bytes + sizeof(uint32_t), &fifteen, sizeof fifteen);
                     FILE *fo = fopen(legacy, "wb");
@@ -2378,9 +2708,10 @@ int main(void) {
                         built_old = (long)fwrite(bytes, 1,
                                                  (size_t)(sz - calibration_tail -
                                                           shadow_tail -
-                                                          deferred_tail), fo) ==
+                                                          deferred_tail -
+                                                          origin_tail), fo) ==
                                     sz - calibration_tail - shadow_tail -
-                                        deferred_tail;
+                                        deferred_tail - origin_tail;
                         fclose(fo);
                     }
                     uint32_t sixteen = 16;
@@ -2389,8 +2720,10 @@ int main(void) {
                     if (fo) {
                         built_compat = (long)fwrite(bytes, 1,
                                                     (size_t)(sz - calibration_tail -
-                                                             deferred_tail), fo) ==
-                                       sz - calibration_tail - deferred_tail;
+                                                             deferred_tail -
+                                                             origin_tail), fo) ==
+                                       sz - calibration_tail - deferred_tail -
+                                           origin_tail;
                         fclose(fo);
                     }
                     uint32_t seventeen = 17;
@@ -2398,8 +2731,9 @@ int main(void) {
                     fo = fopen(truncated, "wb");
                     if (fo) {
                         built_cut = (long)fwrite(bytes, 1,
-                                                (size_t)(sz - deferred_tail - 1), fo) ==
-                                    sz - deferred_tail - 1;
+                                                (size_t)(sz - deferred_tail -
+                                                         origin_tail - 1), fo) ==
+                                    sz - deferred_tail - origin_tail - 1;
                         fclose(fo);
                     }
                 }
@@ -3184,7 +3518,7 @@ int main(void) {
             FILE *tf = fopen(sp, "rb");
             fseek(tf, 0, SEEK_END); long fl = ftell(tf); fseek(tf, 0, SEEK_SET);
             char *fb = malloc((size_t)fl); fread(fb, 1, (size_t)fl, tf); fclose(tf);
-            tf = fopen(sp, "wb"); fwrite(fb, 1, (size_t)(fl - 64), tf); fclose(tf);
+            tf = fopen(sp, "wb"); fwrite(fb, 1, (size_t)(fl - 65), tf); fclose(tf);
             free(fb);
         }
         Leo l3; leo_init(&l3);


### PR DESCRIPTION
Method: The Arianna Method treats explicit conversational address as a reversible transfer of the one speaking slot, never as semantic ownership inferred from resemblance.

Persist active-Wonder provenance in state v20, redirect only an explicitly named waiting sibling, and preserve the displaced question's hypotheses, birth field, episode, and Flow current across sleep. Keep semantic siblings guard-only and old or corrupt bodies fail-closed.

Evidence: 316/316 contracts; full UBSan suite; ASan/UBSan smoke; deterministic two-cohort 10-cell A.43 matrix twice; 6/6 redirects diverge, 4/4 controls stay byte-identical, and 2/2 displaced questions return exactly; isolated A.42 and A.41 retain their prior results.

Quote: "A question may yield the mouth without yielding its history." - Sol