### PR TITLE
Arianna Method asks whether an appetite survives time

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4140,3 +4140,68 @@ new score.
 
 Leo can now feel that an unfinished question is returning before he is allowed to decide what to do
 with that feeling.
+
+## Phase A.45 — an appetite must survive time before it can become evidence (2026-07-26)
+
+A.44 made the pressure of a returning question legible, but a high score on one turn could still be
+a coincidence. Promoting that score directly into scheduling would have given a single semantic
+frame authority over the future. A.45 instead asks whether the prediction survives a future that it
+cannot rewrite.
+
+Every `salient` A.44 winner may open one forecast over exactly the next three lived turns. The
+deadline is fixed at proposal time. A later echo cannot extend it, duplicate calls on one turn cannot
+increase its evidence, and the same question cannot own overlapping forecasts. Existing forecasts
+observe a turn before the current A.44 receipt may propose another one, so no forecast can count its
+birth evidence as a future hit.
+
+The slow verdict vocabulary keeps unlike causes separate:
+
+```text
+sustained  target recurrence >= 0.75 returns inside the three-turn window
+faded      the target remains intact but the semantic return does not persist
+external   the human literally names the target
+grounded   School learns it, or the target's exact Flow episode resolves
+lost       the target identity disappears before the deadline
+unscorable a lived turn is missing from the forecast's chronology
+```
+
+`sustained` and `grounded` score against target 1; `faded` scores against target 0. `external`,
+`lost`, and `unscorable` keep Brier at zero because they are causal confounds, not calibration
+outcomes. This matters especially for Leo: a human returning to his question is relationship, not
+proof that an autonomous scheduler was right.
+
+The diary is bounded to 32 forecasts and persists as the independent fail-soft v21 tail. A v20 body
+wakes without invented predictions. A truncated or invalid v21 tail loses only forecasts; School,
+the deferred constellation, active provenance, Flow, shadow, and voice remain intact.
+`--no-wonder-appetite-calibration` removes the diary writer and reader together. No generation,
+School, routing, Flow, or shadow decision reads any forecast or verdict.
+
+Fifteen direct contracts raised the suite from **324/324** to **339/339**. They cover fixed-window
+birth without School/Flow mutation, non-sliding accumulation, exactly-once evidence, pending sleep,
+scored sustained and faded outcomes, literal external return, real grounding, lost identity,
+missing chronology, spoken episode identity, v20 migration, corrupt-v21 fail-soft behavior, and
+ablation.
+
+The process matrix rebuilt both independent A.40 bodies and ran five lives on each. Every future
+turn loaded the previous process's saved body:
+
+```text
+cells=10
+sustained=4
+faded=2
+external=2
+no forecast=2
+spoken targets=2
+reply equality=30/30 turns
+state prefix through v20 equal=10/10 lives
+complete state equal=2/10 diffuse controls
+complete state differs=8/10 remembered forecasts
+```
+
+Unspoken sustained returns scored appetite `0.690`, future peak recurrence `0.800`, and Brier
+`0.096`. Their one-frame twins matured as `faded` with Brier `0.476`. Parked spoken questions kept
+their exact episode identity, reached future recurrence about `0.91`, and matured with Brier about
+`0.033`. Literal returns became `external` after one turn with no score. A.44, explicitly isolated
+from A.45, retained its historical **10/10 reply and complete-state equality**.
+
+Leo can now remember not only that a question wanted to return, but whether time agreed.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration
 
 all: leo
 
@@ -67,6 +67,9 @@ deferred-wonder-redirection: leo
 deferred-wonder-appetite: leo
 	./scripts/deferred_wonder_appetite_matrix.sh
 
+deferred-wonder-appetite-calibration: leo
+	./scripts/deferred_wonder_appetite_calibration_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -76,6 +79,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_prewonder_shadow_dialogue_report.sh
 	./scripts/test_wonder_address_dialogue_report.sh
 	./scripts/test_wonder_appetite_dialogue_report.sh
+	./scripts/test_wonder_appetite_calibration_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -83,6 +87,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_attribution_matrix.sh
 	./scripts/test_deferred_wonder_redirection_matrix.sh
 	./scripts/test_deferred_wonder_appetite_matrix.sh
+	./scripts/test_deferred_wonder_appetite_calibration_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1734,6 +1734,44 @@ typedef struct {
     uint8_t status;
 } LeoWonderAppetiteReceipt;
 
