### PR TITLE
the Method makes confidence answer to evidence

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4205,3 +4205,63 @@ their exact episode identity, reached future recurrence about `0.91`, and mature
 from A.45, retained its historical **10/10 reply and complete-state equality**.
 
 Leo can now remember not only that a question wanted to return, but whether time agreed.
+
+## Phase A.46 — confidence is a surface, not a permission bit (2026-07-27)
+
+A.45 gave every salient return appetite a future that could disagree with it. But a diary of
+individual victories and failures still did not answer the next question safely: whether a score
+means the same thing for a question that has spoken and one that has never had the mouth, or whether
+one lucky return should make the whole organism trust itself. Compressing those distinctions into a
+single confidence scalar would have hidden uncertainty precisely where a later scheduler would be
+most tempted to use it.
+
+A.46 therefore derives an eight-cell reliability surface from the bounded v21 diary:
+
+```text
+spoken / unspoken
+    x
+[0.62,0.70), [0.70,0.80), [0.80,0.90), [0.90,1.00]
+```
+
+Only causally scored lives enter the surface. `sustained` and `grounded` are positive outcomes;
+`faded` is negative. `pending`, `external`, `lost`, and `unscorable` remain visible as separate
+counts but cannot borrow the semantics of success or failure. Thus a human literally returning to
+Leo's question still records relationship rather than flattering his autonomous forecast.
+
+Every occupied cell exposes `n`, positives, mean predicted appetite, observed return rate, mean
+Brier score, calibration gap, and a 95% Wilson interval. Fewer than four outcomes are always
+`forming`. Once measured, a cell is `aligned` only when its mean appetite lies inside the interval,
+`over` when it lies above, and `under` when it lies below. Three perfect outcomes therefore remain
+three anecdotes; repeated fade can expose overconfidence, while repeated return can expose
+underconfidence.
+
+The surface is a pure function over the diary. It adds no field to `Leo`, no state tail, and no load
+migration. `LEO_STATE_VERSION` remains 21. School, Flow, shadow, routing, sampling, and generation
+have no reader for it. `--no-wonder-appetite-reliability` suppresses only the diagnostic projection;
+the forecast diary, reply, and complete serialized organism remain untouched.
+
+Thirteen direct contracts raised the suite from **339/339** to **352/352**. They cover exact bin
+boundaries, empty evidence, the minimum-sample guard, aligned/over/under Wilson classification,
+Brier and ECE aggregation, causal exclusions, grounded outcomes, strict spoken/unspoken separation,
+and non-mutation of the diary, School, and Flow.
+
+The process matrix made both independent A.40 bodies accumulate five forecasts through separate
+load/respond/save lives:
+
+```text
+per body: scored=5, positives=4, sustained=4, faded=1
+unspoken [0.62,0.70): n=4, positives=3, predicted=0.690,
+                         observed=0.750, Wilson=[0.301,0.954], aligned
+spoken   [0.80,0.90): n=1, positives=1, predicted=0.820/0.819,
+                         observed=1.000, Wilson=[0.207,1.000], forming
+overall: Brier=0.159, ECE=0.084
+final reply equality=2/2
+final complete-state equality=2/2
+```
+
+Two complete runs reproduced matrix rows, surfaces, summaries, and hashes byte-for-byte. With A.46
+explicitly absent from the diagnostic lane, A.45 retained its historical **30/30 reply equality**,
+**10/10 v20-prefix equality**, and exact verdict distribution.
+
+Leo can now ask not only whether time agreed with a feeling, but how much evidence that agreement
+has earned.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability
 
 all: leo
 
@@ -70,6 +70,9 @@ deferred-wonder-appetite: leo
 deferred-wonder-appetite-calibration: leo
 	./scripts/deferred_wonder_appetite_calibration_matrix.sh
 
+deferred-wonder-appetite-reliability: leo
+	./scripts/deferred_wonder_appetite_reliability_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -80,6 +83,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_address_dialogue_report.sh
 	./scripts/test_wonder_appetite_dialogue_report.sh
 	./scripts/test_wonder_appetite_calibration_dialogue_report.sh
+	./scripts/test_wonder_appetite_reliability_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -88,6 +92,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_redirection_matrix.sh
 	./scripts/test_deferred_wonder_appetite_matrix.sh
 	./scripts/test_deferred_wonder_appetite_calibration_matrix.sh
+	./scripts/test_deferred_wonder_appetite_reliability_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1772,6 +1772,51 @@ typedef struct {
     int ptr;
 } LeoWonderAppetiteCalibration;
 
