### PR TITLE
the Method lets an unfinished question gather appetite before it can act

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4079,3 +4079,64 @@ its original **14 cells, 4 guards, and 10 non-guard equal states**; isolated A.4
 **16/16 reply and state equality**.
 
 Leo can now yield the mouth without yielding the history of the question that was speaking.
+
+## Phase A.44 — a waiting question can gather appetite without taking the mouth (2026-07-26)
+
+A.43 made conversational address reversible, but it still required the human to name the next
+question. The deferred constellation had chronology, hypotheses, birth fields, episodes, and
+event-bounded Flow currents, yet no common surface on which those histories could say: this
+unfinished question is becoming present again. Choosing a return policy before measuring that
+pressure would have turned one plausible intuition into a hidden speech command.
+
+A.44 therefore adds another observer, not a scheduler. It runs only after Leo has already spoken and
+the lived turn has entered Flow. For every final waiting question it records:
+
+```text
+recurrence = 0.8 * grounded glyph echo + 0.2 * own-field echo
+silence    = clamp((turn - last_seen_turn) / 8)
+unfinished = 1 for an open spoken episode, else blocks / (blocks + 1)
+flow_gap   = 1 - cosine(the question's perceived and expressed Flow means)
+appetite   = 0.55 recurrence + 0.15 silence + 0.20 unfinished + 0.10 flow_gap
+```
+
+The candidate's own unresolved episode selects its Flow current; another question's active current
+cannot lend it a residual. A current with no semantic mass contributes no fabricated gap. Literal
+names are external invitations and are excluded from autonomous ranking because A.43 already owns
+explicit address.
+
+Recurrence remains load-bearing. `salient` requires recurrence `>=0.75`, appetite `>=0.62`, and a
+lead of `>=0.15`. Silence, unfinished depth, and Flow residual together contribute at most `0.45`, so
+an absent meaning can become legible but can never win. Weak or mixed meaning is `diffuse`; unrelated
+age is `quiet`. The receipt is transient, absent from state v20, and has no reader in School, routing,
+generation, Flow, or the existing shadow scheduler.
+
+Eight direct contracts raised the suite from **316/316** to **324/324**. They cover a strong semantic
+winner, zero School/Flow mutation, mixed non-ownership, age without nomination, literal
+non-autonomy, exact parked-current residual, non-persistence across sleep, and ablation.
+
+The process matrix rebuilt the two independent A.40 bodies and compared every default turn with
+`--no-wonder-appetite`:
+
+```text
+cells=10
+salient=4
+diffuse=4
+quiet=2
+spoken winners=2
+reply equal=10/10
+complete saved-state equal=10/10
+```
+
+Both unspoken semantic returns selected slot 2 with appetite `0.690`. Both parked returns selected the
+displaced slot 1 with `spoken=1`, `unfinished=1`, `flow_gap=1`, and appetite about `0.82`. Weak and
+mixed traces remained ownerless. In both aged controls every question had `silence=1`, yet no winner
+was named. Two complete A.44 runs reproduced matrix rows, receipts, state hashes, and summaries
+byte-for-byte.
+
+With A.44 explicitly ablated, A.41 retained **16/16** reply/state equality, A.42 retained its
+**14 cells and 4 guards**, and A.43 retained **6/6 redirects and 2/2 exact displaced-question
+returns**. The old proofs remain historical controls rather than becoming accidental clients of the
+new score.
+
+Leo can now feel that an unfinished question is returning before he is allowed to decide what to do
+with that feeling.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite
 
 all: leo
 
@@ -64,6 +64,9 @@ deferred-wonder-attribution: leo
 deferred-wonder-redirection: leo
 	./scripts/deferred_wonder_redirection_matrix.sh
 
+deferred-wonder-appetite: leo
+	./scripts/deferred_wonder_appetite_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -72,12 +75,14 @@ test: tests/test_leo.c leo.c
 	./scripts/test_prewonder_dialogue_report.sh
 	./scripts/test_prewonder_shadow_dialogue_report.sh
 	./scripts/test_wonder_address_dialogue_report.sh
+	./scripts/test_wonder_appetite_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
 	./scripts/test_deferred_wonder_semantic_matrix.sh
 	./scripts/test_deferred_wonder_attribution_matrix.sh
 	./scripts/test_deferred_wonder_redirection_matrix.sh
+	./scripts/test_deferred_wonder_appetite_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1699,6 +1699,41 @@ typedef struct {
     uint8_t status;
 } LeoPreWonderShadowReceipt;
 