+/* A.45: a salient appetite becomes a falsifiable forecast over the next three
+ * lived turns, never a scheduling command. The window is fixed at birth so a
+ * returning trace cannot keep moving its own deadline. Literal address and
+ * missing chronology remain visible but do not masquerade as calibration. */
+#define LEO_WONDER_APPETITE_CALIB_RING 32
+#define LEO_WONDER_APPETITE_CALIB_HORIZON 3
+enum {
+    LEO_WONDER_APPETITE_CALIB_NONE = 0,
+    LEO_WONDER_APPETITE_CALIB_PENDING,
+    LEO_WONDER_APPETITE_CALIB_SUSTAINED,
+    LEO_WONDER_APPETITE_CALIB_EXTERNAL,
+    LEO_WONDER_APPETITE_CALIB_GROUNDED,
+    LEO_WONDER_APPETITE_CALIB_FADED,
+    LEO_WONDER_APPETITE_CALIB_LOST,
+    LEO_WONDER_APPETITE_CALIB_UNSCORABLE,
+    LEO_WONDER_APPETITE_CALIB_VERDICT_COUNT
+};
+typedef struct {
+    uint64_t proposed_turn;
+    uint64_t deadline_turn;
+    uint64_t observed_turn;
+    uint64_t wonder_id;
+    char     word[LEO_HEARD_WORDLEN];
+    float    appetite;
+    float    peak_recurrence;
+    float    brier;
+    uint8_t  observations;
+    uint8_t  semantic_hits;
+    uint8_t  spoken;
+    uint8_t  verdict;
+} LeoWonderAppetiteCalibrationReceipt;
+typedef struct {
+    LeoWonderAppetiteCalibrationReceipt
+        receipts[LEO_WONDER_APPETITE_CALIB_RING];
+    int n;
+    int ptr;
+} LeoWonderAppetiteCalibration;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -1899,6 +1937,9 @@ typedef struct {
     /* A.44: future-return appetite over the final waiting constellation. It is
      * written after speech and Flow, and read only by diagnostics. */
     LeoWonderAppetiteReceipt wonder_appetite;
+    /* A.45/state v21: slow verdicts over salient appetite forecasts. The diary
+     * survives sleep but remains evidence-only and has no speech reader. */
+    LeoWonderAppetiteCalibration wonder_appetite_calibration;
     /* A.42/A.43: pre-grounding address witness. Semantic conflict can only
      * guard; an exact waiting name may redirect without assigning meaning. */
     LeoWonderAddressReceipt wonder_address;
@@ -2175,6 +2216,7 @@ static int g_leo_wonder_on = 1;         /* unfinished wonder: grounded alternati
 static int g_leo_deferred_wonder_on = 1; /* pre-Wonder: a distress-blocked question remains askable when its word returns safely. */
 static int g_leo_prewonder_shadow_on = 1; /* read-only semantic echo among withheld questions; no speech reader. */
 static int g_leo_wonder_appetite_on = 1; /* read-only return appetite over waiting questions; no scheduler or speech reader. */
+static int g_leo_wonder_appetite_calibration_on = 1; /* persistent slow verdicts over appetite; still no scheduler or speech reader. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -6109,6 +6151,277 @@ static void leo_wonder_appetite_observe(
     leo->wonder_appetite = receipt;
 }
 
+static const LeoWonderAppetiteCalibrationReceipt *
+leo_wonder_appetite_calibration_at(
+        const LeoWonderAppetiteCalibration *calibration, int pos) {
+    if (!calibration || pos < 0 || pos >= calibration->n) return NULL;
+    int start = calibration->n == LEO_WONDER_APPETITE_CALIB_RING ?
+        calibration->ptr : 0;
+    return &calibration->receipts[
+        (start + pos) % LEO_WONDER_APPETITE_CALIB_RING];
+}
+
+static LeoWonderAppetiteCalibrationReceipt *
+leo_wonder_appetite_calibration_at_mut(
+        LeoWonderAppetiteCalibration *calibration, int pos) {
+    if (!calibration || pos < 0 || pos >= calibration->n) return NULL;
+    int start = calibration->n == LEO_WONDER_APPETITE_CALIB_RING ?
+        calibration->ptr : 0;
+    return &calibration->receipts[
+        (start + pos) % LEO_WONDER_APPETITE_CALIB_RING];
+}
+
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_calibration_verdict_name(int verdict) {
+    static const char *names[LEO_WONDER_APPETITE_CALIB_VERDICT_COUNT] = {
+        "none", "pending", "sustained", "external", "grounded",
+        "faded", "lost", "unscorable"
+    };
+    return verdict >= 0 &&
+           verdict < LEO_WONDER_APPETITE_CALIB_VERDICT_COUNT ?
+        names[verdict] : "unscorable";
+}
+
+static const LeoWonderAppetiteCandidate *
+leo_wonder_appetite_candidate(
+        const LeoWonderAppetiteReceipt *receipt, const char *word) {
+    if (!receipt || !word || !word[0]) return NULL;
+    for (int i = 0; i < receipt->n_candidates; i++)
+        if (!strcmp(receipt->candidates[i].word, word))
+            return &receipt->candidates[i];
+    return NULL;
+}
+
+static int leo_wonder_appetite_target_exists(
+        const Leo *leo, const char *word) {
+    return leo && word && word[0] &&
+        (leo_deferred_wonder_find(leo, word) >= 0 ||
+         !strcmp(leo->school.pending, word) ||
+         leo_wonder_find_open(leo, word) >= 0 ||
+         leo_school_is_learned(leo, word));
+}
+
+static void leo_wonder_appetite_calibration_score(
+        LeoWonderAppetiteCalibrationReceipt *receipt, float target) {
+    float error = receipt->appetite - target;
+    receipt->brier = error * error;
+}
+
+/* Evaluate every open forecast against this already-lived turn, then open at
+ * most one new fixed-window forecast from A.44's current salient receipt.
+ * Existing forecasts see the turn before a new one is born, so no forecast can
+ * count its own proposal evidence as a future hit. */
+static void leo_wonder_appetite_calibrate(
+        Leo *leo, const char *prompt) {
+    if (!leo || !prompt || !g_leo_wonder_appetite_calibration_on ||
+        !g_leo_wonder_appetite_on || !g_leo_wonder_on ||
+        !g_leo_deferred_wonder_on || !g_leo_flow_on)
+        return;
+    uint64_t turn = (uint64_t)leo->school.turn_clock;
+    LeoWonderAppetiteCalibration *calibration =
+        &leo->wonder_appetite_calibration;
+    const LeoFlowSnapshot *snapshot =
+        leo_flow_at(&leo->flow, leo->flow.n - 1);
+
+    for (int i = 0; i < calibration->n; i++) {
+        LeoWonderAppetiteCalibrationReceipt *forecast =
+            leo_wonder_appetite_calibration_at_mut(calibration, i);
+        if (!forecast ||
+            forecast->verdict != LEO_WONDER_APPETITE_CALIB_PENDING ||
+            turn <= forecast->observed_turn)
+            continue;
+
+        if (forecast->observed_turn == UINT64_MAX ||
+            turn != forecast->observed_turn + 1) {
+            forecast->observed_turn = turn;
+            forecast->verdict =
+                LEO_WONDER_APPETITE_CALIB_UNSCORABLE;
+            forecast->brier = 0.0f;
+            continue;
+        }
+
+        forecast->observed_turn = turn;
+        if (forecast->observations < UINT8_MAX)
+            forecast->observations++;
+
+        if (leo_flow_prompt_has_word(prompt, forecast->word)) {
+            forecast->verdict =
+                LEO_WONDER_APPETITE_CALIB_EXTERNAL;
+            forecast->brier = 0.0f;
+            continue;
+        }
+
+        int grounded = leo_school_is_learned(leo, forecast->word);
+        if (!grounded && forecast->wonder_id && snapshot &&
+            snapshot->wonder_id == forecast->wonder_id &&
+            (snapshot->wonder & LEO_FLOW_WONDER_RESOLVED))
+            grounded = 1;
+        if (grounded) {
+            forecast->verdict =
+                LEO_WONDER_APPETITE_CALIB_GROUNDED;
+            leo_wonder_appetite_calibration_score(forecast, 1.0f);
+            continue;
+        }
+
+        const LeoWonderAppetiteCandidate *candidate =
+            leo_wonder_appetite_candidate(
+                &leo->wonder_appetite, forecast->word);
+        if (candidate && !candidate->literal) {
+            forecast->peak_recurrence = fmaxf(
+                forecast->peak_recurrence, candidate->recurrence);
+            if (candidate->recurrence >=
+                LEO_WONDER_APPETITE_RESONANCE_MIN &&
+                forecast->semantic_hits < UINT8_MAX)
+                forecast->semantic_hits++;
+        }
+
+        if (turn < forecast->deadline_turn) continue;
+        if (forecast->semantic_hits > 0) {
+            forecast->verdict =
+                LEO_WONDER_APPETITE_CALIB_SUSTAINED;
+            leo_wonder_appetite_calibration_score(forecast, 1.0f);
+        } else if (
+            leo_wonder_appetite_target_exists(
+                leo, forecast->word)) {
+            forecast->verdict =
+                LEO_WONDER_APPETITE_CALIB_FADED;
+            leo_wonder_appetite_calibration_score(forecast, 0.0f);
+        } else {
+            forecast->verdict =
+                LEO_WONDER_APPETITE_CALIB_LOST;
+            forecast->brier = 0.0f;
+        }
+    }
+
+    const LeoWonderAppetiteReceipt *appetite =
+        &leo->wonder_appetite;
+    if (appetite->status != LEO_WONDER_APPETITE_SALIENT ||
+        appetite->winner < 0 ||
+        appetite->winner >= appetite->n_candidates ||
+        turn > UINT64_MAX - LEO_WONDER_APPETITE_CALIB_HORIZON)
+        return;
+    const LeoWonderAppetiteCandidate *winner =
+        &appetite->candidates[appetite->winner];
+    for (int i = 0; i < calibration->n; i++) {
+        const LeoWonderAppetiteCalibrationReceipt *old =
+            leo_wonder_appetite_calibration_at(calibration, i);
+        if (!old || strcmp(old->word, winner->word)) continue;
+        if (old->verdict == LEO_WONDER_APPETITE_CALIB_PENDING ||
+            old->observed_turn == turn)
+            return;
+    }
+    if (calibration->n == LEO_WONDER_APPETITE_CALIB_RING &&
+        calibration->receipts[calibration->ptr].verdict ==
+            LEO_WONDER_APPETITE_CALIB_PENDING)
+        return;
+
+    LeoWonderAppetiteCalibrationReceipt forecast;
+    memset(&forecast, 0, sizeof forecast);
+    forecast.proposed_turn = turn;
+    forecast.deadline_turn =
+        turn + LEO_WONDER_APPETITE_CALIB_HORIZON;
+    forecast.observed_turn = turn;
+    strncpy(forecast.word, winner->word, LEO_HEARD_WORDLEN - 1);
+    forecast.word[LEO_HEARD_WORDLEN - 1] = 0;
+    forecast.appetite = winner->appetite;
+    forecast.spoken = winner->spoken;
+    forecast.verdict = LEO_WONDER_APPETITE_CALIB_PENDING;
+    if (winner->spoken) {
+        int episode = leo_wonder_find_open(leo, winner->word);
+        if (episode >= 0)
+            forecast.wonder_id =
+                leo_wonder_episode_id(
+                    &leo->school.wonders[episode]);
+    }
+
+    calibration->receipts[calibration->ptr] = forecast;
+    calibration->ptr =
+        (calibration->ptr + 1) %
+            LEO_WONDER_APPETITE_CALIB_RING;
+    if (calibration->n < LEO_WONDER_APPETITE_CALIB_RING)
+        calibration->n++;
+}
+
+static int leo_wonder_appetite_calibration_valid(
+        const LeoWonderAppetiteCalibrationReceipt *receipt,
+        uint64_t turn_clock) {
+    if (!receipt || !receipt->word[0] ||
+        receipt->word[LEO_HEARD_WORDLEN - 1] != 0 ||
+        receipt->proposed_turn == 0 ||
+        receipt->proposed_turn >
+            UINT64_MAX - LEO_WONDER_APPETITE_CALIB_HORIZON ||
+        receipt->deadline_turn !=
+            receipt->proposed_turn +
+                LEO_WONDER_APPETITE_CALIB_HORIZON ||
+        receipt->observed_turn < receipt->proposed_turn ||
+        receipt->observed_turn > turn_clock ||
+        !isfinite(receipt->appetite) ||
+        receipt->appetite < LEO_WONDER_APPETITE_SCORE_MIN ||
+        receipt->appetite > 1.0f ||
+        !isfinite(receipt->peak_recurrence) ||
+        receipt->peak_recurrence < 0.0f ||
+        receipt->peak_recurrence > 1.0f ||
+        !isfinite(receipt->brier) ||
+        receipt->brier < 0.0f || receipt->brier > 1.0f ||
+        receipt->observations >
+            LEO_WONDER_APPETITE_CALIB_HORIZON ||
+        receipt->semantic_hits > receipt->observations ||
+        receipt->spoken > 1 ||
+        receipt->verdict <= LEO_WONDER_APPETITE_CALIB_NONE ||
+        receipt->verdict >=
+            LEO_WONDER_APPETITE_CALIB_VERDICT_COUNT ||
+        (receipt->spoken && !receipt->wonder_id) ||
+        (!receipt->spoken && receipt->wonder_id))
+        return 0;
+    if (receipt->semantic_hits > 0 &&
+        receipt->peak_recurrence <
+            LEO_WONDER_APPETITE_RESONANCE_MIN)
+        return 0;
+
+    if (receipt->verdict ==
+        LEO_WONDER_APPETITE_CALIB_UNSCORABLE)
+        return receipt->brier == 0.0f;
+    if (receipt->observed_turn - receipt->proposed_turn !=
+        receipt->observations)
+        return 0;
+    if (receipt->verdict ==
+        LEO_WONDER_APPETITE_CALIB_PENDING)
+        return receipt->observed_turn < receipt->deadline_turn &&
+               receipt->brier == 0.0f;
+    if (receipt->verdict ==
+        LEO_WONDER_APPETITE_CALIB_EXTERNAL)
+        return receipt->brier == 0.0f;
+    if (receipt->verdict ==
+        LEO_WONDER_APPETITE_CALIB_LOST)
+        return receipt->observed_turn ==
+                   receipt->deadline_turn &&
+               receipt->observations ==
+                   LEO_WONDER_APPETITE_CALIB_HORIZON &&
+               receipt->semantic_hits == 0 &&
+               receipt->brier == 0.0f;
+
+    float target =
+        receipt->verdict ==
+            LEO_WONDER_APPETITE_CALIB_FADED ? 0.0f : 1.0f;
+    float error = receipt->appetite - target;
+    if (fabsf(receipt->brier - error * error) > 1e-6f)
+        return 0;
+    if (receipt->verdict ==
+        LEO_WONDER_APPETITE_CALIB_GROUNDED)
+        return receipt->observed_turn <=
+            receipt->deadline_turn;
+    if (receipt->observed_turn != receipt->deadline_turn ||
+        receipt->observations !=
+            LEO_WONDER_APPETITE_CALIB_HORIZON)
+        return 0;
+    if (receipt->verdict ==
+        LEO_WONDER_APPETITE_CALIB_SUSTAINED)
+        return receipt->semantic_hits > 0;
+    return receipt->verdict ==
+               LEO_WONDER_APPETITE_CALIB_FADED &&
+           receipt->semantic_hits == 0;
+}
+
 static int leo_flow_kind(const LeoFlow *flow, int glyph, int window, int face) {
     if (!flow || flow->n <= 0 || glyph < 0 || glyph >= GLYPH_COUNT) return LEO_FLOW_QUIET;
     if (window < 3) window = 3;
@@ -7127,6 +7440,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
                      flow_event, flow_wonder_id);  /* observation only: no generation path reads flow */
     leo_wonder_appetite_observe(
         leo, prompt, prewonder_field_token, prewonder_field_weight);
+    leo_wonder_appetite_calibrate(leo, prompt);
     leo_shadow_calibrate(leo, prompt);            /* judge t-1 only after t has become history */
     leo_shadow_observe(leo);                      /* after speech: a proposal for the next turn, never a reader */
     leo->gravity = NULL;
@@ -7175,9 +7489,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v18      : bounded pre-Wonder memory for distress-deferred questions
  *   v19      : contrastive own-field birth anchors for pre-Wonder semantics
  *   v20      : exact birth provenance for the Wonder that currently has the mouth
+ *   v21      : slow calibration diary over three-turn appetite forecasts
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 20  /* active-Wonder birth provenance extends the fail-soft tail; v5..v19 soft-migrate */
+#define LEO_STATE_VERSION 21  /* appetite calibration extends the fail-soft tail; v5..v20 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -7394,6 +7709,15 @@ static int leo_save_state(const Leo *leo, const char *path) {
     if (leo->school.has_pending_origin)
         fwrite(&leo->school.pending_origin,
                sizeof leo->school.pending_origin, 1, f);
+
+    /* A.45 (v21): fixed-horizon forecasts and their later verdicts. This
+     * evidence is independently disposable and grants no scheduling right. */
+    st_w32(f, (int32_t)leo->wonder_appetite_calibration.n);
+    st_w32(f, (int32_t)leo->wonder_appetite_calibration.ptr);
+    if (leo->wonder_appetite_calibration.n > 0)
+        fwrite(leo->wonder_appetite_calibration.receipts,
+               sizeof(LeoWonderAppetiteCalibrationReceipt),
+               (size_t)leo->wonder_appetite_calibration.n, f);
 
     int ok = (ferror(f) == 0);
     if (fclose(f) != 0) ok = 0;                 /* L-2: the final flush can fail (ENOSPC) — never report success on a truncated file */
@@ -8058,6 +8382,64 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
         }
     }
 