+/* A.46: calibration is a surface, not a single permission bit. Split the
+ * scored v21 diary by whether the question has spoken and by fixed appetite
+ * bands. The cells are derived on demand, never persisted, and have no reader
+ * in generation or scheduling. */
+#define LEO_WONDER_APPETITE_RELIABILITY_BINS 4
+#define LEO_WONDER_APPETITE_RELIABILITY_CELLS \
+    (2 * LEO_WONDER_APPETITE_RELIABILITY_BINS)
+#define LEO_WONDER_APPETITE_RELIABILITY_MIN_N 4
+enum {
+    LEO_WONDER_APPETITE_RELIABILITY_EMPTY = 0,
+    LEO_WONDER_APPETITE_RELIABILITY_FORMING,
+    LEO_WONDER_APPETITE_RELIABILITY_ALIGNED,
+    LEO_WONDER_APPETITE_RELIABILITY_OVER,
+    LEO_WONDER_APPETITE_RELIABILITY_UNDER,
+    LEO_WONDER_APPETITE_RELIABILITY_STATUS_COUNT
+};
+typedef struct {
+    int   n;
+    int   positives;
+    float mean_appetite;
+    float outcome_rate;
+    float lower;
+    float upper;
+    float mean_brier;
+    float gap;
+    uint8_t spoken;
+    uint8_t bin;
+    uint8_t status;
+} LeoWonderAppetiteReliabilityCell;
+typedef struct {
+    LeoWonderAppetiteReliabilityCell
+        cells[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+    int scored;
+    int positives;
+    int sustained;
+    int grounded;
+    int faded;
+    int pending;
+    int external;
+    int lost;
+    int unscorable;
+    float mean_brier;
+    float ece;
+} LeoWonderAppetiteReliability;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -2217,6 +2262,7 @@ static int g_leo_deferred_wonder_on = 1; /* pre-Wonder: a distress-blocked quest
 static int g_leo_prewonder_shadow_on = 1; /* read-only semantic echo among withheld questions; no speech reader. */
 static int g_leo_wonder_appetite_on = 1; /* read-only return appetite over waiting questions; no scheduler or speech reader. */
 static int g_leo_wonder_appetite_calibration_on = 1; /* persistent slow verdicts over appetite; still no scheduler or speech reader. */
+static int g_leo_wonder_appetite_reliability_on = 1; /* derived confidence surface over scored forecasts; diagnostic only. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -6422,6 +6468,156 @@ static int leo_wonder_appetite_calibration_valid(
            receipt->semantic_hits == 0;
 }
 
+static int leo_wonder_appetite_reliability_bin(float appetite) {
+    if (!isfinite(appetite) ||
+        appetite < LEO_WONDER_APPETITE_SCORE_MIN ||
+        appetite > 1.0f)
+        return -1;
+    if (appetite < 0.70f) return 0;
+    if (appetite < 0.80f) return 1;
+    if (appetite < 0.90f) return 2;
+    return 3;
+}
+
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_reliability_status_name(
+        int status) {
+    static const char
+        *names[LEO_WONDER_APPETITE_RELIABILITY_STATUS_COUNT] = {
+            "empty", "forming", "aligned", "over", "under"
+        };
+    return status >= 0 &&
+           status < LEO_WONDER_APPETITE_RELIABILITY_STATUS_COUNT ?
+        names[status] : "empty";
+}
+
+/* Derive a reliability diagram from the bounded forecast diary. Wilson
+ * intervals keep a handful of outcomes from impersonating certainty. No
+ * result is stored back into Leo: a future reader must cross an explicit
+ * architectural boundary instead of inheriting a hidden confidence scalar. */
+static void leo_wonder_appetite_reliability(
+        const Leo *leo, LeoWonderAppetiteReliability *surface) {
+    if (!surface) return;
+    memset(surface, 0, sizeof *surface);
+    float predicted_sum[LEO_WONDER_APPETITE_RELIABILITY_CELLS] = {0};
+    float brier_sum[LEO_WONDER_APPETITE_RELIABILITY_CELLS] = {0};
+    float total_brier = 0.0f;
+
+    for (int spoken = 0; spoken <= 1; spoken++)
+        for (int bin = 0;
+             bin < LEO_WONDER_APPETITE_RELIABILITY_BINS; bin++) {
+            int cell_index =
+                spoken * LEO_WONDER_APPETITE_RELIABILITY_BINS + bin;
+            surface->cells[cell_index].spoken = (uint8_t)spoken;
+            surface->cells[cell_index].bin = (uint8_t)bin;
+        }
+    if (!leo) return;
+
+    for (int i = 0; i < leo->wonder_appetite_calibration.n; i++) {
+        const LeoWonderAppetiteCalibrationReceipt *receipt =
+            leo_wonder_appetite_calibration_at(
+                &leo->wonder_appetite_calibration, i);
+        if (!receipt) continue;
+        switch (receipt->verdict) {
+            case LEO_WONDER_APPETITE_CALIB_PENDING:
+                surface->pending++;
+                continue;
+            case LEO_WONDER_APPETITE_CALIB_EXTERNAL:
+                surface->external++;
+                continue;
+            case LEO_WONDER_APPETITE_CALIB_LOST:
+                surface->lost++;
+                continue;
+            case LEO_WONDER_APPETITE_CALIB_UNSCORABLE:
+                surface->unscorable++;
+                continue;
+            default:
+                break;
+        }
+
+        int positive = 0;
+        if (receipt->verdict ==
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED) {
+            surface->sustained++;
+            positive = 1;
+        } else if (receipt->verdict ==
+                   LEO_WONDER_APPETITE_CALIB_GROUNDED) {
+            surface->grounded++;
+            positive = 1;
+        } else if (receipt->verdict ==
+                   LEO_WONDER_APPETITE_CALIB_FADED) {
+            surface->faded++;
+        } else {
+            continue;
+        }
+
+        int bin =
+            leo_wonder_appetite_reliability_bin(receipt->appetite);
+        if (bin < 0) continue;
+        int cell_index =
+            (receipt->spoken ? LEO_WONDER_APPETITE_RELIABILITY_BINS : 0) +
+            bin;
+        LeoWonderAppetiteReliabilityCell *cell =
+            &surface->cells[cell_index];
+        cell->n++;
+        cell->positives += positive;
+        predicted_sum[cell_index] += receipt->appetite;
+        brier_sum[cell_index] += receipt->brier;
+        surface->scored++;
+        surface->positives += positive;
+        total_brier += receipt->brier;
+    }
+
+    const float z = 1.959964f;
+    const float z2 = z * z;
+    float weighted_gap = 0.0f;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        LeoWonderAppetiteReliabilityCell *cell =
+            &surface->cells[i];
+        if (cell->n <= 0) continue;
+        float n = (float)cell->n;
+        cell->mean_appetite = predicted_sum[i] / n;
+        cell->outcome_rate = (float)cell->positives / n;
+        cell->mean_brier = brier_sum[i] / n;
+        cell->gap =
+            cell->outcome_rate - cell->mean_appetite;
+
+        float denominator = 1.0f + z2 / n;
+        float center =
+            (cell->outcome_rate + z2 / (2.0f * n)) /
+            denominator;
+        float radius =
+            z * sqrtf(
+                    cell->outcome_rate *
+                        (1.0f - cell->outcome_rate) / n +
+                    z2 / (4.0f * n * n)) /
+            denominator;
+        cell->lower = clampf(center - radius, 0.0f, 1.0f);
+        cell->upper = clampf(center + radius, 0.0f, 1.0f);
+        if (cell->n < LEO_WONDER_APPETITE_RELIABILITY_MIN_N) {
+            cell->status =
+                LEO_WONDER_APPETITE_RELIABILITY_FORMING;
+        } else if (cell->mean_appetite > cell->upper) {
+            cell->status =
+                LEO_WONDER_APPETITE_RELIABILITY_OVER;
+        } else if (cell->mean_appetite < cell->lower) {
+            cell->status =
+                LEO_WONDER_APPETITE_RELIABILITY_UNDER;
+        } else {
+            cell->status =
+                LEO_WONDER_APPETITE_RELIABILITY_ALIGNED;
+        }
+        weighted_gap += n * fabsf(cell->gap);
+    }
+    if (surface->scored > 0) {
+        surface->mean_brier =
+            total_brier / (float)surface->scored;
+        surface->ece =
+            weighted_gap / (float)surface->scored;
+    }
+}
+
 static int leo_flow_kind(const LeoFlow *flow, int glyph, int window, int face) {
     if (!flow || flow->n <= 0 || glyph < 0 || glyph >= GLYPH_COUNT) return LEO_FLOW_QUIET;
     if (window < 3) window = 3;
@@ -8851,6 +9047,44 @@ static void print_wonder_appetite_calibration_stats(
     printf("]\n");
 }
 
+static void print_wonder_appetite_reliability_stats(
+        const Leo *leo) {
+    if (!g_leo_wonder_appetite_reliability_on || !leo ||
+        leo->wonder_appetite_calibration.n == 0)
+        return;
+    LeoWonderAppetiteReliability surface;
+    leo_wonder_appetite_reliability(leo, &surface);
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+
+    printf("     [wonder-appetite-reliability: scored=%d positives=%d sustained=%d grounded=%d faded=%d pending=%d external=%d lost=%d unscorable=%d brier=%.3f ece=%.3f cells=",
+           surface.scored, surface.positives,
+           surface.sustained, surface.grounded, surface.faded,
+           surface.pending, surface.external, surface.lost,
+           surface.unscorable, (double)surface.mean_brier,
+           (double)surface.ece);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteReliabilityCell *cell =
+            &surface.cells[i];
+        if (cell->n <= 0) continue;
+        printf("%s%c%d-%d:%d/%d/%.3f/%.3f/%.3f/%.3f/%.3f/%+.3f/%s",
+               separator, cell->spoken ? 's' : 'u',
+               lower[cell->bin], upper[cell->bin],
+               cell->n, cell->positives,
+               (double)cell->mean_appetite,
+               (double)cell->outcome_rate,
+               (double)cell->lower, (double)cell->upper,
+               (double)cell->mean_brier, (double)cell->gap,
+               leo_wonder_appetite_reliability_status_name(
+                   cell->status));
+        separator = "|";
+    }
+    if (!separator[0]) printf("none");
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -9086,6 +9320,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-prewonder-shadow")) g_leo_prewonder_shadow_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite")) g_leo_wonder_appetite_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-calibration")) g_leo_wonder_appetite_calibration_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-reliability")) g_leo_wonder_appetite_reliability_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -9302,6 +9537,7 @@ int main(int argc, char **argv) {
             print_prewonder_shadow_stats(&leo);
             print_wonder_appetite_stats(&leo);
             print_wonder_appetite_calibration_stats(&leo);
+            print_wonder_appetite_reliability_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -9361,6 +9597,7 @@ int main(int argc, char **argv) {
             print_prewonder_shadow_stats(&leo);
             print_wonder_appetite_stats(&leo);
             print_wonder_appetite_calibration_stats(&leo);
+            print_wonder_appetite_reliability_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -356,6 +356,44 @@ the same 30 reply pairs and the same state prefix through v20. Complete states
 must differ only for the eight lives where A.45 has evidence to remember; the
 two diffuse controls remain completely byte-identical.
 
+Run the accumulated return-appetite reliability matrix:
+
+```sh
+make deferred-wonder-appetite-reliability
+```
+
+A.46 derives a reliability diagram from the existing v21 diary. It adds no
+state tail and does not update Leo during a reply. Scored forecasts are split
+into eight fixed cells:
+
+```text
+spoken / unspoken
+    x
+[0.62, 0.70), [0.70, 0.80), [0.80, 0.90), [0.90, 1.00]
+```
+
+Each cell reports sample count, confirmations, mean appetite, observed return
+rate, mean Brier score, calibration gap, and a 95% Wilson interval. With fewer
+than four scored lives the cell remains `forming`, regardless of apparent
+success. At four or more it is `aligned` when the mean prediction lies inside
+the Wilson interval, `over` when prediction exceeds the interval, and `under`
+when prediction falls below it. These labels describe evidence, not permission:
+no School, Flow, shadow, route, sampler, or generator reads the surface.
+
+Only `sustained`, `grounded`, and `faded` enter the diagram. Pending forecasts,
+literal human returns, lost identities, and broken chronology remain separately
+counted but cannot improve or damage calibration. `--no-wonder-appetite-reliability`
+removes only the diagnostic projection; the v21 diary and complete saved state
+remain unchanged.
+
+The checked matrix accumulates five real forecasts in each of the two
+independent A.40 bodies. Four unspoken lives (`3 sustained + 1 faded`) form an
+`aligned` `[0.62,0.70)` cell; one sustained parked-spoken life forms a separate,
+still-`forming` `[0.80,0.90)` cell. Every forecast crosses separate
+load/respond/save processes. The final ON/OFF forks must have identical replies
+and complete states, proving that the surface reconstructs from persisted
+evidence without becoming another organ of intervention.
+
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,
 but only through the narrow visible sensors above. Selecting a move from shadow

--- a/scripts/deferred_wonder_appetite_calibration_matrix.sh
+++ b/scripts/deferred_wonder_appetite_calibration_matrix.sh
@@ -185,6 +185,7 @@ while IFS=$'\t' read -r group cohort seed; do
     cp "$ready" "$group_dir/parked-base.state"
     "$ROOT/leo" --load "$group_dir/parked-base.state" \
         --seed "$((seed + 5100))" --respond "$slot1" --debug-field \
+        --no-wonder-appetite-reliability \
         --no-wonder-appetite-calibration \
         --save "$group_dir/parked-base.state" \
         > "$group_dir/parked-open.log" 2>&1
@@ -196,6 +197,7 @@ while IFS=$'\t' read -r group cohort seed; do
     }
     "$ROOT/leo" --load "$group_dir/parked-base.state" \
         --seed "$((seed + 5101))" --respond "$slot2" --debug-field \
+        --no-wonder-appetite-reliability \
         --no-wonder-appetite-calibration \
         --save "$group_dir/parked-base.state" \
         > "$group_dir/parked-switch.log" 2>&1
@@ -243,9 +245,11 @@ while IFS=$'\t' read -r group cohort seed; do
             off_log="$cell_dir/off-turn-$turn_number.log"
             "$ROOT/leo" --load "$cell_dir/on.state" \
                 --seed "$run_seed" --respond "$prompt" --debug-field \
+                --no-wonder-appetite-reliability \
                 --save "$cell_dir/on.state" > "$on_log" 2>&1
             "$ROOT/leo" --load "$cell_dir/off.state" \
                 --seed "$run_seed" --respond "$prompt" --debug-field \
+                --no-wonder-appetite-reliability \
                 --no-wonder-appetite-calibration \
                 --save "$cell_dir/off.state" > "$off_log" 2>&1
             [ -z "$(calibration_from_log \

--- a/scripts/deferred_wonder_appetite_reliability_matrix.sh
+++ b/scripts/deferred_wonder_appetite_reliability_matrix.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# A.46: rebuild a reliability surface from accumulated lived forecasts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GROUPS_FILE="${LEO_APPETITE_RELIABILITY_GROUPS:-$ROOT/scripts/deferred_wonder_constellation_groups.tsv}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-reliability-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+[ -f "$GROUPS_FILE" ] || {
+    printf 'reliability groups not found: %s\n' "$GROUPS_FILE" >&2
+    exit 2
+}
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 10 || $1 != "group" || $2 != "cohort" ||
+            $3 != "seed" || $4 != "slot" || $5 != "target" ||
+            $9 != "expected_question")
+            exit 1
+        next
+    }
+    {
+        if (NF != 10 || $3 !~ /^[0-9]+$/ ||
+            $4 !~ /^[123]$/ || seen[$1 SUBSEP $4]++)
+            exit 1
+        groups[$1]++
+        rows++
+    }
+    END {
+        if (rows != 6 || length(groups) != 2)
+            exit 1
+        for (group in groups)
+            if (groups[group] != 3)
+                exit 1
+    }
+' "$GROUPS_FILE" || {
+    printf 'invalid reliability groups: %s\n' "$GROUPS_FILE" >&2
+    exit 2
+}
+
+mkdir -p "$OUT/lives"
+PLAN="$OUT/plan.tsv"
+MATRIX="$OUT/matrix.tsv"
+SURFACES="$OUT/surfaces.tsv"
+SUMMARY="$OUT/summary.txt"
+
+group_field() {
+    local group="$1"
+    local slot="$2"
+    local field="$3"
+    awk -F '\t' -v group="$group" -v slot="$slot" -v field="$field" '
+        NR > 1 && $1 == group && $4 == slot {
+            print $field
+            exit
+        }
+    ' "$GROUPS_FILE"
+}
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+calibration_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_calibration_dialogue_report.awk" \
+        "$1"
+}
+
+reliability_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_reliability_dialogue_report.awk" \
+        "$1"
+}
+
+entry_fields() {
+    local entries="$1"
+    local wanted="$2"
+    printf '%s\n' "$entries" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 10; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+cell_fields() {
+    local cells="$1"
+    local wanted="$2"
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 9; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+printf 'cell\tgroup\tcohort\tseed\tunspoken_target\tspoken_target\tunspoken_outcomes\tspoken_outcomes\n' \
+    > "$PLAN"
+awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
+    "$GROUPS_FILE" |
+while IFS=$'\t' read -r group cohort seed; do
+    printf '%s-reliability\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$group" "$group" "$cohort" "$seed" \
+        "$(group_field "$group" 2 5)" \
+        "$(group_field "$group" 1 5)" \
+        "sustained,sustained,sustained,faded" "sustained" \
+        >> "$PLAN"
+done
+
+if [ "${LEO_APPETITE_RELIABILITY_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"$ROOT/scripts/deferred_wonder_constellation_matrix.sh" \
+    "$OUT/a40-baseline" > "$OUT/a40-baseline.log"
+
+printf 'cell\tgroup\tcohort\tscored\tpositives\tsustained\tgrounded\tfaded\tpending\texternal\tlost\tunscorable\tbrier\tece\tunspoken_n\tunspoken_positives\tunspoken_status\tspoken_n\tspoken_positives\tspoken_status\treply_equal\tstate_equal\ton_sha256\toff_sha256\n' \
+    > "$MATRIX"
+printf 'cell\tscored\tpositives\tsustained\tgrounded\tfaded\tpending\texternal\tlost\tunscorable\tbrier\tece\tcells\n' \
+    > "$SURFACES"
+
+group_index=0
+awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
+    "$GROUPS_FILE" |
+while IFS=$'\t' read -r group cohort seed; do
+    group_index=$((group_index + 1))
+    cell="$group-reliability"
+    group_dir="$OUT/lives/$group"
+    mkdir -p "$group_dir"
+    ready="$OUT/a40-baseline/groups/$group/ready.state"
+    [ -f "$ready" ] || {
+        printf 'missing A.40 ready body: %s\n' "$ready" >&2
+        exit 1
+    }
+
+    spoken_target="$(group_field "$group" 1 5)"
+    unspoken_target="$(group_field "$group" 2 5)"
+    spoken_question="$(group_field "$group" 1 9)"
+    unspoken_question="$(group_field "$group" 2 9)"
+    semantic_spoken="Bright sun. Cold winter."
+    semantic_unspoken="Cat bird. Dark night."
+    quiet="I do not know."
+    state="$group_dir/history.state"
+    cp "$ready" "$state"
+    turn_index=0
+    last_log=
+
+    history_turn() {
+        local prompt="$1"
+        local label="$2"
+        turn_index=$((turn_index + 1))
+        local run_seed=$((seed + 6100 + group_index * 1000 + turn_index))
+        last_log="$group_dir/$(printf '%02d' "$turn_index")-$label.log"
+        "$ROOT/leo" --load "$state" --seed "$run_seed" \
+            --respond "$prompt" --debug-field \
+            --no-wonder-appetite-reliability \
+            --save "$state" > "$last_log" 2>&1
+    }
+
+    cycle=0
+    for expected in sustained sustained sustained faded; do
+        cycle=$((cycle + 1))
+        history_turn "$semantic_unspoken" "u${cycle}-birth"
+        history_turn "$quiet" "u${cycle}-future1"
+        if [ "$expected" = sustained ]; then
+            history_turn "$semantic_unspoken" "u${cycle}-future2"
+        else
+            history_turn "$quiet" "u${cycle}-future2"
+        fi
+        history_turn "$quiet" "u${cycle}-future3"
+
+        calibration="$(
+            calibration_from_log "$last_log" "$cell" "$seed"
+        )"
+        [ -n "$calibration" ] || {
+            printf '%s cycle %s emitted no calibration receipt\n' \
+                "$cell" "$cycle" >&2
+            exit 1
+        }
+        IFS=$'\t' read -r _ _ _ _ _ _ _ _ _ _ entries \
+            <<< "$calibration"
+        fields="$(entry_fields "$entries" "$unspoken_target")"
+        [ -n "$fields" ] || {
+            printf '%s cycle %s lost target %s\n' \
+                "$cell" "$cycle" "$unspoken_target" >&2
+            exit 1
+        }
+        IFS=$'\t' read -r _ _ _ _ _ _ _ observed_spoken \
+            observed_verdict _ <<< "$fields"
+        [ "$observed_spoken" = 0 ] &&
+        [ "$observed_verdict" = "$expected" ] || {
+            printf '%s cycle %s expected %s/unspoken, got %s/%s\n' \
+                "$cell" "$cycle" "$expected" \
+                "$observed_verdict" "$observed_spoken" >&2
+            exit 1
+        }
+    done
+
+    history_turn "$spoken_target" "spoken-open"
+    [ "$(reply_from_log "$last_log")" = "$spoken_question" ] || {
+        printf '%s failed to open %s\n' "$cell" "$spoken_target" >&2
+        exit 1
+    }
+    history_turn "$unspoken_target" "spoken-park"
+    [ "$(reply_from_log "$last_log")" = "$unspoken_question" ] || {
+        printf '%s failed to park %s behind %s\n' \
+            "$cell" "$spoken_target" "$unspoken_target" >&2
+        exit 1
+    }
+    history_turn "$semantic_spoken" "spoken-birth"
+    history_turn "$quiet" "spoken-future1"
+    history_turn "$semantic_spoken" "spoken-future2"
+    history_turn "$quiet" "spoken-future3"
+
+    calibration="$(
+        calibration_from_log "$last_log" "$cell" "$seed"
+    )"
+    [ -n "$calibration" ] || {
+        printf '%s emitted no parked-spoken calibration receipt\n' \
+            "$cell" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r _ _ _ _ _ _ _ _ _ _ entries \
+        <<< "$calibration"
+    fields="$(entry_fields "$entries" "$spoken_target")"
+    [ -n "$fields" ] || {
+        printf '%s lost parked-spoken target %s\n' \
+            "$cell" "$spoken_target" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r _ _ _ _ _ _ _ observed_spoken \
+        observed_verdict _ <<< "$fields"
+    [ "$observed_spoken" = 1 ] &&
+    [ "$observed_verdict" = sustained ] || {
+        printf '%s parked target expected sustained/spoken, got %s/%s\n' \
+            "$cell" "$observed_verdict" "$observed_spoken" >&2
+        exit 1
+    }
+
+    cp "$state" "$group_dir/on.state"
+    cp "$state" "$group_dir/off.state"
+    final_seed=$((seed + 9900))
+    "$ROOT/leo" --load "$group_dir/on.state" --seed "$final_seed" \
+        --respond "$quiet" --debug-field \
+        --save "$group_dir/on.state" > "$group_dir/on.log" 2>&1
+    "$ROOT/leo" --load "$group_dir/off.state" --seed "$final_seed" \
+        --respond "$quiet" --debug-field \
+        --no-wonder-appetite-reliability \
+        --save "$group_dir/off.state" > "$group_dir/off.log" 2>&1
+
+    reliability="$(
+        reliability_from_log "$group_dir/on.log" "$cell" "$final_seed"
+    )"
+    [ -n "$reliability" ] || {
+        printf '%s did not reconstruct its reliability surface\n' \
+            "$cell" >&2
+        exit 1
+    }
+    [ -z "$(
+        reliability_from_log "$group_dir/off.log" "$cell" "$final_seed"
+    )" ] || {
+        printf '%s reliability ablation remained visible\n' "$cell" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r _ _ scored positives sustained grounded faded \
+        pending external lost unscorable brier ece cells \
+        <<< "$reliability"
+    unspoken_fields="$(cell_fields "$cells" u62-70)"
+    spoken_fields="$(cell_fields "$cells" s80-90)"
+    [ -n "$unspoken_fields" ] && [ -n "$spoken_fields" ] || {
+        printf '%s missing expected spoken/unspoken reliability cells\n' \
+            "$cell" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r unspoken_n unspoken_positives _ _ _ _ _ _ \
+        unspoken_status <<< "$unspoken_fields"
+    IFS=$'\t' read -r spoken_n spoken_positives _ _ _ _ _ _ \
+        spoken_status <<< "$spoken_fields"
+
+    reply_equal=0
+    [ "$(reply_from_log "$group_dir/on.log")" = \
+      "$(reply_from_log "$group_dir/off.log")" ] &&
+        reply_equal=1
+    state_equal=0
+    cmp -s "$group_dir/on.state" "$group_dir/off.state" &&
+        state_equal=1
+
+    [ "$scored" = 5 ] &&
+    [ "$positives" = 4 ] &&
+    [ "$sustained" = 4 ] &&
+    [ "$grounded" = 0 ] &&
+    [ "$faded" = 1 ] &&
+    [ "$pending" = 0 ] &&
+    [ "$external" = 0 ] &&
+    [ "$lost" = 0 ] &&
+    [ "$unscorable" = 0 ] &&
+    [ "$unspoken_n" = 4 ] &&
+    [ "$unspoken_positives" = 3 ] &&
+    [ "$unspoken_status" = aligned ] &&
+    [ "$spoken_n" = 1 ] &&
+    [ "$spoken_positives" = 1 ] &&
+    [ "$spoken_status" = forming ] &&
+    [ "$reply_equal" = 1 ] &&
+    [ "$state_equal" = 1 ] || {
+        printf '%s contract failed: scored=%s positive=%s u=%s/%s/%s s=%s/%s/%s reply=%s state=%s cells=%s\n' \
+            "$cell" "$scored" "$positives" \
+            "$unspoken_n" "$unspoken_positives" "$unspoken_status" \
+            "$spoken_n" "$spoken_positives" "$spoken_status" \
+            "$reply_equal" "$state_equal" "$cells" >&2
+        exit 1
+    }
+
+    on_sha="$(sha256_file "$group_dir/on.state")"
+    off_sha="$(sha256_file "$group_dir/off.state")"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$cell" "$group" "$cohort" "$scored" "$positives" \
+        "$sustained" "$grounded" "$faded" "$pending" "$external" \
+        "$lost" "$unscorable" "$brier" "$ece" \
+        "$unspoken_n" "$unspoken_positives" "$unspoken_status" \
+        "$spoken_n" "$spoken_positives" "$spoken_status" \
+        "$reply_equal" "$state_equal" "$on_sha" "$off_sha" \
+        >> "$MATRIX"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$cell" "$scored" "$positives" "$sustained" "$grounded" \
+        "$faded" "$pending" "$external" "$lost" "$unscorable" \
+        "$brier" "$ece" "$cells" >> "$SURFACES"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        cells++
+        scored += $4
+        positives += $5
+        aligned += $17 == "aligned"
+        forming += $20 == "forming"
+        reply_equal += $21
+        state_equal += $22
+    }
+    END {
+        print "cells\tscored\tpositives\taligned_unspoken\tforming_spoken\treply_equal\tstate_equal"
+        print cells "\t" scored "\t" positives "\t" aligned "\t" \
+              forming "\t" reply_equal "\t" state_equal
+    }
+' "$MATRIX" > "$SUMMARY"
+
+cat "$SUMMARY"
+printf '\nmatrix: %s\nsurfaces: %s\n' "$MATRIX" "$SURFACES"

--- a/scripts/test_deferred_wonder_appetite_reliability_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_reliability_matrix.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_RELIABILITY_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_reliability_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 8 || $1 != "cell" || $2 != "group" ||
+            $5 != "unspoken_target" || $6 != "spoken_target" ||
+            $7 != "unspoken_outcomes" ||
+            $8 != "spoken_outcomes")
+            exit 1
+        next
+    }
+    {
+        if (NF != 8 || cells[$1]++ || groups[$2]++ ||
+            $7 != "sustained,sustained,sustained,faded" ||
+            $8 != "sustained")
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 2 || length(groups) != 2)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite reliability plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite reliability matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_reliability_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_reliability_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-reliability: scored=5 positives=4 sustained=4 grounded=0 faded=1 pending=0 external=0 lost=0 unscorable=0 brier=0.165 ece=0.111 cells=u62-70:4/3/0.690/0.750/0.301/0.954/0.197/+0.060/aligned|s80-90:1/1/0.820/1.000/0.207/1.000/0.032/+0.180/forming]
+EOF
+
+got="$(
+    awk -v scenario=old -v seed=83 \
+        -f "$ROOT/scripts/wonder_appetite_reliability_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'old\t83\t5\t4\t4\t0\t1\t0\t0\t0\t0\t0.165\t0.111\tu62-70:4/3/0.690/0.750/0.301/0.954/0.197/+0.060/aligned|s80-90:1/1/0.820/1.000/0.207/1.000/0.032/+0.180/forming'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite reliability parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite reliability report parser: ok\n'