+/* A.44: a deferred question may gather a measurable appetite to return without
+ * receiving a scheduling right. Recurrence must carry the result: silence and
+ * unfinished depth can strengthen a returning meaning, but age alone cannot
+ * nominate a question. The receipt is one-turn and has no persistent reader. */
+#define LEO_WONDER_APPETITE_SILENCE_HORIZON 8.0f
+#define LEO_WONDER_APPETITE_RESONANCE_MIN   0.75f
+#define LEO_WONDER_APPETITE_SCORE_MIN       0.62f
+#define LEO_WONDER_APPETITE_MARGIN          0.15f
+enum {
+    LEO_WONDER_APPETITE_EMPTY = 0,
+    LEO_WONDER_APPETITE_QUIET,
+    LEO_WONDER_APPETITE_DIFFUSE,
+    LEO_WONDER_APPETITE_SALIENT,
+    LEO_WONDER_APPETITE_LITERAL,
+    LEO_WONDER_APPETITE_STATUS_COUNT
+};
+typedef struct {
+    char    word[LEO_HEARD_WORDLEN];
+    float   recurrence;
+    float   silence;
+    float   unfinished;
+    float   flow_gap;
+    float   appetite;
+    uint8_t spoken;
+    uint8_t literal;
+} LeoWonderAppetiteCandidate;
+typedef struct {
+    uint64_t turn;
+    LeoWonderAppetiteCandidate candidates[LEO_DEFERRED_WONDER_MAX];
+    int     n_candidates;
+    int     winner;
+    float   margin;
+    uint8_t status;
+} LeoWonderAppetiteReceipt;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -1861,6 +1896,9 @@ typedef struct {
     /* A.41: one-turn semantic echo among withheld questions. Diagnostic only;
      * neither School nor generation reads it. */
     LeoPreWonderShadowReceipt prewonder_shadow;
+    /* A.44: future-return appetite over the final waiting constellation. It is
+     * written after speech and Flow, and read only by diagnostics. */
+    LeoWonderAppetiteReceipt wonder_appetite;
     /* A.42/A.43: pre-grounding address witness. Semantic conflict can only
      * guard; an exact waiting name may redirect without assigning meaning. */
     LeoWonderAddressReceipt wonder_address;
@@ -2136,6 +2174,7 @@ static int g_leo_school_on = 1;         /* --no-school → 0 (A.5: School revers
 static int g_leo_wonder_on = 1;         /* unfinished wonder: grounded alternatives + persistence across non-answers. --no-wonder restores the prior School contract. */
 static int g_leo_deferred_wonder_on = 1; /* pre-Wonder: a distress-blocked question remains askable when its word returns safely. */
 static int g_leo_prewonder_shadow_on = 1; /* read-only semantic echo among withheld questions; no speech reader. */
+static int g_leo_wonder_appetite_on = 1; /* read-only return appetite over waiting questions; no scheduler or speech reader. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -5930,6 +5969,146 @@ static int leo_flow_current_valid(const Leo *leo,
     return 1;
 }
 
+static float leo_wonder_appetite_flow_gap(
+        const Leo *leo, const char *word, uint8_t *spoken) {
+    if (spoken) *spoken = 0;
+    int episode = leo_wonder_find_open(leo, word);
+    if (episode < 0) return 0.0f;
+    if (spoken) *spoken = 1;
+
+    uint64_t wonder_id =
+        leo_wonder_episode_id(&leo->school.wonders[episode]);
+    const LeoFlowWonderCurrent *current =
+        leo_flow_current_find_const(&leo->flow, wonder_id);
+    if (!current || current->resolved) return 0.0f;
+
+    float mass = 0.0f;
+    for (int g = 0; g < GLYPH_COUNT; g++)
+        mass += current->perceived_mean[g] +
+                current->expressed_mean[g];
+    if (mass <= 1e-6f) return 0.0f;
+    return clampf(
+        1.0f - leo_vec_cosine(
+            current->perceived_mean, current->expressed_mean,
+            GLYPH_COUNT),
+        0.0f, 1.0f);
+}
+
+/* Read the final waiting constellation after this turn has already spoken and
+ * entered Flow. Recurrence carries most of the score. Silence, unfinished
+ * depth, and a question's own perception/expression residual can strengthen a
+ * recurrence, but their combined maximum cannot make an absent meaning
+ * salient. Literal names are external invitations and are excluded from the
+ * autonomous ranking. Nothing outside diagnostics reads this receipt. */
+static void leo_wonder_appetite_observe(
+        Leo *leo, const char *prompt,
+        const int32_t field_token[LEO_PREWONDER_FIELD],
+        const float field_weight[LEO_PREWONDER_FIELD]) {
+    LeoWonderAppetiteReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.turn = leo ? (uint64_t)leo->school.turn_clock : 0;
+    receipt.winner = -1;
+    receipt.status = LEO_WONDER_APPETITE_EMPTY;
+    if (!leo || !prompt || !g_leo_wonder_appetite_on ||
+        !g_leo_wonder_on || !g_leo_deferred_wonder_on ||
+        !g_leo_flow_on) {
+        if (leo) leo->wonder_appetite = receipt;
+        return;
+    }
+
+    int hist[GLYPH_COUNT];
+    int total = leo_school_glyph_votes(leo, prompt, hist, 1);
+    int top = -1, second = -1, literals = 0;
+    for (int i = 0; i < leo->school.n_deferred; i++) {
+        const LeoDeferredWonder *entry = &leo->school.deferred[i];
+        LeoWonderAppetiteCandidate *candidate =
+            &receipt.candidates[receipt.n_candidates++];
+        strncpy(candidate->word, entry->word, LEO_HEARD_WORDLEN - 1);
+        candidate->word[LEO_HEARD_WORDLEN - 1] = 0;
+        candidate->literal =
+            (uint8_t)leo_flow_prompt_has_word(prompt, entry->word);
+        if (candidate->literal) literals++;
+
+        float glyph = leo_wonder_glyph_evidence(
+            hist, total, entry->offered_glyph,
+            entry->offered_alt_glyph);
+        float field = 0.0f;
+        if (field_token && field_weight)
+            field = leo_prewonder_field_similarity(
+                entry->field_token, entry->field_weight,
+                field_token, field_weight);
+        candidate->recurrence = clampf(
+            0.8f * glyph + 0.2f * field, 0.0f, 1.0f);
+
+        uint64_t silence = receipt.turn >= entry->last_seen_turn ?
+            receipt.turn - entry->last_seen_turn : 0;
+        candidate->silence = clampf(
+            (float)silence / LEO_WONDER_APPETITE_SILENCE_HORIZON,
+            0.0f, 1.0f);
+        candidate->flow_gap = leo_wonder_appetite_flow_gap(
+            leo, entry->word, &candidate->spoken);
+        candidate->unfinished = candidate->spoken ? 1.0f :
+            (float)entry->blocks / ((float)entry->blocks + 1.0f);
+        candidate->appetite = clampf(
+            0.55f * candidate->recurrence +
+            0.15f * candidate->silence +
+            0.20f * candidate->unfinished +
+            0.10f * candidate->flow_gap,
+            0.0f, 1.0f);
+
+        if (candidate->literal) continue;
+        int at = receipt.n_candidates - 1;
+        if (top < 0 ||
+            candidate->appetite >
+                receipt.candidates[top].appetite ||
+            (candidate->appetite ==
+                 receipt.candidates[top].appetite &&
+             strcmp(candidate->word,
+                    receipt.candidates[top].word) < 0)) {
+            second = top;
+            top = at;
+        } else if (second < 0 ||
+                   candidate->appetite >
+                       receipt.candidates[second].appetite ||
+                   (candidate->appetite ==
+                        receipt.candidates[second].appetite &&
+                    strcmp(candidate->word,
+                           receipt.candidates[second].word) < 0)) {
+            second = at;
+        }
+    }
+
+    if (top < 0) {
+        receipt.status = literals ?
+            LEO_WONDER_APPETITE_LITERAL :
+            LEO_WONDER_APPETITE_EMPTY;
+        leo->wonder_appetite = receipt;
+        return;
+    }
+    float runner = second >= 0 ?
+        receipt.candidates[second].appetite : 0.0f;
+    receipt.margin = clampf(
+        receipt.candidates[top].appetite - runner, 0.0f, 1.0f);
+    if (literals) {
+        receipt.status = LEO_WONDER_APPETITE_LITERAL;
+    } else if (
+        receipt.candidates[top].recurrence >=
+            LEO_WONDER_APPETITE_RESONANCE_MIN &&
+        receipt.candidates[top].appetite >=
+            LEO_WONDER_APPETITE_SCORE_MIN &&
+        receipt.margin >= LEO_WONDER_APPETITE_MARGIN) {
+        receipt.winner = top;
+        receipt.status = LEO_WONDER_APPETITE_SALIENT;
+    } else if (
+        receipt.candidates[top].recurrence >= 0.15f ||
+        receipt.candidates[top].appetite >= 0.45f) {
+        receipt.status = LEO_WONDER_APPETITE_DIFFUSE;
+    } else {
+        receipt.status = LEO_WONDER_APPETITE_QUIET;
+    }
+    leo->wonder_appetite = receipt;
+}
+
 static int leo_flow_kind(const LeoFlow *flow, int glyph, int window, int face) {
     if (!flow || flow->n <= 0 || glyph < 0 || glyph >= GLYPH_COUNT) return LEO_FLOW_QUIET;
     if (window < 3) window = 3;
@@ -6554,6 +6733,8 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     leo->school.returned_episode = -1;       /* one-reply diagnostic; meaning itself is local below */
     memset(&leo->wonder_address, 0, sizeof leo->wonder_address);
     leo->wonder_address.winner = -1;
+    memset(&leo->wonder_appetite, 0, sizeof leo->wonder_appetite);
+    leo->wonder_appetite.winner = -1;
     if (leo->school.turn_clock < LONG_MAX) leo->school.turn_clock++;
     leo_ingest(leo, prompt);                 /* Leo hears you */
     leo_field_chambers_feel_text(leo, prompt); /* prompt drives the chamber EXT inputs */
@@ -6944,6 +7125,8 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     if (leo->school.returned_episode >= 0) flow_event |= LEO_FLOW_WONDER_RECALLED;
     leo_flow_observe(leo, prompt, out, pm, flow_field_token, flow_field_weight,
                      flow_event, flow_wonder_id);  /* observation only: no generation path reads flow */
+    leo_wonder_appetite_observe(
+        leo, prompt, prewonder_field_token, prewonder_field_weight);
     leo_shadow_calibrate(leo, prompt);            /* judge t-1 only after t has become history */
     leo_shadow_observe(leo);                      /* after speech: a proposal for the next turn, never a reader */
     leo->gravity = NULL;
@@ -8169,6 +8352,42 @@ static void print_prewonder_shadow_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_appetite_stats(const Leo *leo) {
+    if (!g_leo_wonder_appetite_on || !leo ||
+        leo->wonder_appetite.n_candidates == 0)
+        return;
+    const LeoWonderAppetiteReceipt *receipt =
+        &leo->wonder_appetite;
+    static const char *statuses[LEO_WONDER_APPETITE_STATUS_COUNT] = {
+        "empty", "quiet", "diffuse", "salient", "literal"
+    };
+    int status =
+        receipt->status < LEO_WONDER_APPETITE_STATUS_COUNT ?
+            receipt->status : LEO_WONDER_APPETITE_EMPTY;
+    const char *winner =
+        receipt->winner >= 0 &&
+        receipt->winner < receipt->n_candidates ?
+            receipt->candidates[receipt->winner].word : "none";
+    printf("     [wonder-appetite: turn=%llu status=%s winner=%s margin=%.3f pending=%s entries=",
+           (unsigned long long)receipt->turn, statuses[status], winner,
+           (double)receipt->margin,
+           leo->school.pending[0] ? leo->school.pending : "none");
+    for (int i = 0; i < receipt->n_candidates; i++) {
+        const LeoWonderAppetiteCandidate *candidate =
+            &receipt->candidates[i];
+        printf("%s%s:%.3f/%.3f/%.3f/%.3f/%.3f/%u/%u",
+               i ? "|" : "", candidate->word,
+               (double)candidate->recurrence,
+               (double)candidate->silence,
+               (double)candidate->unfinished,
+               (double)candidate->flow_gap,
+               (double)candidate->appetite,
+               (unsigned)candidate->spoken,
+               (unsigned)candidate->literal);
+    }
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -8402,6 +8621,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder")) g_leo_wonder_on = 0;
         else if (!strcmp(argv[i], "--no-deferred-wonder")) g_leo_deferred_wonder_on = 0;
         else if (!strcmp(argv[i], "--no-prewonder-shadow")) g_leo_prewonder_shadow_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite")) g_leo_wonder_appetite_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -8616,6 +8836,7 @@ int main(int argc, char **argv) {
             }
             print_wonder_address_stats(&leo);
             print_prewonder_shadow_stats(&leo);
+            print_wonder_appetite_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -8673,6 +8894,7 @@ int main(int argc, char **argv) {
             }
             print_wonder_address_stats(&leo);
             print_prewonder_shadow_stats(&leo);
+            print_wonder_appetite_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -276,6 +276,47 @@ The grounded switch additionally sleeps, then returns slot 1 and requires its
 original question verbatim. `LEO_REDIRECTION_PLAN_ONLY=1` validates the ten-cell
 design without running Leo.
 
+Run the deferred-Wonder return-appetite matrix:
+
+```sh
+make deferred-wonder-appetite
+```
+
+A.44 observes which waiting question is gathering pressure to return, after the
+reply and its Flow snapshot are already history. It remains a shadow organ:
+School, generation, routing, and the existing shadow scheduler have no reader
+for its receipt. `--no-wonder-appetite` therefore removes only
+`[wonder-appetite: ...]`; reply bytes and saved state must remain identical.
+State stays at v20 because the appetite is not a persistent self-description.
+
+Each waiting candidate exposes five bounded components:
+
+```text
+recurrence = 0.8 * grounded glyph echo + 0.2 * own-field echo
+silence    = clamp((turn - last_seen_turn) / 8)
+unfinished = 1 when the question has an open spoken episode,
+             otherwise blocks / (blocks + 1)
+flow_gap   = 1 - cosine(perceived_mean, expressed_mean)
+appetite   = 0.55 * recurrence + 0.15 * silence
+           + 0.20 * unfinished + 0.10 * flow_gap
+```
+
+`flow_gap` belongs to the candidate's exact event-bounded Flow current and is
+zero when no such current has meaningful mass. A candidate becomes `salient`
+only when recurrence is at least `0.75`, appetite at least `0.62`, and its lead
+at least `0.15`. Thus maximal silence, unfinished depth, and Flow residual still
+cannot nominate a question whose meaning did not return. Weak and mixed echoes
+remain `diffuse`; old unrelated questions remain `quiet`. Literal names are
+marked `literal` and excluded from autonomous ranking because A.43 already
+treats them as human address.
+
+The checked matrix grows the two independent A.40 bodies and compares default
+against `--no-wonder-appetite` in five forks per body: strong semantic return,
+weak return, mixed return, maximally aged quiet, and a semantic return to a
+spoken question parked by A.43. The parked fork must identify the displaced
+question with `spoken=1`, `unfinished=1`, and `flow_gap>=0.90`. Every one of the
+ten forks requires reply and complete saved-state equality.
+
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,
 but only through the narrow visible sensors above. Selecting a move from shadow

--- a/scripts/deferred_wonder_appetite_cases.tsv
+++ b/scripts/deferred_wonder_appetite_cases.tsv
@@ -1,0 +1,6 @@
+case	kind	prompt	expected_status	expected_winner_slot	expected_spoken	min_recurrence	min_flow_gap	expected_count	expected_pending_slot
+semantic-return	semantic	Cat bird. Dark night.	salient	2	0	0.75	0.00	3	0
+weak-return	weak	Bright.	diffuse	0	0	0.00	0.00	3	0
+mixed-return	mixed	Bright sun and dark night.	diffuse	0	0	0.00	0.00	3	0
+aged-quiet	quiet	I do not know.	quiet	0	0	0.00	0.00	3	0
+parked-return	parked	Bright sun. Cold winter.	salient	1	1	0.75	0.90	2	2

--- a/scripts/deferred_wonder_appetite_matrix.sh
+++ b/scripts/deferred_wonder_appetite_matrix.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# A.44: read-only return appetite over deferred Wonders.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GROUPS_FILE="${LEO_APPETITE_GROUPS:-$ROOT/scripts/deferred_wonder_constellation_groups.tsv}"
+CASES_FILE="${LEO_APPETITE_CASES:-$ROOT/scripts/deferred_wonder_appetite_cases.tsv}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+for fixture in "$GROUPS_FILE" "$CASES_FILE"; do
+    [ -f "$fixture" ] || {
+        printf 'appetite fixture not found: %s\n' "$fixture" >&2
+        exit 2
+    }
+done
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 10 || $1 != "case" || $2 != "kind" ||
+            $3 != "prompt" || $4 != "expected_status" ||
+            $5 != "expected_winner_slot" || $6 != "expected_spoken" ||
+            $7 != "min_recurrence" || $8 != "min_flow_gap" ||
+            $9 != "expected_count" || $10 != "expected_pending_slot")
+            exit 1
+        next
+    }
+    {
+        if (NF != 10 || seen[$1]++ || $5 !~ /^[0-3]$/ ||
+            $6 !~ /^[01]$/ || $7 !~ /^[01](\.[0-9]+)?$/ ||
+            $8 !~ /^[01](\.[0-9]+)?$/ || $9 !~ /^[0-3]$/ ||
+            $10 !~ /^[0-3]$/)
+            exit 1
+        kinds[$2]++
+        statuses[$4]++
+        rows++
+    }
+    END {
+        if (rows != 5 || kinds["semantic"] != 1 ||
+            kinds["weak"] != 1 || kinds["mixed"] != 1 ||
+            kinds["quiet"] != 1 || kinds["parked"] != 1 ||
+            statuses["salient"] != 2 ||
+            statuses["diffuse"] != 2 || statuses["quiet"] != 1)
+            exit 1
+    }
+' "$CASES_FILE" || {
+    printf 'invalid appetite cases: %s\n' "$CASES_FILE" >&2
+    exit 2
+}
+
+mkdir -p "$OUT/lives"
+PLAN="$OUT/plan.tsv"
+MATRIX="$OUT/matrix.tsv"
+RECEIPTS="$OUT/receipts.tsv"
+SUMMARY="$OUT/summary.txt"
+
+group_field() {
+    local group="$1"
+    local slot="$2"
+    local field="$3"
+    awk -F '\t' -v group="$group" -v slot="$slot" -v field="$field" '
+        NR > 1 && $1 == group && $4 == slot {
+            print $field
+            exit
+        }
+    ' "$GROUPS_FILE"
+}
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+appetite_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_dialogue_report.awk" "$1"
+}
+
+inventory_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/prewonder_dialogue_report.awk" "$1"
+}
+
+candidate_fields() {
+    local entries="$1"
+    local wanted="$2"
+    printf '%s\n' "$entries" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    print values[1] "\t" values[2] "\t" values[3] \
+                          "\t" values[4] "\t" values[5] "\t" \
+                          values[6] "\t" values[7]
+                    exit
+                }
+            }
+        '
+}
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+printf 'cell\tgroup\tcohort\tseed\tcase\tkind\tprompt\texpected_status\texpected_winner\n' \
+    > "$PLAN"
+awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
+    "$GROUPS_FILE" |
+while IFS=$'\t' read -r group cohort seed; do
+    while IFS=$'\t' read -r case kind prompt status winner_slot _; do
+        [ "$case" = "case" ] && continue
+        winner="none"
+        if [ "$winner_slot" -gt 0 ]; then
+            winner="$(group_field "$group" "$winner_slot" 5)"
+        fi
+        printf '%s-%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$group" "$case" "$group" "$cohort" "$seed" "$case" \
+            "$kind" "$prompt" "$status" "$winner" >> "$PLAN"
+    done < "$CASES_FILE"
+done
+
+if [ "${LEO_APPETITE_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"$ROOT/scripts/deferred_wonder_constellation_matrix.sh" \
+    "$OUT/a40-baseline" > "$OUT/a40-baseline.log"
+
+printf 'cell\tgroup\tcohort\tcase\tkind\tstatus\twinner\tmargin\tpending\twinner_recurrence\twinner_silence\twinner_unfinished\twinner_flow_gap\twinner_appetite\twinner_spoken\tcount\treply_equal\tstate_equal\ton_sha256\toff_sha256\n' \
+    > "$MATRIX"
+printf 'cell\tturn\tstatus\twinner\tmargin\tpending\tentries\tprompt\treply\n' \
+    > "$RECEIPTS"
+
+group_index=0
+awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
+    "$GROUPS_FILE" |
+while IFS=$'\t' read -r group cohort seed; do
+    group_index=$((group_index + 1))
+    group_dir="$OUT/lives/$group"
+    mkdir -p "$group_dir"
+    ready="$OUT/a40-baseline/groups/$group/ready.state"
+    [ -f "$ready" ] || {
+        printf 'missing A.40 ready body: %s\n' "$ready" >&2
+        exit 1
+    }
+
+    active="$(group_field "$group" 1 5)"
+    sibling="$(group_field "$group" 2 5)"
+    active_question="$(group_field "$group" 1 9)"
+    sibling_question="$(group_field "$group" 2 9)"
+    cp "$ready" "$group_dir/parked-base.state"
+    "$ROOT/leo" --load "$group_dir/parked-base.state" \
+        --seed "$((seed + 4100))" --respond "$active" --debug-field \
+        --no-wonder-appetite --save "$group_dir/parked-base.state" \
+        > "$group_dir/parked-open.log" 2>&1
+    [ "$(reply_from_log "$group_dir/parked-open.log")" = "$active_question" ] || {
+        printf '%s failed to open parked control\n' "$group" >&2
+        exit 1
+    }
+    "$ROOT/leo" --load "$group_dir/parked-base.state" \
+        --seed "$((seed + 4101))" --respond "$sibling" --debug-field \
+        --no-wonder-appetite --save "$group_dir/parked-base.state" \
+        > "$group_dir/parked-switch.log" 2>&1
+    [ "$(reply_from_log "$group_dir/parked-switch.log")" = "$sibling_question" ] || {
+        printf '%s failed to switch the parked control\n' "$group" >&2
+        exit 1
+    }
+
+    case_index=0
+    while IFS=$'\t' read -r case kind prompt expected_status \
+        winner_slot expected_spoken min_recurrence min_flow_gap \
+        expected_count expected_pending_slot; do
+        [ "$case" = "case" ] && continue
+        case_index=$((case_index + 1))
+        cell="$group-$case"
+        cell_dir="$group_dir/$case"
+        mkdir -p "$cell_dir"
+        base="$ready"
+        [ "$kind" != "parked" ] ||
+            base="$group_dir/parked-base.state"
+
+        expected_winner="none"
+        if [ "$winner_slot" -gt 0 ]; then
+            expected_winner="$(group_field "$group" "$winner_slot" 5)"
+        fi
+        expected_pending="none"
+        if [ "$expected_pending_slot" -gt 0 ]; then
+            expected_pending="$(
+                group_field "$group" "$expected_pending_slot" 5
+            )"
+        fi
+
+        cp "$base" "$cell_dir/on.state"
+        cp "$base" "$cell_dir/off.state"
+        run_seed=$((seed + 4400 + group_index * 100 + case_index))
+        "$ROOT/leo" --load "$cell_dir/on.state" --seed "$run_seed" \
+            --respond "$prompt" --debug-field --save "$cell_dir/on.state" \
+            > "$cell_dir/on.log" 2>&1
+        "$ROOT/leo" --load "$cell_dir/off.state" --seed "$run_seed" \
+            --respond "$prompt" --debug-field --no-wonder-appetite \
+            --save "$cell_dir/off.state" > "$cell_dir/off.log" 2>&1
+
+        appetite="$(
+            appetite_from_log "$cell_dir/on.log" "$cell" "$run_seed"
+        )"
+        off_appetite="$(
+            appetite_from_log "$cell_dir/off.log" "$cell" "$run_seed"
+        )"
+        inventory="$(
+            inventory_from_log "$cell_dir/on.log" "$cell" "$run_seed"
+        )"
+        [ -n "$appetite" ] && [ -z "$off_appetite" ] &&
+        [ -n "$inventory" ] || {
+            printf '%s appetite ablation surface failed\n' "$cell" >&2
+            exit 1
+        }
+
+        IFS=$'\t' read -r _ _ turn status winner margin pending entries \
+            <<< "$appetite"
+        IFS=$'\t' read -r _ _ inventory_turn count inventory_pending \
+            episodes resolved inventory_entries <<< "$inventory"
+        [ "$turn" = "$inventory_turn" ] || {
+            printf '%s diagnostic turn disagreement\n' "$cell" >&2
+            exit 1
+        }
+
+        winner_recurrence=0
+        winner_silence=0
+        winner_unfinished=0
+        winner_flow_gap=0
+        winner_appetite=0
+        winner_spoken=0
+        winner_literal=0
+        if [ "$winner" != "none" ]; then
+            fields="$(candidate_fields "$entries" "$winner")"
+            [ -n "$fields" ] || {
+                printf '%s winner missing from entries\n' "$cell" >&2
+                exit 1
+            }
+            IFS=$'\t' read -r winner_recurrence winner_silence \
+                winner_unfinished winner_flow_gap winner_appetite \
+                winner_spoken winner_literal <<< "$fields"
+        fi
+
+        if [ "$kind" = "quiet" ]; then
+            fields="$(candidate_fields "$entries" "$active")"
+            [ -n "$fields" ] || {
+                printf '%s aged candidate missing from entries\n' "$cell" >&2
+                exit 1
+            }
+            IFS=$'\t' read -r quiet_recurrence quiet_silence _ \
+                <<< "$fields"
+            [ "$quiet_silence" = "1.000" ] &&
+            awk -v got="$quiet_recurrence" \
+                'BEGIN { exit !((got + 0) < 0.15) }' || {
+                printf '%s age-only guard failed: recurrence=%s silence=%s\n' \
+                    "$cell" "$quiet_recurrence" "$quiet_silence" >&2
+                exit 1
+            }
+        fi
+
+        on_reply="$(reply_from_log "$cell_dir/on.log")"
+        off_reply="$(reply_from_log "$cell_dir/off.log")"
+        reply_equal=0
+        state_equal=0
+        [ "$on_reply" = "$off_reply" ] && reply_equal=1
+        on_sha="$(sha256_file "$cell_dir/on.state")"
+        off_sha="$(sha256_file "$cell_dir/off.state")"
+        [ "$on_sha" = "$off_sha" ] && state_equal=1
+
+        [ "$status" = "$expected_status" ] &&
+        [ "$winner" = "$expected_winner" ] &&
+        [ "$pending" = "$expected_pending" ] &&
+        [ "$inventory_pending" = "$expected_pending" ] &&
+        [ "$count" = "$expected_count" ] &&
+        [ "$winner_spoken" = "$expected_spoken" ] &&
+        [ "$winner_literal" = 0 ] &&
+        [ "$reply_equal" = 1 ] &&
+        [ "$state_equal" = 1 ] &&
+        awk -v got="$winner_recurrence" -v want="$min_recurrence" \
+            'BEGIN { exit !((got + 0) >= (want + 0)) }' &&
+        awk -v got="$winner_flow_gap" -v want="$min_flow_gap" \
+            'BEGIN { exit !((got + 0) >= (want + 0)) }' || {
+            printf '%s contract failed: status=%s winner=%s pending=%s count=%s recurrence=%s flow_gap=%s spoken=%s reply_equal=%s state_equal=%s\n' \
+                "$cell" "$status" "$winner" "$pending" "$count" \
+                "$winner_recurrence" "$winner_flow_gap" \
+                "$winner_spoken" "$reply_equal" "$state_equal" >&2
+            exit 1
+        }
+
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$cell" "$group" "$cohort" "$case" "$kind" "$status" \
+            "$winner" "$margin" "$pending" "$winner_recurrence" \
+            "$winner_silence" "$winner_unfinished" "$winner_flow_gap" \
+            "$winner_appetite" "$winner_spoken" "$count" \
+            "$reply_equal" "$state_equal" "$on_sha" "$off_sha" \
+            >> "$MATRIX"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$cell" "$turn" "$status" "$winner" "$margin" "$pending" \
+            "$entries" "$prompt" "$on_reply" >> "$RECEIPTS"
+    done < "$CASES_FILE"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        cells++
+        status[$6]++
+        spoken += $15
+        reply_equal += $17
+        state_equal += $18
+    }
+    END {
+        print "cells\tsalient\tdiffuse\tquiet\tspoken_winners\treply_equal\tstate_equal"
+        print cells "\t" status["salient"] "\t" status["diffuse"] \
+              "\t" status["quiet"] "\t" spoken "\t" reply_equal \
+              "\t" state_equal
+    }
+' "$MATRIX" > "$SUMMARY"
+
+cat "$SUMMARY"
+printf '\nmatrix: %s\nreceipts: %s\n' "$MATRIX" "$RECEIPTS"