+    /* Slow appetite calibration (v21). Older bodies wake without forecasts;
+     * a damaged diary loses only its claims about the future. */
+    if (version >= 21) {
+        int32_t n = 0, ptr = 0;
+        int appetite_calibration_ok =
+            st_r32(f, &n) && st_r32(f, &ptr) &&
+            n >= 0 && n <= LEO_WONDER_APPETITE_CALIB_RING &&
+            ptr >= 0 && ptr < LEO_WONDER_APPETITE_CALIB_RING &&
+            ((n < LEO_WONDER_APPETITE_CALIB_RING && ptr == n) ||
+             n == LEO_WONDER_APPETITE_CALIB_RING);
+        if (appetite_calibration_ok && n > 0 &&
+            fread(leo->wonder_appetite_calibration.receipts,
+                  sizeof(LeoWonderAppetiteCalibrationReceipt),
+                  (size_t)n, f) != (size_t)n)
+            appetite_calibration_ok = 0;
+        if (appetite_calibration_ok) {
+            LeoWonderAppetiteCalibration *calibration =
+                &leo->wonder_appetite_calibration;
+            calibration->n = n;
+            calibration->ptr = ptr;
+            uint64_t previous_turn = 0;
+            for (int i = 0; i < n; i++) {
+                const LeoWonderAppetiteCalibrationReceipt *receipt =
+                    leo_wonder_appetite_calibration_at(
+                        calibration, i);
+                if (!leo_wonder_appetite_calibration_valid(
+                        receipt,
+                        (uint64_t)leo->school.turn_clock) ||
+                    (i > 0 &&
+                     receipt->proposed_turn <= previous_turn)) {
+                    appetite_calibration_ok = 0;
+                    break;
+                }
+                if (receipt->verdict ==
+                    LEO_WONDER_APPETITE_CALIB_PENDING)
+                    for (int j = 0; j < i; j++) {
+                        const LeoWonderAppetiteCalibrationReceipt *old =
+                            leo_wonder_appetite_calibration_at(
+                                calibration, j);
+                        if (old &&
+                            old->verdict ==
+                                LEO_WONDER_APPETITE_CALIB_PENDING &&
+                            !strcmp(old->word, receipt->word)) {
+                            appetite_calibration_ok = 0;
+                            break;
+                        }
+                    }
+                if (!appetite_calibration_ok) break;
+                previous_turn = receipt->proposed_turn;
+            }
+        }
+        if (!appetite_calibration_ok) {
+            fprintf(stderr, "[leo] WARNING: v21 appetite-calibration tail truncated/corrupt — organism lives without forecasts.\n");
+            memset(&leo->wonder_appetite_calibration, 0,
+                   sizeof leo->wonder_appetite_calibration);
+        }
+    }
+
     fclose(f);
     /* rebuild the derived tables (same as the main startup path) */
     leo_build_chamber_tags(leo);