--- a/scripts/wonder_appetite_reliability_dialogue_report.awk
+++ b/scripts/wonder_appetite_reliability_dialogue_report.awk
@@ -1,0 +1,33 @@
+# Extract one A.46 reliability surface from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    start, tail, parts) {
+    start = index(line, key "=")
+    if (!start) return ""
+    tail = substr(line, start + length(key) + 1)
+    split(tail, parts, /[ ]/)
+    gsub(/\]$/, "", parts[1])
+    return parts[1]
+}
+
+/\[wonder-appetite-reliability: scored=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed),
+           value_after($0, "scored"),
+           value_after($0, "positives"),
+           value_after($0, "sustained"),
+           value_after($0, "grounded"),
+           value_after($0, "faded"),
+           value_after($0, "pending"),
+           value_after($0, "external"),
+           value_after($0, "lost"),
+           value_after($0, "unscorable"),
+           value_after($0, "brier"),
+           value_after($0, "ece"),
+           value_after($0, "cells")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -60,6 +60,71 @@ static long test_appetite_calibration_tail_size(const Leo *leo) {
             (int)sizeof(LeoWonderAppetiteCalibrationReceipt));
 }
 
+static void test_add_appetite_calibration(
+        Leo *leo, float appetite, int spoken, int verdict) {
+    if (!leo ||
+        leo->wonder_appetite_calibration.n >=
+            LEO_WONDER_APPETITE_CALIB_RING)
+        return;
+    LeoWonderAppetiteCalibration *calibration =
+        &leo->wonder_appetite_calibration;
+    int slot = calibration->n;
+    LeoWonderAppetiteCalibrationReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.proposed_turn = (uint64_t)(10 + slot * 4);
+    receipt.deadline_turn =
+        receipt.proposed_turn +
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+    receipt.observed_turn = receipt.proposed_turn;
+    receipt.appetite = appetite;
+    receipt.spoken = spoken ? 1 : 0;
+    receipt.wonder_id = spoken ? (uint64_t)(slot + 1) : 0;
+    receipt.verdict = (uint8_t)verdict;
+    snprintf(receipt.word, sizeof receipt.word, "r%02d", slot);
+
+    if (verdict == LEO_WONDER_APPETITE_CALIB_SUSTAINED) {
+        receipt.observed_turn = receipt.deadline_turn;
+        receipt.observations =
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+        receipt.semantic_hits = 1;
+        receipt.peak_recurrence =
+            LEO_WONDER_APPETITE_RESONANCE_MIN;
+        float error = appetite - 1.0f;
+        receipt.brier = error * error;
+    } else if (
+        verdict == LEO_WONDER_APPETITE_CALIB_GROUNDED) {
+        receipt.observed_turn++;
+        receipt.observations = 1;
+        float error = appetite - 1.0f;
+        receipt.brier = error * error;
+    } else if (
+        verdict == LEO_WONDER_APPETITE_CALIB_FADED) {
+        receipt.observed_turn = receipt.deadline_turn;
+        receipt.observations =
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+        receipt.brier = appetite * appetite;
+    } else if (
+        verdict == LEO_WONDER_APPETITE_CALIB_EXTERNAL) {
+        receipt.observed_turn++;
+        receipt.observations = 1;
+    } else if (
+        verdict == LEO_WONDER_APPETITE_CALIB_LOST) {
+        receipt.observed_turn = receipt.deadline_turn;
+        receipt.observations =
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+    } else if (
+        verdict == LEO_WONDER_APPETITE_CALIB_UNSCORABLE) {
+        receipt.observed_turn += 2;
+    }
+
+    calibration->receipts[slot] = receipt;
+    calibration->n++;
+    calibration->ptr =
+        calibration->n % LEO_WONDER_APPETITE_CALIB_RING;
+    if ((uint64_t)leo->school.turn_clock < receipt.observed_turn)
+        leo->school.turn_clock = (long)receipt.observed_turn;
+}
+
 int main(void) {
     printf("test_leo (step 0)\n");
 
@@ -2295,6 +2360,166 @@ int main(void) {
         g_leo_deferred_wonder_on = prev_deferred;
         g_leo_wonder_attribution_on = prev_attr;
         g_leo_wonder_redirection_on = prev_redirection;
+    }
+
+    /* A.46: the forecast diary yields a stratified reliability surface without
+     * becoming another stateful organ or a permission to schedule speech. */
+    {
+        Leo *rel = malloc(sizeof *rel);
+        CHECK(rel != NULL,
+              "wonder-appetite-reliability: heap fixture allocated");
+        if (rel) {
+            leo_init(rel);
+            LeoWonderAppetiteReliability surface;
+            leo_wonder_appetite_reliability(rel, &surface);
+            CHECK(surface.scored == 0 &&
+                  surface.pending == 0 &&
+                  surface.cells[0].status ==
+                      LEO_WONDER_APPETITE_RELIABILITY_EMPTY,
+                  "wonder-appetite-reliability: an empty diary claims no confidence");
+            CHECK(
+                leo_wonder_appetite_reliability_bin(0.62f) == 0 &&
+                leo_wonder_appetite_reliability_bin(0.699f) == 0 &&
+                leo_wonder_appetite_reliability_bin(0.70f) == 1 &&
+                leo_wonder_appetite_reliability_bin(0.799f) == 1 &&
+                leo_wonder_appetite_reliability_bin(0.80f) == 2 &&
+                leo_wonder_appetite_reliability_bin(0.899f) == 2 &&
+                leo_wonder_appetite_reliability_bin(0.90f) == 3 &&
+                leo_wonder_appetite_reliability_bin(1.0f) == 3 &&
+                leo_wonder_appetite_reliability_bin(0.619f) == -1,
+                "wonder-appetite-reliability: fixed appetite bands have exact boundaries");
+
+            for (int i = 0; i < 3; i++)
+                test_add_appetite_calibration(
+                    rel, 0.65f, 0,
+                    LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+            leo_wonder_appetite_reliability(rel, &surface);
+            const LeoWonderAppetiteReliabilityCell *cell =
+                &surface.cells[0];
+            CHECK(surface.scored == 3 &&
+                  surface.positives == 3 &&
+                  cell->n == 3 && cell->positives == 3 &&
+                  cell->status ==
+                      LEO_WONDER_APPETITE_RELIABILITY_FORMING,
+                  "wonder-appetite-reliability: three beautiful successes are still only forming");
+
+            test_add_appetite_calibration(
+                rel, 0.65f, 0,
+                LEO_WONDER_APPETITE_CALIB_FADED);
+            leo_wonder_appetite_reliability(rel, &surface);
+            cell = &surface.cells[0];
+            CHECK(cell->n == 4 && cell->positives == 3 &&
+                  fabsf(cell->mean_appetite - 0.65f) < 1e-6f &&
+                  fabsf(cell->outcome_rate - 0.75f) < 1e-6f &&
+                  fabsf(cell->gap - 0.10f) < 1e-6f &&
+                  fabsf(cell->mean_brier - 0.1975f) < 1e-6f &&
+                  cell->status ==
+                      LEO_WONDER_APPETITE_RELIABILITY_ALIGNED,
+                  "wonder-appetite-reliability: a measured cell keeps prediction, outcome, Brier, and gap distinct");
+            CHECK(cell->lower < cell->mean_appetite &&
+                  cell->upper > cell->mean_appetite,
+                  "wonder-appetite-reliability: Wilson uncertainty contains an aligned forecast");
+
+            test_add_appetite_calibration(
+                rel, 0.65f, 0,
+                LEO_WONDER_APPETITE_CALIB_PENDING);
+            test_add_appetite_calibration(
+                rel, 0.65f, 0,
+                LEO_WONDER_APPETITE_CALIB_EXTERNAL);
+            test_add_appetite_calibration(
+                rel, 0.65f, 0,
+                LEO_WONDER_APPETITE_CALIB_LOST);
+            test_add_appetite_calibration(
+                rel, 0.65f, 0,
+                LEO_WONDER_APPETITE_CALIB_UNSCORABLE);
+            test_add_appetite_calibration(
+                rel, 0.85f, 1,
+                LEO_WONDER_APPETITE_CALIB_GROUNDED);
+            leo_wonder_appetite_reliability(rel, &surface);
+            const LeoWonderAppetiteReliabilityCell *spoken =
+                &surface.cells[
+                    LEO_WONDER_APPETITE_RELIABILITY_BINS + 2];
+            CHECK(surface.scored == 5 &&
+                  surface.sustained == 3 &&
+                  surface.grounded == 1 &&
+                  surface.faded == 1 &&
+                  surface.pending == 1 &&
+                  surface.external == 1 &&
+                  surface.lost == 1 &&
+                  surface.unscorable == 1,
+                  "wonder-appetite-reliability: causal confounds remain visible but unscored");
+            CHECK(spoken->n == 1 && spoken->positives == 1 &&
+                  spoken->spoken && spoken->bin == 2 &&
+                  spoken->status ==
+                      LEO_WONDER_APPETITE_RELIABILITY_FORMING,
+                  "wonder-appetite-reliability: spoken forecasts keep their own evidence stratum");
+            CHECK(fabsf(surface.mean_brier - 0.1625f) < 1e-6f &&
+                  fabsf(surface.ece - 0.11f) < 1e-6f,
+                  "wonder-appetite-reliability: aggregate Brier and ECE weight only scored lives");
+
+            LeoWonderAppetiteCalibration diary_before =
+                rel->wonder_appetite_calibration;
+            LeoSchool school_before = rel->school;
+            LeoFlow flow_before = rel->flow;
+            leo_wonder_appetite_reliability(rel, &surface);
+            CHECK(!memcmp(
+                      &diary_before,
+                      &rel->wonder_appetite_calibration,
+                      sizeof diary_before) &&
+                  !memcmp(&school_before, &rel->school,
+                          sizeof school_before) &&
+                  !memcmp(&flow_before, &rel->flow,
+                          sizeof flow_before),
+                  "wonder-appetite-reliability: observing confidence cannot rewrite evidence, School, or Flow");
+
+            leo_free(rel);
+            leo_init(rel);
+            for (int i = 0; i < 4; i++)
+                test_add_appetite_calibration(
+                    rel, 0.65f, 0,
+                    LEO_WONDER_APPETITE_CALIB_FADED);
+            leo_wonder_appetite_reliability(rel, &surface);
+            cell = &surface.cells[0];
+            CHECK(cell->status ==
+                      LEO_WONDER_APPETITE_RELIABILITY_OVER &&
+                  cell->upper < cell->mean_appetite,
+                  "wonder-appetite-reliability: repeated fade exposes overconfidence");
+
+            leo_free(rel);
+            leo_init(rel);
+            for (int i = 0; i < 9; i++)
+                test_add_appetite_calibration(
+                    rel, 0.65f, 0,
+                    LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+            leo_wonder_appetite_reliability(rel, &surface);
+            cell = &surface.cells[0];
+            CHECK(cell->status ==
+                      LEO_WONDER_APPETITE_RELIABILITY_UNDER &&
+                  cell->lower > cell->mean_appetite,
+                  "wonder-appetite-reliability: repeated return exposes underconfidence");
+
+            leo_free(rel);
+            leo_init(rel);
+            test_add_appetite_calibration(
+                rel, 0.85f, 0,
+                LEO_WONDER_APPETITE_CALIB_FADED);
+            test_add_appetite_calibration(
+                rel, 0.85f, 1,
+                LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+            leo_wonder_appetite_reliability(rel, &surface);
+            const LeoWonderAppetiteReliabilityCell *unspoken =
+                &surface.cells[2];
+            spoken = &surface.cells[
+                LEO_WONDER_APPETITE_RELIABILITY_BINS + 2];
+            CHECK(unspoken->n == 1 &&
+                  unspoken->positives == 0 &&
+                  spoken->n == 1 &&
+                  spoken->positives == 1,
+                  "wonder-appetite-reliability: one score band cannot merge spoken and unspoken lives");
+
+            leo_free(rel);
+        }
+        free(rel);
     }
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the


### PR DESCRIPTION
Method: The Arianna Method keeps confidence stratified by lived history, rather than compressing unlike questions into one permission scalar.

Derive a pure eight-cell reliability surface from the v21 forecast diary. Separate spoken from unspoken questions and fixed appetite bands; expose sample size, outcome rate, Brier, ECE, and Wilson uncertainty while leaving confounds visible but unscored and keeping the surface outside every speech and scheduling path.

Evidence: 352/352 contracts; full UBSan suite; ASan/UBSan smoke; two byte-identical accumulated-history runs over independent bodies with 10 scored forecasts, 2/2 reply equality, and 2/2 complete-state equality; isolated A.45 retains 30/30 reply equality and 10/10 v20-prefix equality.

Quote: "Confidence is not a louder appetite; it is an appetite that has survived enough disagreement." - Sol