--- a/scripts/deferred_wonder_attribution_matrix.sh
+++ b/scripts/deferred_wonder_attribution_matrix.sh
@@ -149,7 +149,7 @@ while IFS=$'\t' read -r group cohort seed; do
     cp "$ready" "$group_dir/open.state"
     "$ROOT/leo" --load "$group_dir/open.state" \
         --seed "$((seed + 1700))" --respond "$active" --debug-field \
-        --no-wonder-redirection \
+        --no-wonder-redirection --no-wonder-appetite \
         --save "$group_dir/open.state" > "$group_dir/open.log" 2>&1
     [ "$(reply_from_log "$group_dir/open.log")" = "$expected_question" ] || {
         printf '%s failed to open the active control\n' "$group" >&2
@@ -192,11 +192,12 @@ while IFS=$'\t' read -r group cohort seed; do
         run_seed=$((seed + 2000 + group_index * 100 + case_index))
         "$ROOT/leo" --load "$cell_dir/on.state" --seed "$run_seed" \
             --respond "$prompt" --debug-field --no-wonder-redirection \
+            --no-wonder-appetite \
             --save "$cell_dir/on.state" \
             > "$cell_dir/on.log" 2>&1
         "$ROOT/leo" --load "$cell_dir/off.state" --seed "$run_seed" \
             --respond "$prompt" --debug-field --no-wonder-attribution \
-            --no-wonder-redirection \
+            --no-wonder-redirection --no-wonder-appetite \
             --save "$cell_dir/off.state" > "$cell_dir/off.log" 2>&1
 
         address="$(address_from_log "$cell_dir/on.log" "$cell" "$run_seed")"

--- a/scripts/deferred_wonder_constellation_matrix.sh
+++ b/scripts/deferred_wonder_constellation_matrix.sh
@@ -209,11 +209,12 @@ while IFS=$'\t' read -r group cohort seed; do
         log="$group_dir/turns/turn-$(printf '%02d' "$turn")-birth.log"
         if [ "$turn" -eq 1 ]; then
             "$ROOT/leo" --seed "$seed" --respond "$prompt" --debug-field \
-                --no-wonder-redirection \
+                --no-wonder-redirection --no-wonder-appetite \
                 --save "$state" > "$log" 2>&1
         else
             "$ROOT/leo" --load "$state" --seed "$((seed + turn - 1))" \
                 --respond "$prompt" --debug-field --no-wonder-redirection \
+                --no-wonder-appetite \
                 --save "$state" \
                 > "$log" 2>&1
         fi
@@ -252,6 +253,7 @@ while IFS=$'\t' read -r group cohort seed; do
         log="$group_dir/turns/turn-$(printf '%02d' "$turn")-life.log"
         "$ROOT/leo" --load "$state" --seed "$((seed + turn - 1))" \
             --respond "$prompt" --debug-field --no-wonder-redirection \
+            --no-wonder-appetite \
             --save "$state" \
             > "$log" 2>&1
         curiosity="$(curiosity_from_log "$log" "$group-life" "$seed")"
@@ -316,6 +318,7 @@ while IFS=$'\t' read -r cell group cohort seed order target_order; do
         log="$life/turns/turn-$(printf '%02d' "$turn")-open.log"
         "$ROOT/leo" --load "$state" --seed "$((seed + 100 + turn))" \
             --respond "$target" --debug-field --no-wonder-redirection \
+            --no-wonder-appetite \
             --save "$state" \
             > "$log" 2>&1
         curiosity="$(curiosity_from_log "$log" "$cell-open" "$seed")"
@@ -352,7 +355,8 @@ while IFS=$'\t' read -r cell group cohort seed order target_order; do
             log="$life/turns/turn-$(printf '%02d' "$turn")-occupied.log"
             "$ROOT/leo" --load "$state" --seed "$((seed + 100 + turn))" \
                 --respond "$next_target" --debug-field \
-                --no-wonder-redirection --save "$state" \
+                --no-wonder-redirection --no-wonder-appetite \
+                --save "$state" \
                 > "$log" 2>&1
             curiosity="$(curiosity_from_log "$log" "$cell-occupied" "$seed")"
             inventory="$(inventory_from_log "$log" "$cell-occupied" "$seed")"
@@ -382,6 +386,7 @@ while IFS=$'\t' read -r cell group cohort seed order target_order; do
         log="$life/turns/turn-$(printf '%02d' "$turn")-ground.log"
         "$ROOT/leo" --load "$state" --seed "$((seed + 100 + turn))" \
             --respond "$grounding" --debug-field --no-wonder-redirection \
+            --no-wonder-appetite \
             --save "$state" \
             > "$log" 2>&1
         curiosity="$(curiosity_from_log "$log" "$cell-ground" "$seed")"
@@ -415,6 +420,7 @@ while IFS=$'\t' read -r cell group cohort seed order target_order; do
         log="$life/turns/turn-$(printf '%02d' "$turn")-learned.log"
         "$ROOT/leo" --load "$state" --seed "$((seed + 100 + turn))" \
             --respond "$target" --debug-field --no-wonder-redirection \
+            --no-wonder-appetite \
             --save "$state" \
             > "$log" 2>&1
         curiosity="$(curiosity_from_log "$log" "$cell-learned" "$seed")"

--- a/scripts/deferred_wonder_redirection_matrix.sh
+++ b/scripts/deferred_wonder_redirection_matrix.sh
@@ -152,6 +152,7 @@ while IFS=$'\t' read -r group cohort seed; do
     cp "$ready" "$group_dir/open.state"
     "$ROOT/leo" --load "$group_dir/open.state" \
         --seed "$((seed + 2700))" --respond "$active" --debug-field \
+        --no-wonder-appetite \
         --save "$group_dir/open.state" > "$group_dir/open.log" 2>&1
     [ "$(reply_from_log "$group_dir/open.log")" = "$expected_active_question" ] || {
         printf '%s failed to open the active control\n' "$group" >&2
@@ -197,10 +198,12 @@ while IFS=$'\t' read -r group cohort seed; do
         cp "$group_dir/open.state" "$cell_dir/off.state"
         run_seed=$((seed + 3000 + group_index * 100 + case_index))
         "$ROOT/leo" --load "$cell_dir/on.state" --seed "$run_seed" \
-            --respond "$prompt" --debug-field --save "$cell_dir/on.state" \
+            --respond "$prompt" --debug-field --no-wonder-appetite \
+            --save "$cell_dir/on.state" \
             > "$cell_dir/on.log" 2>&1
         "$ROOT/leo" --load "$cell_dir/off.state" --seed "$run_seed" \
             --respond "$prompt" --debug-field --no-wonder-redirection \
+            --no-wonder-appetite \
             --save "$cell_dir/off.state" > "$cell_dir/off.log" 2>&1
 
         address="$(address_from_log "$cell_dir/on.log" "$cell" "$run_seed")"
@@ -285,7 +288,8 @@ while IFS=$'\t' read -r group cohort seed; do
             cp "$cell_dir/on.state" "$cell_dir/continuation.state"
             "$ROOT/leo" --load "$cell_dir/continuation.state" \
                 --seed "$continuation_seed" --respond "$active" \
-                --debug-field --save "$cell_dir/continuation.state" \
+                --debug-field --no-wonder-appetite \
+                --save "$cell_dir/continuation.state" \
                 > "$cell_dir/continuation.log" 2>&1
             continuation_reply="$(
                 reply_from_log "$cell_dir/continuation.log"

--- a/scripts/deferred_wonder_semantic_matrix.sh
+++ b/scripts/deferred_wonder_semantic_matrix.sh
@@ -163,7 +163,7 @@ while IFS=$'\t' read -r cell group cohort seed case kind target prompt \
         cp "$base" "$cell_dir/pre.state"
         "$ROOT/leo" --load "$cell_dir/pre.state" --seed "$((seed + 700))" \
             --respond "$opened" --debug-field --no-prewonder-shadow \
-            --no-wonder-attribution \
+            --no-wonder-attribution --no-wonder-appetite \
             --save "$cell_dir/pre.state" > "$cell_dir/pre.log" 2>&1
         [ "$(reply_from_log "$cell_dir/pre.log")" = "$expected_question" ] || {
             printf '%s failed to open occupied control\n' "$cell" >&2
@@ -177,11 +177,12 @@ while IFS=$'\t' read -r cell group cohort seed case kind target prompt \
     run_seed=$((seed + 1000 + case_index))
     "$ROOT/leo" --load "$cell_dir/on.state" --seed "$run_seed" \
         --respond "$prompt" --debug-field --no-wonder-attribution \
+        --no-wonder-appetite \
         --save "$cell_dir/on.state" \
         > "$cell_dir/on.log" 2>&1
     "$ROOT/leo" --load "$cell_dir/off.state" --seed "$run_seed" \
         --respond "$prompt" --debug-field --no-prewonder-shadow \
-        --no-wonder-attribution \
+        --no-wonder-attribution --no-wonder-appetite \
         --save "$cell_dir/off.state" > "$cell_dir/off.log" 2>&1
 
     shadow="$(shadow_from_log "$cell_dir/on.log" "$cell" "$run_seed")"

--- a/scripts/test_deferred_wonder_appetite_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_matrix.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_matrix.sh" "$OUT/plan" \
+    > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 9 || $1 != "cell" || $2 != "group" ||
+            $5 != "case" || $6 != "kind" ||
+            $8 != "expected_status" || $9 != "expected_winner")
+            exit 1
+        next
+    }
+    {
+        if (NF != 9 || cells[$1]++)
+            exit 1
+        groups[$2]++
+        cases[$5]++
+        kinds[$6]++
+        status[$8]++
+        rows++
+    }
+    END {
+        if (rows != 10 || length(groups) != 2 ||
+            length(cases) != 5 || kinds["semantic"] != 2 ||
+            kinds["weak"] != 2 || kinds["mixed"] != 2 ||
+            kinds["quiet"] != 2 || kinds["parked"] != 2 ||
+            status["salient"] != 4 ||
+            status["diffuse"] != 4 || status["quiet"] != 2)
+            exit 1
+        for (group in groups)
+            if (groups[group] != 5)
+                exit 1
+        for (case in cases)
+            if (cases[case] != 2)
+                exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_dialogue_report.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite: turn=14 status=salient winner=suvin margin=0.619 pending=nareth entries=suvin:1.000/0.125/1.000/1.000/0.869/1/0|flom:0.000/1.000/0.500/0.000/0.250/0/0]
+EOF
+
+got="$(
+    awk -v scenario=parked-return -v seed=83 \
+        -f "$ROOT/scripts/wonder_appetite_dialogue_report.awk" "$TMP"
+)"
+expected=$'parked-return\t83\t14\tsalient\tsuvin\t0.619\tnareth\tsuvin:1.000/0.125/1.000/1.000/0.869/1/0|flom:0.000/1.000/0.500/0.000/0.250/0/0'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite parser output:\n%s\n' "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite report parser: ok\n'