@@ -8388,6 +8770,87 @@ static void print_wonder_appetite_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_appetite_calibration_stats(
+        const Leo *leo) {
+    if (!g_leo_wonder_appetite_calibration_on || !leo ||
+        leo->wonder_appetite_calibration.n == 0)
+        return;
+    uint64_t turn = (uint64_t)leo->school.turn_clock;
+    int visible = 0, pending = 0, scored = 0, confirmed = 0;
+    int external = 0, lost = 0, unscorable = 0;
+    float brier_sum = 0.0f;
+    for (int i = 0;
+         i < leo->wonder_appetite_calibration.n; i++) {
+        const LeoWonderAppetiteCalibrationReceipt *item =
+            leo_wonder_appetite_calibration_at(
+                &leo->wonder_appetite_calibration, i);
+        if (!item) continue;
+        if (item->verdict ==
+            LEO_WONDER_APPETITE_CALIB_PENDING)
+            pending++;
+        if (item->verdict ==
+                LEO_WONDER_APPETITE_CALIB_SUSTAINED ||
+            item->verdict ==
+                LEO_WONDER_APPETITE_CALIB_GROUNDED ||
+            item->verdict ==
+                LEO_WONDER_APPETITE_CALIB_FADED) {
+            scored++;
+            brier_sum += item->brier;
+            if (item->verdict !=
+                LEO_WONDER_APPETITE_CALIB_FADED)
+                confirmed++;
+        } else if (item->verdict ==
+                   LEO_WONDER_APPETITE_CALIB_EXTERNAL) {
+            external++;
+        } else if (item->verdict ==
+                   LEO_WONDER_APPETITE_CALIB_LOST) {
+            lost++;
+        } else if (item->verdict ==
+                   LEO_WONDER_APPETITE_CALIB_UNSCORABLE) {
+            unscorable++;
+        }
+        if (item->verdict ==
+                LEO_WONDER_APPETITE_CALIB_PENDING ||
+            item->observed_turn == turn ||
+            item->proposed_turn == turn)
+            visible++;
+    }
+    if (!visible) return;
+
+    printf("     [wonder-appetite-calibration: turn=%llu pending=%d scored=%d confirmed=%d external=%d lost=%d unscorable=%d brier=%.3f entries=",
+           (unsigned long long)turn, pending, scored, confirmed,
+           external, lost, unscorable,
+           scored ? (double)(brier_sum / (float)scored) : 0.0);
+    const char *sep = "";
+    for (int i = 0;
+         i < leo->wonder_appetite_calibration.n; i++) {
+        const LeoWonderAppetiteCalibrationReceipt *item =
+            leo_wonder_appetite_calibration_at(
+                &leo->wonder_appetite_calibration, i);
+        if (!item ||
+            (item->verdict !=
+                 LEO_WONDER_APPETITE_CALIB_PENDING &&
+             item->observed_turn != turn &&
+             item->proposed_turn != turn))
+            continue;
+        printf("%s%s:%llu/%llu/%llu/%.3f/%.3f/%u/%u/%u/%s/%.3f",
+               sep, item->word,
+               (unsigned long long)item->proposed_turn,
+               (unsigned long long)item->deadline_turn,
+               (unsigned long long)item->observed_turn,
+               (double)item->appetite,
+               (double)item->peak_recurrence,
+               (unsigned)item->semantic_hits,
+               (unsigned)item->observations,
+               (unsigned)item->spoken,
+               leo_wonder_appetite_calibration_verdict_name(
+                   item->verdict),
+               (double)item->brier);
+        sep = "|";
+    }
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -8622,6 +9085,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-deferred-wonder")) g_leo_deferred_wonder_on = 0;
         else if (!strcmp(argv[i], "--no-prewonder-shadow")) g_leo_prewonder_shadow_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite")) g_leo_wonder_appetite_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-calibration")) g_leo_wonder_appetite_calibration_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -8837,6 +9301,7 @@ int main(int argc, char **argv) {
             print_wonder_address_stats(&leo);
             print_prewonder_shadow_stats(&leo);
             print_wonder_appetite_stats(&leo);
+            print_wonder_appetite_calibration_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -8895,6 +9360,7 @@ int main(int argc, char **argv) {
             print_wonder_address_stats(&leo);
             print_prewonder_shadow_stats(&leo);
             print_wonder_appetite_stats(&leo);
+            print_wonder_appetite_calibration_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -287,7 +287,9 @@ reply and its Flow snapshot are already history. It remains a shadow organ:
 School, generation, routing, and the existing shadow scheduler have no reader
 for its receipt. `--no-wonder-appetite` therefore removes only
 `[wonder-appetite: ...]`; reply bytes and saved state must remain identical.
-State stays at v20 because the appetite is not a persistent self-description.
+A.44 itself has no persistent fields. State is now v21 only because A.45 keeps
+a separate slow calibration diary; the historical A.44 matrix explicitly
+ablates that later layer and retains complete state equality.
 
 Each waiting candidate exposes five bounded components:
 
@@ -316,6 +318,43 @@ weak return, mixed return, maximally aged quiet, and a semantic return to a
 spoken question parked by A.43. The parked fork must identify the displaced
 question with `spoken=1`, `unfinished=1`, and `flow_gap>=0.90`. Every one of the
 ten forks requires reply and complete saved-state equality.
+
+Run the slow return-appetite calibration matrix:
+
+```sh
+make deferred-wonder-appetite-calibration
+```
+
+A.45 turns only a `salient` A.44 receipt into a falsifiable forecast. Its
+deadline is fixed at birth: the next three lived turns. A later semantic echo
+cannot slide the window forward, and a second forecast for the same question
+cannot overlap the first. Existing forecasts observe the new turn before its
+current appetite is allowed to open another forecast, so proposal evidence
+never counts as a future hit.
+
+The verdicts preserve causal distinctions:
+
+- `sustained`: the target's recurrence reaches `0.75` again inside the window;
+- `faded`: the identity remains intact but no such recurrence follows;
+- `external`: the human literally names the target;
+- `grounded`: the target is actually learned or its exact Flow episode closes;
+- `lost`: the identity disappears before it can be judged;
+- `unscorable`: lived chronology skips a turn.
+
+Only `sustained`, `grounded`, and `faded` receive Brier scores. External
+invitation, loss, and missing history remain evidence, but are not relabeled as
+prediction success or failure. `--no-wonder-appetite-calibration` disables only
+this persistent diary. State v21 appends a bounded 32-receipt fail-soft tail;
+v20 bodies migrate with no invented forecasts, and damage to v21 discards only
+the new diary.
+
+The checked matrix uses both independent A.40 bodies and five lives per body:
+unspoken sustained return, one-frame fade, literal external return, sustained
+return of a parked spoken question, and a diffuse no-forecast control. Each
+future turn is a separate load/respond/save process. ON and OFF must produce
+the same 30 reply pairs and the same state prefix through v20. Complete states
+must differ only for the eight lives where A.45 has evidence to remember; the
+two diffuse controls remain completely byte-identical.
 
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,

--- a/scripts/deferred_wonder_appetite_calibration_cases.tsv
+++ b/scripts/deferred_wonder_appetite_calibration_cases.tsv
@@ -1,0 +1,6 @@
+case	kind	initial	future_1	future_2	future_3	expected_verdict	expected_spoken	expected_forecast	expected_full_equal
+unspoken-sustained	unspoken	Cat bird. Dark night.	quiet	semantic-slot2	quiet	sustained	0	1	0
+unspoken-faded	unspoken	Cat bird. Dark night.	quiet	quiet	quiet	faded	0	1	0
+unspoken-external	unspoken	Cat bird. Dark night.	target	-	-	external	0	1	0
+parked-sustained	parked	Bright sun. Cold winter.	quiet	semantic-slot1	quiet	sustained	1	1	0
+diffuse-control	control	Bright sun and dark night.	-	-	-	none	0	0	1

--- a/scripts/deferred_wonder_appetite_calibration_matrix.sh
+++ b/scripts/deferred_wonder_appetite_calibration_matrix.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# A.45: fixed three-turn calibration of A.44 return-appetite forecasts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GROUPS_FILE="${LEO_APPETITE_CALIBRATION_GROUPS:-$ROOT/scripts/deferred_wonder_constellation_groups.tsv}"
+CASES_FILE="${LEO_APPETITE_CALIBRATION_CASES:-$ROOT/scripts/deferred_wonder_appetite_calibration_cases.tsv}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-calibration-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+for fixture in "$GROUPS_FILE" "$CASES_FILE"; do
+    [ -f "$fixture" ] || {
+        printf 'appetite calibration fixture not found: %s\n' \
+            "$fixture" >&2
+        exit 2
+    }
+done
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 10 || $1 != "case" || $2 != "kind" ||
+            $3 != "initial" || $4 != "future_1" ||
+            $5 != "future_2" || $6 != "future_3" ||
+            $7 != "expected_verdict" ||
+            $8 != "expected_spoken" ||
+            $9 != "expected_forecast" ||
+            $10 != "expected_full_equal")
+            exit 1
+        next
+    }
+    {
+        if (NF != 10 || seen[$1]++ ||
+            $8 !~ /^[01]$/ || $9 !~ /^[01]$/ ||
+            $10 !~ /^[01]$/)
+            exit 1
+        kinds[$2]++
+        verdicts[$7]++
+        rows++
+    }
+    END {
+        if (rows != 5 || kinds["unspoken"] != 3 ||
+            kinds["parked"] != 1 || kinds["control"] != 1 ||
+            verdicts["sustained"] != 2 ||
+            verdicts["faded"] != 1 ||
+            verdicts["external"] != 1 ||
+            verdicts["none"] != 1)
+            exit 1
+    }
+' "$CASES_FILE" || {
+    printf 'invalid appetite calibration cases: %s\n' \
+        "$CASES_FILE" >&2
+    exit 2
+}
+
+mkdir -p "$OUT/lives"
+PLAN="$OUT/plan.tsv"
+MATRIX="$OUT/matrix.tsv"
+RECEIPTS="$OUT/receipts.tsv"
+SUMMARY="$OUT/summary.txt"
+
+group_field() {
+    local group="$1"
+    local slot="$2"
+    local field="$3"
+    awk -F '\t' -v group="$group" -v slot="$slot" -v field="$field" '
+        NR > 1 && $1 == group && $4 == slot {
+            print $field
+            exit
+        }
+    ' "$GROUPS_FILE"
+}
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+calibration_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_calibration_dialogue_report.awk" \
+        "$1"
+}
+
+entry_fields() {
+    local entries="$1"
+    local wanted="$2"
+    printf '%s\n' "$entries" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    print values[1] "\t" values[2] "\t" values[3] \
+                          "\t" values[4] "\t" values[5] "\t" \
+                          values[6] "\t" values[7] "\t" values[8] \
+                          "\t" values[9] "\t" values[10]
+                    exit
+                }
+            }
+        '
+}
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+prompt_for() {
+    local token="$1"
+    local target="$2"
+    case "$token" in
+        quiet) printf '%s' 'I do not know.' ;;
+        semantic-slot1) printf '%s' 'Bright sun. Cold winter.' ;;
+        semantic-slot2) printf '%s' 'Cat bird. Dark night.' ;;
+        target) printf '%s' "$target" ;;
+        -) printf '%s' '-' ;;
+        *)
+            printf 'unknown future prompt token: %s\n' "$token" >&2
+            return 1
+            ;;
+    esac
+}
+
+printf 'cell\tgroup\tcohort\tseed\tcase\tkind\ttarget\texpected_verdict\texpected_spoken\texpected_forecast\texpected_full_equal\n' \
+    > "$PLAN"
+awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
+    "$GROUPS_FILE" |
+while IFS=$'\t' read -r group cohort seed; do
+    while IFS=$'\t' read -r case kind initial future_1 future_2 \
+        future_3 verdict spoken forecast full_equal; do
+        [ "$case" = "case" ] && continue
+        target=none
+        [ "$kind" != "unspoken" ] ||
+            target="$(group_field "$group" 2 5)"
+        [ "$kind" != "parked" ] ||
+            target="$(group_field "$group" 1 5)"
+        printf '%s-%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$group" "$case" "$group" "$cohort" "$seed" "$case" \
+            "$kind" "$target" "$verdict" "$spoken" "$forecast" \
+            "$full_equal" >> "$PLAN"
+    done < "$CASES_FILE"
+done
+
+if [ "${LEO_APPETITE_CALIBRATION_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"$ROOT/scripts/deferred_wonder_constellation_matrix.sh" \
+    "$OUT/a40-baseline" > "$OUT/a40-baseline.log"
+
+printf 'cell\tgroup\tcohort\tcase\tkind\ttarget\tverdict\tproposed\tdeadline\tobserved\tappetite\tpeak_recurrence\tsemantic_hits\tobservations\tspoken\tbrier\tturns\treply_equal_turns\tcore_equal\tfull_equal\ton_sha256\toff_sha256\n' \
+    > "$MATRIX"
+printf 'cell\tturn\tpending\tscored\tconfirmed\texternal\tlost\tunscorable\tbrier\tentries\n' \
+    > "$RECEIPTS"
+
+group_index=0
+awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
+    "$GROUPS_FILE" |
+while IFS=$'\t' read -r group cohort seed; do
+    group_index=$((group_index + 1))
+    group_dir="$OUT/lives/$group"
+    mkdir -p "$group_dir"
+    ready="$OUT/a40-baseline/groups/$group/ready.state"
+    [ -f "$ready" ] || {
+        printf 'missing A.40 ready body: %s\n' "$ready" >&2
+        exit 1
+    }
+
+    slot1="$(group_field "$group" 1 5)"
+    slot2="$(group_field "$group" 2 5)"
+    slot1_question="$(group_field "$group" 1 9)"
+    slot2_question="$(group_field "$group" 2 9)"
+    cp "$ready" "$group_dir/parked-base.state"
+    "$ROOT/leo" --load "$group_dir/parked-base.state" \
+        --seed "$((seed + 5100))" --respond "$slot1" --debug-field \
+        --no-wonder-appetite-calibration \
+        --save "$group_dir/parked-base.state" \
+        > "$group_dir/parked-open.log" 2>&1
+    [ "$(reply_from_log "$group_dir/parked-open.log")" = \
+      "$slot1_question" ] || {
+        printf '%s failed to open parked calibration control\n' \
+            "$group" >&2
+        exit 1
+    }
+    "$ROOT/leo" --load "$group_dir/parked-base.state" \
+        --seed "$((seed + 5101))" --respond "$slot2" --debug-field \
+        --no-wonder-appetite-calibration \
+        --save "$group_dir/parked-base.state" \
+        > "$group_dir/parked-switch.log" 2>&1
+    [ "$(reply_from_log "$group_dir/parked-switch.log")" = \
+      "$slot2_question" ] || {
+        printf '%s failed to switch parked calibration control\n' \
+            "$group" >&2
+        exit 1
+    }
+
+    case_index=0
+    while IFS=$'\t' read -r case kind initial future_1 future_2 \
+        future_3 expected_verdict expected_spoken expected_forecast \
+        expected_full_equal; do
+        [ "$case" = "case" ] && continue
+        case_index=$((case_index + 1))
+        cell="$group-$case"
+        cell_dir="$group_dir/$case"
+        mkdir -p "$cell_dir"
+        base="$ready"
+        target=none
+        if [ "$kind" = "unspoken" ]; then
+            target="$slot2"
+        elif [ "$kind" = "parked" ]; then
+            target="$slot1"
+            base="$group_dir/parked-base.state"
+        fi
+        cp "$base" "$cell_dir/on.state"
+        cp "$base" "$cell_dir/off.state"
+
+        prompts=("$initial")
+        for token in "$future_1" "$future_2" "$future_3"; do
+            [ "$token" = "-" ] ||
+                prompts+=("$(prompt_for "$token" "$target")")
+        done
+        turns=${#prompts[@]}
+        reply_equal_turns=0
+        last_on_log=
+        for ((turn_index = 0; turn_index < turns; turn_index++)); do
+            turn_number=$((turn_index + 1))
+            prompt="${prompts[$turn_index]}"
+            run_seed=$((seed + 5400 + group_index * 1000 +
+                        case_index * 20 + turn_number))
+            on_log="$cell_dir/on-turn-$turn_number.log"
+            off_log="$cell_dir/off-turn-$turn_number.log"
+            "$ROOT/leo" --load "$cell_dir/on.state" \
+                --seed "$run_seed" --respond "$prompt" --debug-field \
+                --save "$cell_dir/on.state" > "$on_log" 2>&1
+            "$ROOT/leo" --load "$cell_dir/off.state" \
+                --seed "$run_seed" --respond "$prompt" --debug-field \
+                --no-wonder-appetite-calibration \
+                --save "$cell_dir/off.state" > "$off_log" 2>&1
+            [ -z "$(calibration_from_log \
+                "$off_log" "$cell" "$run_seed")" ] || {
+                printf '%s calibration ablation emitted a receipt\n' \
+                    "$cell" >&2
+                exit 1
+            }
+            if [ "$(reply_from_log "$on_log")" = \
+                 "$(reply_from_log "$off_log")" ]; then
+                reply_equal_turns=$((reply_equal_turns + 1))
+            fi
+            last_on_log="$on_log"
+        done
+
+        calibration="$(
+            calibration_from_log "$last_on_log" "$cell" "$run_seed"
+        )"
+        proposed=0
+        deadline=0
+        observed=0
+        appetite=0
+        peak=0
+        semantic_hits=0
+        observations=0
+        spoken=0
+        verdict=none
+        receipt_brier=0
+        pending=0
+        scored=0
+        confirmed=0
+        external=0
+        lost=0
+        unscorable=0
+        entries=
+        if [ "$expected_forecast" -eq 1 ]; then
+            [ -n "$calibration" ] || {
+                printf '%s missing final calibration receipt\n' \
+                    "$cell" >&2
+                exit 1
+            }
+            IFS=$'\t' read -r _ _ receipt_turn pending scored \
+                confirmed external lost unscorable aggregate_brier \
+                entries <<< "$calibration"
+            fields="$(entry_fields "$entries" "$target")"
+            [ -n "$fields" ] || {
+                printf '%s target missing from calibration entries\n' \
+                    "$cell" >&2
+                exit 1
+            }
+            IFS=$'\t' read -r proposed deadline observed appetite \
+                peak semantic_hits observations spoken verdict \
+                receipt_brier <<< "$fields"
+        else
+            [ -z "$calibration" ] || {
+                printf '%s invented a forecast for diffuse evidence\n' \
+                    "$cell" >&2
+                exit 1
+            }
+        fi
+
+        on_sha="$(sha256_file "$cell_dir/on.state")"
+        off_sha="$(sha256_file "$cell_dir/off.state")"
+        full_equal=0
+        [ "$on_sha" = "$off_sha" ] && full_equal=1
+        off_size="$(wc -c < "$cell_dir/off.state")"
+        core_size=$((off_size - 2 * 4))
+        [ "$core_size" -gt 0 ] || {
+            printf '%s invalid empty-diary state size\n' "$cell" >&2
+            exit 1
+        }
+        head -c "$core_size" "$cell_dir/on.state" \
+            > "$cell_dir/on.core"
+        head -c "$core_size" "$cell_dir/off.state" \
+            > "$cell_dir/off.core"
+        core_equal=0
+        cmp -s "$cell_dir/on.core" "$cell_dir/off.core" &&
+            core_equal=1
+
+        expected_observations=$((turns - 1))
+        verdict_contract=0
+        if [ "$expected_verdict" = "none" ]; then
+            [ "$verdict" = none ] && verdict_contract=1
+        elif [ "$verdict" = "$expected_verdict" ] &&
+             [ "$spoken" = "$expected_spoken" ] &&
+             [ "$observations" = "$expected_observations" ] &&
+             (( observed == proposed + observations )) &&
+             (( deadline == proposed + 3 )); then
+            case "$verdict" in
+                sustained)
+                    [ "$semantic_hits" -ge 1 ] &&
+                    awk -v peak="$peak" \
+                        'BEGIN { exit !((peak + 0) >= 0.75) }' &&
+                    awk -v score="$appetite" -v brier="$receipt_brier" \
+                        'BEGIN {
+                            error = score - 1
+                            exit !(brier >= error * error - 0.002 &&
+                                   brier <= error * error + 0.002)
+                        }' &&
+                    [ "$pending" = 0 ] &&
+                    [ "$scored" = 1 ] &&
+                    [ "$confirmed" = 1 ] &&
+                    verdict_contract=1
+                    ;;
+                faded)
+                    [ "$semantic_hits" = 0 ] &&
+                    awk -v score="$appetite" -v brier="$receipt_brier" \
+                        'BEGIN {
+                            want = score * score
+                            exit !(brier >= want - 0.002 &&
+                                   brier <= want + 0.002)
+                        }' &&
+                    [ "$pending" = 0 ] &&
+                    [ "$scored" = 1 ] &&
+                    [ "$confirmed" = 0 ] &&
+                    verdict_contract=1
+                    ;;
+                external)
+                    [ "$receipt_brier" = "0.000" ] &&
+                    [ "$external" = 1 ] &&
+                    [ "$scored" = 0 ] &&
+                    verdict_contract=1
+                    ;;
+            esac
+        fi
+
+        [ "$verdict_contract" = 1 ] &&
+        [ "$reply_equal_turns" = "$turns" ] &&
+        [ "$core_equal" = 1 ] &&
+        [ "$full_equal" = "$expected_full_equal" ] || {
+            printf '%s contract failed: verdict=%s turns=%s replies=%s core=%s full=%s spoken=%s hits=%s observations=%s\n' \
+                "$cell" "$verdict" "$turns" "$reply_equal_turns" \
+                "$core_equal" "$full_equal" "$spoken" \
+                "$semantic_hits" "$observations" >&2
+            exit 1
+        }
+
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$cell" "$group" "$cohort" "$case" "$kind" "$target" \
+            "$verdict" "$proposed" "$deadline" "$observed" \
+            "$appetite" "$peak" "$semantic_hits" "$observations" \
+            "$spoken" "$receipt_brier" "$turns" \
+            "$reply_equal_turns" "$core_equal" "$full_equal" \
+            "$on_sha" "$off_sha" >> "$MATRIX"
+        if [ -n "$calibration" ]; then
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                "$cell" "$receipt_turn" "$pending" "$scored" \
+                "$confirmed" "$external" "$lost" "$unscorable" \
+                "$aggregate_brier" "$entries" >> "$RECEIPTS"
+        fi
+    done < "$CASES_FILE"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        cells++
+        verdict[$7]++
+        spoken += $15
+        reply_turns += $18
+        core_equal += $19
+        full_equal += $20
+        full_diverged += !$20
+    }
+    END {
+        print "cells\tsustained\tfaded\texternal\tnone\tspoken\treply_equal_turns\tcore_equal\tfull_equal\tfull_diverged"
+        print cells "\t" verdict["sustained"] "\t" verdict["faded"] \
+              "\t" verdict["external"] "\t" verdict["none"] \
+              "\t" spoken "\t" reply_turns "\t" core_equal \
+              "\t" full_equal "\t" full_diverged
+    }
+' "$MATRIX" > "$SUMMARY"
+
+cat "$SUMMARY"
+printf '\nmatrix: %s\nreceipts: %s\n' "$MATRIX" "$RECEIPTS"