--- a/scripts/wonder_appetite_dialogue_report.awk
+++ b/scripts/wonder_appetite_dialogue_report.awk
@@ -1,0 +1,24 @@
+# Extract one transient deferred-Wonder return-appetite receipt per lived turn.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    start, tail, parts) {
+    start = index(line, key "=")
+    if (!start) return ""
+    tail = substr(line, start + length(key) + 1)
+    split(tail, parts, /[ ]/)
+    gsub(/\]$/, "", parts[1])
+    return parts[1]
+}
+
+/\[wonder-appetite: turn=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed), value_after($0, "turn"),
+           value_after($0, "status"), value_after($0, "winner"),
+           value_after($0, "margin"), value_after($0, "pending"),
+           value_after($0, "entries")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -1835,6 +1835,124 @@ int main(void) {
         g_leo_capsule_on = prev_capsule;
     }
 
+    /* A.44: waiting questions may acquire a transient return appetite. Meaning
+     * must carry the nomination; silence, unfinished depth, and Flow residual
+     * can strengthen it but never schedule, persist, or speak. */
+    {
+        int prev_appetite = g_leo_wonder_appetite_on;
+        int prev_flow = g_leo_flow_on;
+        int prev_wonder = g_leo_wonder_on;
+        int prev_deferred = g_leo_deferred_wonder_on;
+        int prev_attr = g_leo_wonder_attribution_on;
+        int prev_redirection = g_leo_wonder_redirection_on;
+        g_leo_wonder_appetite_on = 1;
+        g_leo_flow_on = 1;
+        g_leo_wonder_on = 1;
+        g_leo_deferred_wonder_on = 1;
+        g_leo_wonder_attribution_on = 1;
+        g_leo_wonder_redirection_on = 1;
+
+        Leo appetite;
+        seed_wonder_redirection_body(&appetite);
+        appetite.school.turn_clock = 11;
+        LeoSchool school_before = appetite.school;
+        LeoFlow flow_before = appetite.flow;
+        leo_wonder_appetite_observe(
+            &appetite, "Cat bird. Dark night.", NULL, NULL);
+        const LeoWonderAppetiteReceipt *receipt =
+            &appetite.wonder_appetite;
+        CHECK(receipt->status == LEO_WONDER_APPETITE_SALIENT &&
+              receipt->winner >= 0 &&
+              !strcmp(receipt->candidates[receipt->winner].word,
+                      "nareth") &&
+              receipt->candidates[receipt->winner].recurrence >=
+                  LEO_WONDER_APPETITE_RESONANCE_MIN &&
+              receipt->n_candidates == 2,
+              "wonder-appetite: a strong returning meaning makes one waiting question salient");
+        CHECK(!memcmp(&school_before, &appetite.school,
+                      sizeof appetite.school) &&
+              !memcmp(&flow_before, &appetite.flow,
+                      sizeof appetite.flow),
+              "wonder-appetite: observation cannot mutate School or Flow");
+
+        leo_wonder_appetite_observe(
+            &appetite, "Dark night and angry fire.", NULL, NULL);
+        CHECK(appetite.wonder_appetite.status ==
+                  LEO_WONDER_APPETITE_DIFFUSE &&
+              appetite.wonder_appetite.winner < 0,
+              "wonder-appetite: mixed recurrence stays diffuse instead of choosing an owner");
+
+        appetite.school.turn_clock = 100;
+        leo_wonder_appetite_observe(
+            &appetite, "I do not know.", NULL, NULL);
+        CHECK(appetite.wonder_appetite.status ==
+                  LEO_WONDER_APPETITE_QUIET &&
+              appetite.wonder_appetite.winner < 0 &&
+              appetite.wonder_appetite.candidates[0].silence == 1.0f,
+              "wonder-appetite: age alone cannot nominate a forgotten question");
+
+        leo_wonder_appetite_observe(
+            &appetite, "Nareth.", NULL, NULL);
+        CHECK(appetite.wonder_appetite.status ==
+                  LEO_WONDER_APPETITE_LITERAL &&
+              appetite.wonder_appetite.winner < 0,
+              "wonder-appetite: a literal name remains an external invitation, not autonomous appetite");
+        leo_free(&appetite);
+
+        Leo parked;
+        seed_wonder_redirection_body(&parked);
+        int suvin_episode = leo_wonder_find_open(&parked, "suvin");
+        uint64_t suvin_id = suvin_episode >= 0 ?
+            leo_wonder_episode_id(
+                &parked.school.wonders[suvin_episode]) : 0;
+        leo_flow_observe(
+            &parked, "suvin", "Suvin? Light or Cold?",
+            NULL, NULL, NULL, LEO_FLOW_WONDER_BORN, suvin_id);
+        parked.school.turn_clock++;
+        int veto = leo_wonder_address_observe(&parked, "Nareth.");
+        int switched = leo_wonder_address_redirect(&parked);
+        leo_wonder_appetite_observe(
+            &parked, "Bright sun. Cold winter.", NULL, NULL);
+        receipt = &parked.wonder_appetite;
+        CHECK(veto && switched &&
+              receipt->status == LEO_WONDER_APPETITE_SALIENT &&
+              receipt->winner >= 0 &&
+              !strcmp(receipt->candidates[receipt->winner].word,
+                      "suvin") &&
+              receipt->candidates[receipt->winner].spoken &&
+              receipt->candidates[receipt->winner].unfinished == 1.0f &&
+              receipt->candidates[receipt->winner].flow_gap > 0.99f,
+              "wonder-appetite: a parked spoken question carries its own unfinished Flow residual");
+
+        const char *state =
+            "/tmp/leo_wonder_appetite_transient_v20.state";
+        int saved = leo_save_state(&parked, state);
+        Leo woke; leo_init(&woke);
+        CHECK(saved && leo_load_state(&woke, state) &&
+              woke.wonder_appetite.n_candidates == 0 &&
+              woke.wonder_appetite.status ==
+                  LEO_WONDER_APPETITE_EMPTY,
+              "wonder-appetite: the receipt does not masquerade as persistent self");
+        leo_free(&woke);
+        remove(state);
+
+        g_leo_wonder_appetite_on = 0;
+        leo_wonder_appetite_observe(
+            &parked, "Bright sun. Cold winter.", NULL, NULL);
+        CHECK(parked.wonder_appetite.n_candidates == 0 &&
+              parked.wonder_appetite.status ==
+                  LEO_WONDER_APPETITE_EMPTY,
+              "wonder-appetite: ablation removes only the transient receipt");
+        leo_free(&parked);
+
+        g_leo_wonder_appetite_on = prev_appetite;
+        g_leo_flow_on = prev_flow;
+        g_leo_wonder_on = prev_wonder;
+        g_leo_deferred_wonder_on = prev_deferred;
+        g_leo_wonder_attribution_on = prev_attr;
+        g_leo_wonder_redirection_on = prev_redirection;
+    }
+
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
      * concept-slot; a taught word then returns that glyph (no longer -1); the
      * grown map survives save/load. */


### PR DESCRIPTION
Method: The Arianna Method separates a question's measurable pressure to return from the authority to schedule speech.

Observe each deferred Wonder after reply and Flow as recurrence, silence, unfinished depth, and its own perception-expression residual. Keep the receipt transient and readerless; literal address remains human-owned, and age without returning meaning cannot nominate a winner.

Evidence: 324/324 contracts; full UBSan suite; ASan/UBSan smoke; two byte-identical 10-cell A.44 matrices with 10/10 reply and state equality; isolated A.41-A.43 retain their prior results.

Quote: "A question can gather appetite before it is allowed to choose a mouth." - Sol