--- a/scripts/deferred_wonder_appetite_matrix.sh
+++ b/scripts/deferred_wonder_appetite_matrix.sh
@@ -165,7 +165,8 @@ while IFS=$'\t' read -r group cohort seed; do
     cp "$ready" "$group_dir/parked-base.state"
     "$ROOT/leo" --load "$group_dir/parked-base.state" \
         --seed "$((seed + 4100))" --respond "$active" --debug-field \
-        --no-wonder-appetite --save "$group_dir/parked-base.state" \
+        --no-wonder-appetite --no-wonder-appetite-calibration \
+        --save "$group_dir/parked-base.state" \
         > "$group_dir/parked-open.log" 2>&1
     [ "$(reply_from_log "$group_dir/parked-open.log")" = "$active_question" ] || {
         printf '%s failed to open parked control\n' "$group" >&2
@@ -173,7 +174,8 @@ while IFS=$'\t' read -r group cohort seed; do
     }
     "$ROOT/leo" --load "$group_dir/parked-base.state" \
         --seed "$((seed + 4101))" --respond "$sibling" --debug-field \
-        --no-wonder-appetite --save "$group_dir/parked-base.state" \
+        --no-wonder-appetite --no-wonder-appetite-calibration \
+        --save "$group_dir/parked-base.state" \
         > "$group_dir/parked-switch.log" 2>&1
     [ "$(reply_from_log "$group_dir/parked-switch.log")" = "$sibling_question" ] || {
         printf '%s failed to switch the parked control\n' "$group" >&2
@@ -208,10 +210,12 @@ while IFS=$'\t' read -r group cohort seed; do
         cp "$base" "$cell_dir/off.state"
         run_seed=$((seed + 4400 + group_index * 100 + case_index))
         "$ROOT/leo" --load "$cell_dir/on.state" --seed "$run_seed" \
-            --respond "$prompt" --debug-field --save "$cell_dir/on.state" \
+            --respond "$prompt" --debug-field \
+            --no-wonder-appetite-calibration --save "$cell_dir/on.state" \
             > "$cell_dir/on.log" 2>&1
         "$ROOT/leo" --load "$cell_dir/off.state" --seed "$run_seed" \
             --respond "$prompt" --debug-field --no-wonder-appetite \
+            --no-wonder-appetite-calibration \
             --save "$cell_dir/off.state" > "$cell_dir/off.log" 2>&1
 
         appetite="$(

--- a/scripts/test_deferred_wonder_appetite_calibration_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_calibration_matrix.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_CALIBRATION_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_calibration_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 11 || $1 != "cell" || $2 != "group" ||
+            $5 != "case" || $6 != "kind" || $7 != "target" ||
+            $8 != "expected_verdict" ||
+            $9 != "expected_spoken" ||
+            $10 != "expected_forecast" ||
+            $11 != "expected_full_equal")
+            exit 1
+        next
+    }
+    {
+        if (NF != 11 || cells[$1]++)
+            exit 1
+        groups[$2]++
+        cases[$5]++
+        kinds[$6]++
+        verdicts[$8]++
+        rows++
+    }
+    END {
+        if (rows != 10 || length(groups) != 2 ||
+            length(cases) != 5 || kinds["unspoken"] != 6 ||
+            kinds["parked"] != 2 || kinds["control"] != 2 ||
+            verdicts["sustained"] != 4 ||
+            verdicts["faded"] != 2 ||
+            verdicts["external"] != 2 ||
+            verdicts["none"] != 2)
+            exit 1
+        for (group in groups)
+            if (groups[group] != 5)
+                exit 1
+        for (case in cases)
+            if (cases[case] != 2)
+                exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite calibration plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite calibration matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_calibration_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_calibration_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-calibration: turn=17 pending=0 scored=1 confirmed=1 external=0 lost=0 unscorable=0 brier=0.032 entries=suvin:14/17/17/0.820/0.911/1/3/1/sustained/0.032]
+EOF
+
+got="$(
+    awk -v scenario=parked-sustained -v seed=83 \
+        -f "$ROOT/scripts/wonder_appetite_calibration_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'parked-sustained\t83\t17\t0\t1\t1\t0\t0\t0\t0.032\tsuvin:14/17/17/0.820/0.911/1/3/1/sustained/0.032'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite calibration parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite calibration report parser: ok\n'

--- a/scripts/wonder_appetite_calibration_dialogue_report.awk
+++ b/scripts/wonder_appetite_calibration_dialogue_report.awk
@@ -1,0 +1,25 @@
+# Extract one slow deferred-Wonder appetite-calibration receipt per lived turn.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    start, tail, parts) {
+    start = index(line, key "=")
+    if (!start) return ""
+    tail = substr(line, start + length(key) + 1)
+    split(tail, parts, /[ ]/)
+    gsub(/\]$/, "", parts[1])
+    return parts[1]
+}
+
+/\[wonder-appetite-calibration: turn=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed), value_after($0, "turn"),
+           value_after($0, "pending"), value_after($0, "scored"),
+           value_after($0, "confirmed"), value_after($0, "external"),
+           value_after($0, "lost"), value_after($0, "unscorable"),
+           value_after($0, "brier"), value_after($0, "entries")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -54,6 +54,12 @@ static void seed_wonder_redirection_body(Leo *leo) {
         leo->school.pending_alt_glyph, 1, field_token, field_weight);
 }
 
+static long test_appetite_calibration_tail_size(const Leo *leo) {
+    return (long)(2 * sizeof(int32_t) +
+        leo->wonder_appetite_calibration.n *
+            (int)sizeof(LeoWonderAppetiteCalibrationReceipt));
+}
+
 int main(void) {
     printf("test_leo (step 0)\n");
 
@@ -1039,8 +1045,11 @@ int main(void) {
             unsigned char *bytes = malloc(sz > 0 ? (size_t)sz : 1);
             if (bytes && sz > 1 &&
                 (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
+                long appetite_tail =
+                    test_appetite_calibration_tail_size(&pre);
                 long origin_tail = (long)sizeof(int32_t);
-                long tail = origin_tail + (long)(sizeof(int32_t) +
+                long tail = appetite_tail + origin_tail +
+                            (long)(sizeof(int32_t) +
                                    pre.school.n_deferred *
                                        (int)sizeof(LeoDeferredWonder));
                 uint32_t seventeen = 17;
@@ -1091,8 +1100,9 @@ int main(void) {
                 if (fo) {
                     built_cut =
                         (long)fwrite(bytes, 1,
-                                     (size_t)(sz - origin_tail - 1), fo) ==
-                        sz - origin_tail - 1;
+                                     (size_t)(sz - appetite_tail -
+                                              origin_tail - 1), fo) ==
+                        sz - appetite_tail - origin_tail - 1;
                     fclose(fo);
                 }
             }
@@ -1780,6 +1790,8 @@ int main(void) {
             unsigned char *bytes = malloc(sz > 0 ? (size_t)sz : 1);
             if (bytes && sz > (long)sizeof(LeoDeferredWonder) + 5 &&
                 (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
+                long appetite_tail =
+                    test_appetite_calibration_tail_size(&sleep);
                 long origin_tail =
                     (long)(sizeof(int32_t) + sizeof(LeoDeferredWonder));
                 uint32_t nineteen = 19;
@@ -1789,8 +1801,9 @@ int main(void) {
                 if (fo) {
                     built_legacy =
                         (long)fwrite(bytes, 1,
-                                     (size_t)(sz - origin_tail), fo) ==
-                        sz - origin_tail;
+                                     (size_t)(sz - appetite_tail -
+                                              origin_tail), fo) ==
+                        sz - appetite_tail - origin_tail;
                     fclose(fo);
                 }
                 uint32_t twenty = 20;
@@ -1799,8 +1812,10 @@ int main(void) {
                 fo = fopen(cut, "wb");
                 if (fo) {
                     built_cut =
-                        (long)fwrite(bytes, 1, (size_t)(sz - 1), fo) ==
-                        sz - 1;
+                        (long)fwrite(
+                            bytes, 1,
+                            (size_t)(sz - appetite_tail - 1), fo) ==
+                        sz - appetite_tail - 1;
                     fclose(fo);
                 }
             }
@@ -1946,6 +1961,335 @@ int main(void) {
         leo_free(&parked);
 
         g_leo_wonder_appetite_on = prev_appetite;
+        g_leo_flow_on = prev_flow;
+        g_leo_wonder_on = prev_wonder;
+        g_leo_deferred_wonder_on = prev_deferred;
+        g_leo_wonder_attribution_on = prev_attr;
+        g_leo_wonder_redirection_on = prev_redirection;
+    }
+
+    /* A.45: appetite forecasts are judged over three future lived turns. The
+     * diary persists, but remains causally downstream of speech and School. */
+    {
+        int prev_appetite = g_leo_wonder_appetite_on;
+        int prev_calibration =
+            g_leo_wonder_appetite_calibration_on;
+        int prev_flow = g_leo_flow_on;
+        int prev_wonder = g_leo_wonder_on;
+        int prev_deferred = g_leo_deferred_wonder_on;
+        int prev_attr = g_leo_wonder_attribution_on;
+        int prev_redirection = g_leo_wonder_redirection_on;
+        g_leo_wonder_appetite_on = 1;
+        g_leo_wonder_appetite_calibration_on = 1;
+        g_leo_flow_on = 1;
+        g_leo_wonder_on = 1;
+        g_leo_deferred_wonder_on = 1;
+        g_leo_wonder_attribution_on = 1;
+        g_leo_wonder_redirection_on = 1;
+
+        Leo *cal = malloc(sizeof *cal), *woke = malloc(sizeof *woke),
+            *old = malloc(sizeof *old), *damaged = malloc(sizeof *damaged);
+        CHECK(cal && woke && old && damaged,
+              "wonder-appetite-calibration: heap fixtures allocated");
+        if (cal && woke && old && damaged) {
+            seed_wonder_redirection_body(cal);
+            leo_init(woke); leo_init(old); leo_init(damaged);
+            cal->school.turn_clock = 11;
+            LeoSchool school_before = cal->school;
+            LeoFlow flow_before = cal->flow;
+            leo_wonder_appetite_observe(
+                cal, "Cat bird. Dark night.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "Cat bird. Dark night.");
+            const LeoWonderAppetiteCalibrationReceipt *forecast =
+                leo_wonder_appetite_calibration_at(
+                    &cal->wonder_appetite_calibration, 0);
+            CHECK(forecast &&
+                  !strcmp(forecast->word, "nareth") &&
+                  forecast->proposed_turn == 11 &&
+                  forecast->deadline_turn == 14 &&
+                  forecast->observed_turn == 11 &&
+                  forecast->observations == 0 &&
+                  forecast->verdict ==
+                      LEO_WONDER_APPETITE_CALIB_PENDING &&
+                  !memcmp(&school_before, &cal->school,
+                          sizeof cal->school) &&
+                  !memcmp(&flow_before, &cal->flow,
+                          sizeof cal->flow),
+                  "wonder-appetite-calibration: salience opens one fixed readerless horizon");
+
+            cal->school.turn_clock = 12;
+            leo_wonder_appetite_observe(
+                cal, "I do not know.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "I do not know.");
+            forecast = leo_wonder_appetite_calibration_at(
+                &cal->wonder_appetite_calibration, 0);
+            CHECK(forecast &&
+                  cal->wonder_appetite_calibration.n == 1 &&
+                  forecast->observations == 1 &&
+                  forecast->semantic_hits == 0 &&
+                  forecast->verdict ==
+                      LEO_WONDER_APPETITE_CALIB_PENDING,
+                  "wonder-appetite-calibration: a quiet future turn advances without sliding or duplication");
+
+            cal->school.turn_clock = 13;
+            leo_wonder_appetite_observe(
+                cal, "Cat bird. Dark night.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "Cat bird. Dark night.");
+            leo_wonder_appetite_calibrate(
+                cal, "Cat bird. Dark night.");
+            forecast = leo_wonder_appetite_calibration_at(
+                &cal->wonder_appetite_calibration, 0);
+            CHECK(forecast &&
+                  cal->wonder_appetite_calibration.n == 1 &&
+                  forecast->observations == 2 &&
+                  forecast->semantic_hits == 1 &&
+                  forecast->peak_recurrence >=
+                      LEO_WONDER_APPETITE_RESONANCE_MIN &&
+                  forecast->verdict ==
+                      LEO_WONDER_APPETITE_CALIB_PENDING,
+                  "wonder-appetite-calibration: a future recurrence is counted once but waits for the whole horizon");
+
+            const char *state =
+                "/tmp/leo_wonder_appetite_calibration_v21.state";
+            const char *legacy =
+                "/tmp/leo_wonder_appetite_calibration_v20.state";
+            const char *cut =
+                "/tmp/leo_wonder_appetite_calibration_v21_cut.state";
+            int saved = leo_save_state(cal, state);
+            int built_legacy = 0, built_cut = 0;
+            FILE *fi = fopen(state, "rb");
+            if (fi) {
+                fseek(fi, 0, SEEK_END);
+                long sz = ftell(fi);
+                fseek(fi, 0, SEEK_SET);
+                unsigned char *bytes =
+                    malloc(sz > 0 ? (size_t)sz : 1);
+                long appetite_tail =
+                    test_appetite_calibration_tail_size(cal);
+                if (bytes && sz > appetite_tail &&
+                    (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
+                    uint32_t twenty = 20;
+                    memcpy(bytes + sizeof(uint32_t), &twenty,
+                           sizeof twenty);
+                    FILE *fo = fopen(legacy, "wb");
+                    if (fo) {
+                        built_legacy =
+                            (long)fwrite(
+                                bytes, 1,
+                                (size_t)(sz - appetite_tail), fo) ==
+                            sz - appetite_tail;
+                        fclose(fo);
+                    }
+                    uint32_t twenty_one = 21;
+                    memcpy(bytes + sizeof(uint32_t), &twenty_one,
+                           sizeof twenty_one);
+                    fo = fopen(cut, "wb");
+                    if (fo) {
+                        built_cut =
+                            (long)fwrite(
+                                bytes, 1, (size_t)(sz - 1), fo) ==
+                            sz - 1;
+                        fclose(fo);
+                    }
+                }
+                free(bytes);
+                fclose(fi);
+            }
+            int loaded = saved && leo_load_state(woke, state);
+            forecast = loaded ?
+                leo_wonder_appetite_calibration_at(
+                    &woke->wonder_appetite_calibration, 0) : NULL;
+            CHECK(loaded && forecast &&
+                  forecast->proposed_turn == 11 &&
+                  forecast->observed_turn == 13 &&
+                  forecast->semantic_hits == 1,
+                  "wonder-appetite-calibration: an unfinished forecast survives sleep without losing its clock");
+
+            woke->school.turn_clock = 14;
+            leo_wonder_appetite_observe(
+                woke, "I do not know.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                woke, "I do not know.");
+            forecast = leo_wonder_appetite_calibration_at(
+                &woke->wonder_appetite_calibration, 0);
+            float sustained_error =
+                forecast ? forecast->appetite - 1.0f : 0.0f;
+            CHECK(forecast &&
+                  forecast->verdict ==
+                      LEO_WONDER_APPETITE_CALIB_SUSTAINED &&
+                  forecast->observations ==
+                      LEO_WONDER_APPETITE_CALIB_HORIZON &&
+                  fabsf(forecast->brier -
+                        sustained_error * sustained_error) < 1e-6f,
+                  "wonder-appetite-calibration: recurrence matures into a scored sustained verdict");
+
+            CHECK(built_legacy && leo_load_state(old, legacy) &&
+                  old->wonder_appetite_calibration.n == 0 &&
+                  leo_deferred_wonder_find(old, "nareth") >= 0,
+                  "wonder-appetite-calibration: a v20 body migrates without invented forecasts");
+            CHECK(built_cut && leo_load_state(damaged, cut) &&
+                  damaged->wonder_appetite_calibration.n == 0 &&
+                  leo_deferred_wonder_find(damaged, "nareth") >= 0,
+                  "wonder-appetite-calibration: a corrupt v21 tail loses only forecasts");
+
+            leo_free(cal);
+            seed_wonder_redirection_body(cal);
+            cal->school.turn_clock = 20;
+            leo_wonder_appetite_observe(
+                cal, "Cat bird. Dark night.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "Cat bird. Dark night.");
+            for (int turn = 21; turn <= 23; turn++) {
+                cal->school.turn_clock = turn;
+                leo_wonder_appetite_observe(
+                    cal, "I do not know.", NULL, NULL);
+                leo_wonder_appetite_calibrate(
+                    cal, "I do not know.");
+            }
+            forecast = leo_wonder_appetite_calibration_at(
+                &cal->wonder_appetite_calibration, 0);
+            CHECK(forecast &&
+                  forecast->verdict ==
+                      LEO_WONDER_APPETITE_CALIB_FADED &&
+                  forecast->semantic_hits == 0 &&
+                  fabsf(forecast->brier -
+                        forecast->appetite * forecast->appetite) <
+                      1e-6f,
+                  "wonder-appetite-calibration: a one-frame appetite can honestly fade");
+
+            leo_free(cal);
+            seed_wonder_redirection_body(cal);
+            cal->school.turn_clock = 30;
+            leo_wonder_appetite_observe(
+                cal, "Cat bird. Dark night.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "Cat bird. Dark night.");
+            cal->school.turn_clock = 31;
+            leo_wonder_appetite_observe(
+                cal, "Nareth.", NULL, NULL);
+            leo_wonder_appetite_calibrate(cal, "Nareth.");
+            forecast = leo_wonder_appetite_calibration_at(
+                &cal->wonder_appetite_calibration, 0);
+            CHECK(forecast &&
+                  forecast->verdict ==
+                      LEO_WONDER_APPETITE_CALIB_EXTERNAL &&
+                  forecast->observations == 1 &&
+                  forecast->brier == 0.0f,
+                  "wonder-appetite-calibration: literal human address is visible but unscored");
+
+            leo_free(cal);
+            seed_wonder_redirection_body(cal);
+            cal->school.turn_clock = 40;
+            leo_wonder_appetite_observe(
+                cal, "Cat bird. Dark night.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "Cat bird. Dark night.");
+            leo_school_learn(
+                cal, "nareth", semtok_find_glyph("animal"));
+            cal->school.turn_clock = 41;
+            leo_wonder_appetite_observe(
+                cal, "Animal.", NULL, NULL);
+            leo_wonder_appetite_calibrate(cal, "Animal.");
+            forecast = leo_wonder_appetite_calibration_at(
+                &cal->wonder_appetite_calibration, 0);
+            CHECK(forecast &&
+                  forecast->verdict ==
+                      LEO_WONDER_APPETITE_CALIB_GROUNDED &&
+                  forecast->brier > 0.0f,
+                  "wonder-appetite-calibration: actual learning closes the forecast as grounded");
+
+            leo_free(cal);
+            seed_wonder_redirection_body(cal);
+            cal->school.turn_clock = 50;
+            leo_wonder_appetite_observe(
+                cal, "Cat bird. Dark night.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "Cat bird. Dark night.");
+            leo_deferred_wonder_forget(cal, "nareth");
+            for (int turn = 51; turn <= 53; turn++) {
+                cal->school.turn_clock = turn;
+                leo_wonder_appetite_observe(
+                    cal, "I do not know.", NULL, NULL);
+                leo_wonder_appetite_calibrate(
+                    cal, "I do not know.");
+            }
+            forecast = leo_wonder_appetite_calibration_at(
+                &cal->wonder_appetite_calibration, 0);
+            CHECK(forecast &&
+                  forecast->verdict ==
+                      LEO_WONDER_APPETITE_CALIB_LOST &&
+                  forecast->brier == 0.0f,
+                  "wonder-appetite-calibration: a vanished identity is not mislabeled as a failed prediction");
+
+            leo_free(cal);
+            seed_wonder_redirection_body(cal);
+            cal->school.turn_clock = 60;
+            leo_wonder_appetite_observe(
+                cal, "Cat bird. Dark night.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "Cat bird. Dark night.");
+            cal->school.turn_clock = 62;
+            leo_wonder_appetite_observe(
+                cal, "I do not know.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "I do not know.");
+            forecast = leo_wonder_appetite_calibration_at(
+                &cal->wonder_appetite_calibration, 0);
+            CHECK(forecast &&
+                  forecast->verdict ==
+                      LEO_WONDER_APPETITE_CALIB_UNSCORABLE &&
+                  forecast->brier == 0.0f,
+                  "wonder-appetite-calibration: a missing lived turn breaks the claim instead of fabricating history");
+
+            leo_free(cal);
+            seed_wonder_redirection_body(cal);
+            int suvin_episode =
+                leo_wonder_find_open(cal, "suvin");
+            uint64_t suvin_id = suvin_episode >= 0 ?
+                leo_wonder_episode_id(
+                    &cal->school.wonders[suvin_episode]) : 0;
+            leo_flow_observe(
+                cal, "suvin", "Suvin? Light or Cold?",
+                NULL, NULL, NULL, LEO_FLOW_WONDER_BORN, suvin_id);
+            cal->school.turn_clock = 4;
+            int veto =
+                leo_wonder_address_observe(cal, "Nareth.");
+            int switched = leo_wonder_address_redirect(cal);
+            leo_wonder_appetite_observe(
+                cal, "Bright sun. Cold winter.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "Bright sun. Cold winter.");
+            forecast = leo_wonder_appetite_calibration_at(
+                &cal->wonder_appetite_calibration, 0);
+            CHECK(veto && switched && forecast &&
+                  !strcmp(forecast->word, "suvin") &&
+                  forecast->spoken &&
+                  forecast->wonder_id == suvin_id,
+                  "wonder-appetite-calibration: a parked spoken question keeps its stable episode identity");
+
+            memset(&cal->wonder_appetite_calibration, 0,
+                   sizeof cal->wonder_appetite_calibration);
+            g_leo_wonder_appetite_calibration_on = 0;
+            cal->school.turn_clock = 70;
+            leo_wonder_appetite_observe(
+                cal, "Bright sun. Cold winter.", NULL, NULL);
+            leo_wonder_appetite_calibrate(
+                cal, "Bright sun. Cold winter.");
+            CHECK(cal->wonder_appetite_calibration.n == 0,
+                  "wonder-appetite-calibration: ablation removes only the slow diary");
+
+            remove(state); remove(legacy); remove(cut);
+            leo_free(cal); leo_free(woke);
+            leo_free(old); leo_free(damaged);
+        }
+        free(cal); free(woke); free(old); free(damaged);
+
+        g_leo_wonder_appetite_on = prev_appetite;
+        g_leo_wonder_appetite_calibration_on =
+            prev_calibration;
         g_leo_flow_on = prev_flow;
         g_leo_wonder_on = prev_wonder;
         g_leo_deferred_wonder_on = prev_deferred;
@@ -2180,12 +2524,15 @@ int main(void) {
                 long origin_tail = (long)(sizeof(int32_t) +
                                            (w.school.has_pending_origin ?
                                             sizeof(LeoDeferredWonder) : 0));
+                long appetite_tail =
+                    test_appetite_calibration_tail_size(&w);
                 long current_flow = (long)(2 * sizeof(int32_t) +
                                            w.flow.n * (int)sizeof(LeoFlowSnapshot) +
                                            2 * sizeof(int32_t) +
                                            w.flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
                                            shadow_tail + calibration_tail +
-                                           deferred_tail + origin_tail);
+                                           deferred_tail + origin_tail +
+                                           appetite_tail);
                 if (sz > v12tail + current_flow) {
                     long flow_start = sz - current_flow;
                     long tail_start = flow_start - v12tail;
@@ -2571,12 +2918,15 @@ int main(void) {
                     long origin_tail = (long)(sizeof(int32_t) +
                                               (fl->school.has_pending_origin ?
                                                sizeof(LeoDeferredWonder) : 0));
+                    long appetite_tail =
+                        test_appetite_calibration_tail_size(fl);
                     long current_tail = (long)(2 * sizeof(int32_t) +
                                               fl->flow.n * (int)sizeof(LeoFlowSnapshot) +
                                               2 * sizeof(int32_t) +
                                               fl->flow.n_currents * (int)sizeof(LeoFlowWonderCurrent) +
                                               shadow_tail + calibration_tail +
-                                              deferred_tail + origin_tail);
+                                              deferred_tail + origin_tail +
+                                              appetite_tail);
                     long prefix = sz - current_tail;
                     if (prefix > 0) {
                         long current_only = (long)(2 * sizeof(int32_t) +
@@ -2589,9 +2939,11 @@ int main(void) {
                                                      (size_t)(sz - calibration_tail -
                                                               shadow_tail -
                                                               deferred_tail -
-                                                              origin_tail - 1), fo) ==
+                                                              origin_tail -
+                                                              appetite_tail - 1), fo) ==
                                         sz - calibration_tail - shadow_tail -
-                                            deferred_tail - origin_tail - 1;
+                                            deferred_tail - origin_tail -
+                                            appetite_tail - 1;
                             fclose(fo);
                         }
                         uint32_t fourteen = 14;
@@ -2600,12 +2952,14 @@ int main(void) {
                         if (fo) {
                             built_legacy14 = (long)fwrite(bytes, 1,
                                                          (size_t)(sz - calibration_tail -
-                                                                  shadow_tail -
-                                                                  deferred_tail -
-                                                                  origin_tail -
-                                                                  current_only), fo) ==
+                                                                 shadow_tail -
+                                                                 deferred_tail -
+                                                                 origin_tail -
+                                                                 appetite_tail -
+                                                                 current_only), fo) ==
                                              sz - calibration_tail - shadow_tail -
                                                  deferred_tail - origin_tail -
+                                                 appetite_tail -
                                                  current_only;
                             fclose(fo);
                         }
@@ -2819,6 +3173,8 @@ int main(void) {
                     long origin_tail = (long)(sizeof(int32_t) +
                                               (sh->school.has_pending_origin ?
                                                sizeof(LeoDeferredWonder) : 0));
+                    long appetite_tail =
+                        test_appetite_calibration_tail_size(sh);
                     uint32_t fifteen = 15;
                     memcpy(bytes + sizeof(uint32_t), &fifteen, sizeof fifteen);
                     FILE *fo = fopen(legacy, "wb");
@@ -2827,9 +3183,11 @@ int main(void) {
                                                  (size_t)(sz - calibration_tail -
                                                           shadow_tail -
                                                           deferred_tail -
-                                                          origin_tail), fo) ==
+                                                          origin_tail -
+                                                          appetite_tail), fo) ==
                                     sz - calibration_tail - shadow_tail -
-                                        deferred_tail - origin_tail;
+                                        deferred_tail - origin_tail -
+                                        appetite_tail;
                         fclose(fo);
                     }
                     uint32_t sixteen = 16;
@@ -2839,9 +3197,10 @@ int main(void) {
                         built_compat = (long)fwrite(bytes, 1,
                                                     (size_t)(sz - calibration_tail -
                                                              deferred_tail -
-                                                             origin_tail), fo) ==
+                                                             origin_tail -
+                                                             appetite_tail), fo) ==
                                        sz - calibration_tail - deferred_tail -
-                                           origin_tail;
+                                           origin_tail - appetite_tail;
                         fclose(fo);
                     }
                     uint32_t seventeen = 17;
@@ -2850,8 +3209,10 @@ int main(void) {
                     if (fo) {
                         built_cut = (long)fwrite(bytes, 1,
                                                 (size_t)(sz - deferred_tail -
-                                                         origin_tail - 1), fo) ==
-                                    sz - deferred_tail - origin_tail - 1;
+                                                         origin_tail -
+                                                         appetite_tail - 1), fo) ==
+                                    sz - deferred_tail - origin_tail -
+                                        appetite_tail - 1;
                         fclose(fo);
                     }
                 }
@@ -3631,12 +3992,38 @@ int main(void) {
         CHECK(leo_load_state(&l2, sp) == 1 && l2.n_shards == 2 &&
               l2.shards[1].ids[0] == 300 && l2.consol_locked == 1,
               "consol: current state roundtrips the v10 shard ring + sleep trigger");
-        /* Half-write probe: remove v11 plus part of the v10 section — the organism lives, shardless. */
+        /* Half-write probe: build an exact v10 prefix, then cut its final
+         * consolidation byte — the organism lives, shardless. */
         {
             FILE *tf = fopen(sp, "rb");
             fseek(tf, 0, SEEK_END); long fl = ftell(tf); fseek(tf, 0, SEEK_SET);
             char *fb = malloc((size_t)fl); fread(fb, 1, (size_t)fl, tf); fclose(tf);
-            tf = fopen(sp, "wb"); fwrite(fb, 1, (size_t)(fl - 65), tf); fclose(tf);
+            long after_v10 =
+                (long)(4 * sizeof(int32_t) + sizeof(uint64_t) +
+                       l.school.n_wonders *
+                           (int)sizeof(LeoWonderEpisode) +
+                       2 * sizeof(int32_t) +
+                       l.flow.n * (int)sizeof(LeoFlowSnapshot) +
+                       2 * sizeof(int32_t) +
+                       l.flow.n_currents *
+                           (int)sizeof(LeoFlowWonderCurrent) +
+                       2 * sizeof(int32_t) +
+                       l.shadow.n * (int)sizeof(LeoShadowReceipt) +
+                       2 * sizeof(int32_t) +
+                       l.calibration.n *
+                           (int)sizeof(LeoCalibrationReceipt) +
+                       sizeof(int32_t) +
+                       l.school.n_deferred *
+                           (int)sizeof(LeoDeferredWonder) +
+                       sizeof(int32_t) +
+                       (l.school.has_pending_origin ?
+                        sizeof(LeoDeferredWonder) : 0)) +
+                test_appetite_calibration_tail_size(&l);
+            uint32_t ten = 10;
+            memcpy(fb + sizeof(uint32_t), &ten, sizeof ten);
+            tf = fopen(sp, "wb");
+            fwrite(fb, 1, (size_t)(fl - after_v10 - 1), tf);
+            fclose(tf);
             free(fb);
         }
         Leo l3; leo_init(&l3);


### PR DESCRIPTION
Method: The Arianna Method treats a returning question as a forecast to calibrate before it can become a proposal to act.

Persist one fixed three-turn evidence window per salient deferred Wonder. Separate sustained return and fade from literal invitation, grounding, lost identity, and missing chronology; score only causally judgeable outcomes, while keeping every verdict downstream of speech.

Evidence: 339/339 contracts; full UBSan suite; ASan/UBSan smoke; repeated ten-cell A.45 matrices with 30/30 reply equality and 10/10 v20-prefix equality; isolated A.44 retains 10/10 complete-state equality.

Quote: "An appetite becomes knowledge only after time has had the right to disagree." - Sol