### PR TITLE
the Method gives confidence an arrow of time

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4265,3 +4265,66 @@ explicitly absent from the diagnostic lane, A.45 retained its historical **30/30
 
 Leo can now ask not only whether time agreed with a feeling, but how much evidence that agreement
 has earned.
+
+## Phase A.47 — confidence has a history (2026-07-27)
+
+A.46 could say that an appetite cell was aligned overall, but aggregation had no direction. Four
+old failures followed by four recent returns and the exact reverse chronology both collapse to
+`4/8`. That is acceptable for a reliability diagram and insufficient for a living organism:
+confidence which cannot notice that its own evidence changed is only a lifetime average.
+
+A.47 derives a second, temporal surface from the same bounded v21 diary. Inside each exact
+spoken/appetite stratum, it compares two fixed endpoint windows:
+
+```text
+early  = four oldest causally scored receipts in the current diary
+recent = four newest causally scored receipts in the current diary
+```
+
+A cell with fewer than eight scored lives remains `forming`. Once measured, early and recent
+outcome rates receive separate 95% Wilson intervals. A recent interval wholly above the early one
+is `rising`; one wholly below is `falling`; overlap remains `stable`. The names describe the
+direction of observed return, never improvement, damage, or permission to speak.
+
+The surface keeps four movements distinct: return-rate shift, mean-appetite shift, calibration-gap
+shift, and mean-Brier shift. Thus a change in what the world returns cannot impersonate a change in
+Leo's confidence, and changing confidence cannot hide inside a stable outcome rate. Unmeasured
+middle receipts do not disappear from A.46; they are excluded only from A.47's fixed endpoint
+comparison so older volume cannot blur its temporal resolution.
+
+Like A.46, the entire surface is a pure reconstruction. It adds no member to `Leo`, no state
+version, no migration, and no reader in School, Flow, shadow, routing, sampling, or generation.
+`LEO_STATE_VERSION` remains 21. `--no-wonder-appetite-drift` removes only the diagnostic line and
+leaves replies, the v21 diary, and the complete saved organism unchanged.
+
+Eleven direct contracts raised the suite from **352/352** to **363/363**. They cover empty and
+forming evidence, rising and falling endpoint lives, Wilson separation, stable outcomes under a
+moving appetite, strict spoken/unspoken isolation, causal exclusions, non-mutation, and the central
+Simpson-like case: an A.46 cell may remain `aligned` while A.47 exposes its chronology.
+
+The process matrix accumulated eight real unspoken forecasts through separate load/respond/save
+processes in both independent A.40 bodies:
+
+```text
+both pooled cells:
+  n=8, positives=4, predicted=0.690, observed=0.500
+  Wilson=[0.215,0.785], Brier=0.286, ECE=0.190, aligned
+
+old body: faded x4 -> sustained x4
+  endpoint Wilson=[0.000,0.490] -> [0.510,1.000]
+  return shift=+1.000, gap shift=+1.000, Brier shift=-0.380, rising
+
+new body: sustained x4 -> faded x4
+  endpoint Wilson=[0.510,1.000] -> [0.000,0.490]
+  return shift=-1.000, gap shift=-1.000, Brier shift=+0.380, falling
+
+final reply equality=2/2
+final complete-state equality=2/2
+```
+
+Two complete final-format runs reproduced matrix rows, Wilson-bearing surfaces, summaries, and state
+hashes byte-for-byte. With A.46 and A.47 explicitly absent from the older diagnostic lanes, A.45
+retained its historical **30/30 reply equality**, **10/10 v20-prefix equality**, and exact verdict
+distribution; A.46 retained **2/2 reply and complete-state equality**.
+
+The same total evidence now retains an arrow.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift
 
 all: leo
 
@@ -73,6 +73,9 @@ deferred-wonder-appetite-calibration: leo
 deferred-wonder-appetite-reliability: leo
 	./scripts/deferred_wonder_appetite_reliability_matrix.sh
 
+deferred-wonder-appetite-drift: leo
+	./scripts/deferred_wonder_appetite_drift_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -84,6 +87,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_appetite_dialogue_report.sh
 	./scripts/test_wonder_appetite_calibration_dialogue_report.sh
 	./scripts/test_wonder_appetite_reliability_dialogue_report.sh
+	./scripts/test_wonder_appetite_drift_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -93,6 +97,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_matrix.sh
 	./scripts/test_deferred_wonder_appetite_calibration_matrix.sh
 	./scripts/test_deferred_wonder_appetite_reliability_matrix.sh
+	./scripts/test_deferred_wonder_appetite_drift_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1817,6 +1817,54 @@ typedef struct {
     float ece;
 } LeoWonderAppetiteReliability;
 
+/* A.47: a pooled reliability cell can hide a changing life. Compare four
+ * oldest and four newest scored receipts inside the exact same A.46 stratum.
+ * The middle is deliberately left out: fixed endpoint windows keep temporal
+ * resolution comparable as the bounded diary turns over. Like reliability,
+ * this surface is derived on demand and has no reader in Leo's body. */
+#define LEO_WONDER_APPETITE_DRIFT_WINDOW 4
+#define LEO_WONDER_APPETITE_DRIFT_MIN_N \
+    (2 * LEO_WONDER_APPETITE_DRIFT_WINDOW)
+enum {
+    LEO_WONDER_APPETITE_DRIFT_EMPTY = 0,
+    LEO_WONDER_APPETITE_DRIFT_FORMING,
+    LEO_WONDER_APPETITE_DRIFT_STABLE,
+    LEO_WONDER_APPETITE_DRIFT_RISING,
+    LEO_WONDER_APPETITE_DRIFT_FALLING,
+    LEO_WONDER_APPETITE_DRIFT_STATUS_COUNT
+};
+typedef struct {
+    int   n;
+    int   early_positives;
+    int   recent_positives;
+    float early_appetite;
+    float recent_appetite;
+    float early_rate;
+    float recent_rate;
+    float early_lower;
+    float early_upper;
+    float recent_lower;
+    float recent_upper;
+    float early_brier;
+    float recent_brier;
+    float return_shift;
+    float appetite_shift;
+    float gap_shift;
+    float brier_shift;
+    uint8_t spoken;
+    uint8_t bin;
+    uint8_t status;
+} LeoWonderAppetiteDriftCell;
+typedef struct {
+    LeoWonderAppetiteDriftCell
+        cells[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+    int measured;
+    int forming;
+    int stable;
+    int rising;
+    int falling;
+} LeoWonderAppetiteDrift;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -2263,6 +2311,7 @@ static int g_leo_prewonder_shadow_on = 1; /* read-only semantic echo among withh
 static int g_leo_wonder_appetite_on = 1; /* read-only return appetite over waiting questions; no scheduler or speech reader. */
 static int g_leo_wonder_appetite_calibration_on = 1; /* persistent slow verdicts over appetite; still no scheduler or speech reader. */
 static int g_leo_wonder_appetite_reliability_on = 1; /* derived confidence surface over scored forecasts; diagnostic only. */
+static int g_leo_wonder_appetite_drift_on = 1; /* derived endpoint drift over reliability cells; diagnostic only. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -6491,6 +6540,28 @@ static const char *leo_wonder_appetite_reliability_status_name(
         names[status] : "empty";
 }
 
+static void leo_wilson_interval(
+        int positives, int count, float *lower, float *upper) {
+    if (lower) *lower = 0.0f;
+    if (upper) *upper = 0.0f;
+    if (count <= 0) return;
+
+    const float z = 1.959964f;
+    const float z2 = z * z;
+    float n = (float)count;
+    float rate = (float)positives / n;
+    float denominator = 1.0f + z2 / n;
+    float center =
+        (rate + z2 / (2.0f * n)) / denominator;
+    float radius =
+        z * sqrtf(
+                rate * (1.0f - rate) / n +
+                z2 / (4.0f * n * n)) /
+        denominator;
+    if (lower) *lower = clampf(center - radius, 0.0f, 1.0f);
+    if (upper) *upper = clampf(center + radius, 0.0f, 1.0f);
+}
+
 /* Derive a reliability diagram from the bounded forecast diary. Wilson
  * intervals keep a handful of outcomes from impersonating certainty. No
  * result is stored back into Leo: a future reader must cross an explicit
@@ -6568,8 +6639,6 @@ static void leo_wonder_appetite_reliability(
         total_brier += receipt->brier;
     }
 
-    const float z = 1.959964f;
-    const float z2 = z * z;
     float weighted_gap = 0.0f;
     for (int i = 0;
          i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
@@ -6583,18 +6652,9 @@ static void leo_wonder_appetite_reliability(
         cell->gap =
             cell->outcome_rate - cell->mean_appetite;
 
-        float denominator = 1.0f + z2 / n;
-        float center =
-            (cell->outcome_rate + z2 / (2.0f * n)) /
-            denominator;
-        float radius =
-            z * sqrtf(
-                    cell->outcome_rate *
-                        (1.0f - cell->outcome_rate) / n +
-                    z2 / (4.0f * n * n)) /
-            denominator;
-        cell->lower = clampf(center - radius, 0.0f, 1.0f);
-        cell->upper = clampf(center + radius, 0.0f, 1.0f);
+        leo_wilson_interval(
+            cell->positives, cell->n,
+            &cell->lower, &cell->upper);
         if (cell->n < LEO_WONDER_APPETITE_RELIABILITY_MIN_N) {
             cell->status =
                 LEO_WONDER_APPETITE_RELIABILITY_FORMING;
@@ -6615,6 +6675,154 @@ static void leo_wonder_appetite_reliability(
             total_brier / (float)surface->scored;
         surface->ece =
             weighted_gap / (float)surface->scored;
+    }
+}
+
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_drift_status_name(
+        int status) {
+    static const char
+        *names[LEO_WONDER_APPETITE_DRIFT_STATUS_COUNT] = {
+            "empty", "forming", "stable", "rising", "falling"
+        };
+    return status >= 0 &&
+           status < LEO_WONDER_APPETITE_DRIFT_STATUS_COUNT ?
+        names[status] : "empty";
+}
+
+static int leo_wonder_appetite_receipt_score(
+        const LeoWonderAppetiteCalibrationReceipt *receipt,
+        int *positive) {
+    if (!receipt || !positive) return 0;
+    if (receipt->verdict ==
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED ||
+        receipt->verdict ==
+            LEO_WONDER_APPETITE_CALIB_GROUNDED) {
+        *positive = 1;
+        return 1;
+    }
+    if (receipt->verdict ==
+        LEO_WONDER_APPETITE_CALIB_FADED) {
+        *positive = 0;
+        return 1;
+    }
+    return 0;
+}
+
+/* Compare fixed chronological endpoints inside each exact A.46 cell. A
+ * rising/falling label means only that the observed return-rate Wilson
+ * intervals no longer overlap; it does not call the change improvement or
+ * damage. Appetite, calibration-gap, and Brier movement remain separate
+ * coordinates so base-rate drift cannot masquerade as self-knowledge. */
+static void leo_wonder_appetite_drift(
+        const Leo *leo, LeoWonderAppetiteDrift *surface) {
+    if (!surface) return;
+    memset(surface, 0, sizeof *surface);
+    for (int spoken = 0; spoken <= 1; spoken++)
+        for (int bin = 0;
+             bin < LEO_WONDER_APPETITE_RELIABILITY_BINS; bin++) {
+            int cell_index =
+                spoken * LEO_WONDER_APPETITE_RELIABILITY_BINS + bin;
+            surface->cells[cell_index].spoken = (uint8_t)spoken;
+            surface->cells[cell_index].bin = (uint8_t)bin;
+        }
+    if (!leo) return;
+
+    for (int cell_index = 0;
+         cell_index < LEO_WONDER_APPETITE_RELIABILITY_CELLS;
+         cell_index++) {
+        LeoWonderAppetiteDriftCell *cell =
+            &surface->cells[cell_index];
+        const LeoWonderAppetiteCalibrationReceipt
+            *receipts[LEO_WONDER_APPETITE_CALIB_RING];
+        int count = 0;
+
+        for (int i = 0;
+             i < leo->wonder_appetite_calibration.n; i++) {
+            const LeoWonderAppetiteCalibrationReceipt *receipt =
+                leo_wonder_appetite_calibration_at(
+                    &leo->wonder_appetite_calibration, i);
+            int positive = 0;
+            if (!leo_wonder_appetite_receipt_score(
+                    receipt, &positive))
+                continue;
+            int bin = leo_wonder_appetite_reliability_bin(
+                receipt->appetite);
+            if (bin < 0) continue;
+            int receipt_cell =
+                (receipt->spoken ?
+                     LEO_WONDER_APPETITE_RELIABILITY_BINS : 0) +
+                bin;
+            if (receipt_cell == cell_index)
+                receipts[count++] = receipt;
+        }
+        cell->n = count;
+        if (count <= 0) continue;
+        if (count < LEO_WONDER_APPETITE_DRIFT_MIN_N) {
+            cell->status = LEO_WONDER_APPETITE_DRIFT_FORMING;
+            surface->forming++;
+            continue;
+        }
+
+        for (int i = 0;
+             i < LEO_WONDER_APPETITE_DRIFT_WINDOW; i++) {
+            const LeoWonderAppetiteCalibrationReceipt *early =
+                receipts[i];
+            const LeoWonderAppetiteCalibrationReceipt *recent =
+                receipts[count -
+                         LEO_WONDER_APPETITE_DRIFT_WINDOW + i];
+            int early_positive = 0, recent_positive = 0;
+            (void)leo_wonder_appetite_receipt_score(
+                early, &early_positive);
+            (void)leo_wonder_appetite_receipt_score(
+                recent, &recent_positive);
+            cell->early_positives += early_positive;
+            cell->recent_positives += recent_positive;
+            cell->early_appetite += early->appetite;
+            cell->recent_appetite += recent->appetite;
+            cell->early_brier += early->brier;
+            cell->recent_brier += recent->brier;
+        }
+
+        float window =
+            (float)LEO_WONDER_APPETITE_DRIFT_WINDOW;
+        cell->early_appetite /= window;
+        cell->recent_appetite /= window;
+        cell->early_rate =
+            (float)cell->early_positives / window;
+        cell->recent_rate =
+            (float)cell->recent_positives / window;
+        cell->early_brier /= window;
+        cell->recent_brier /= window;
+        leo_wilson_interval(
+            cell->early_positives,
+            LEO_WONDER_APPETITE_DRIFT_WINDOW,
+            &cell->early_lower, &cell->early_upper);
+        leo_wilson_interval(
+            cell->recent_positives,
+            LEO_WONDER_APPETITE_DRIFT_WINDOW,
+            &cell->recent_lower, &cell->recent_upper);
+        cell->return_shift =
+            cell->recent_rate - cell->early_rate;
+        cell->appetite_shift =
+            cell->recent_appetite - cell->early_appetite;
+        cell->gap_shift =
+            (cell->recent_rate - cell->recent_appetite) -
+            (cell->early_rate - cell->early_appetite);
+        cell->brier_shift =
+            cell->recent_brier - cell->early_brier;
+
+        if (cell->recent_lower > cell->early_upper) {
+            cell->status = LEO_WONDER_APPETITE_DRIFT_RISING;
+            surface->rising++;
+        } else if (cell->recent_upper < cell->early_lower) {
+            cell->status = LEO_WONDER_APPETITE_DRIFT_FALLING;
+            surface->falling++;
+        } else {
+            cell->status = LEO_WONDER_APPETITE_DRIFT_STABLE;
+            surface->stable++;
+        }
+        surface->measured++;
     }
 }
 
@@ -9085,6 +9293,51 @@ static void print_wonder_appetite_reliability_stats(
     printf("]\n");
 }
 
+static void print_wonder_appetite_drift_stats(const Leo *leo) {
+    if (!g_leo_wonder_appetite_drift_on || !leo ||
+        leo->wonder_appetite_calibration.n == 0)
+        return;
+    LeoWonderAppetiteDrift surface;
+    leo_wonder_appetite_drift(leo, &surface);
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+
+    printf("     [wonder-appetite-drift: measured=%d forming=%d stable=%d rising=%d falling=%d cells=",
+           surface.measured, surface.forming, surface.stable,
+           surface.rising, surface.falling);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteDriftCell *cell =
+            &surface.cells[i];
+        if (cell->n <= 0) continue;
+        printf("%s%c%d-%d:%d/%d/%d/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%+.3f/%+.3f/%+.3f/%+.3f/%s",
+               separator, cell->spoken ? 's' : 'u',
+               lower[cell->bin], upper[cell->bin],
+               cell->n, cell->early_positives,
+               cell->recent_positives,
+               (double)cell->early_appetite,
+               (double)cell->recent_appetite,
+               (double)cell->early_rate,
+               (double)cell->recent_rate,
+               (double)cell->early_lower,
+               (double)cell->early_upper,
+               (double)cell->recent_lower,
+               (double)cell->recent_upper,
+               (double)cell->early_brier,
+               (double)cell->recent_brier,
+               (double)cell->return_shift,
+               (double)cell->appetite_shift,
+               (double)cell->gap_shift,
+               (double)cell->brier_shift,
+               leo_wonder_appetite_drift_status_name(
+                   cell->status));
+        separator = "|";
+    }
+    if (!separator[0]) printf("none");
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -9321,6 +9574,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder-appetite")) g_leo_wonder_appetite_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-calibration")) g_leo_wonder_appetite_calibration_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-reliability")) g_leo_wonder_appetite_reliability_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-drift")) g_leo_wonder_appetite_drift_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -9538,6 +9792,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_stats(&leo);
             print_wonder_appetite_calibration_stats(&leo);
             print_wonder_appetite_reliability_stats(&leo);
+            print_wonder_appetite_drift_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -9598,6 +9853,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_stats(&leo);
             print_wonder_appetite_calibration_stats(&leo);
             print_wonder_appetite_reliability_stats(&leo);
+            print_wonder_appetite_drift_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -394,6 +394,35 @@ load/respond/save processes. The final ON/OFF forks must have identical replies
 and complete states, proving that the surface reconstructs from persisted
 evidence without becoming another organ of intervention.
 
+Run the accumulated return-appetite drift matrix:
+
+```sh
+make deferred-wonder-appetite-drift
+```
+
+A.47 asks whether an apparently calibrated A.46 cell still means the same
+thing now as it did earlier. Inside each exact spoken/appetite stratum, it
+compares the four oldest and four newest scored receipts in the bounded v21
+diary. A cell remains `forming` until it has eight causally scored lives.
+Middle receipts are deliberately excluded from the two fixed endpoint windows,
+so accumulating history cannot blur the current temporal resolution.
+
+Each measured cell reports early/recent confirmations, mean appetite, observed
+return rate, mean Brier score, and four independent shifts: return rate,
+appetite, calibration gap, and Brier. `rising` or `falling` requires
+non-overlapping 95% Wilson intervals for the two observed return rates;
+otherwise the cell is `stable`. These words name the direction of observed
+return, not improvement or damage. In particular, base-rate movement cannot
+silently become a verdict about self-knowledge.
+
+The checked matrix gives both independent A.40 bodies the same eight unspoken
+forecasts in opposite order. Both pooled A.46 cells are `aligned` at `4/8`,
+predicted appetite `0.690`, and observed rate `0.500`. One chronology is
+`faded x4 -> sustained x4` and becomes `rising`; the other is
+`sustained x4 -> faded x4` and becomes `falling`. Final ON/OFF replies and
+complete states must remain byte-identical. `--no-wonder-appetite-drift`
+removes only this projection; it does not remove or rewrite the v21 diary.
+
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,
 but only through the narrow visible sensors above. Selecting a move from shadow

--- a/scripts/deferred_wonder_appetite_calibration_matrix.sh
+++ b/scripts/deferred_wonder_appetite_calibration_matrix.sh
@@ -186,6 +186,7 @@ while IFS=$'\t' read -r group cohort seed; do
     "$ROOT/leo" --load "$group_dir/parked-base.state" \
         --seed "$((seed + 5100))" --respond "$slot1" --debug-field \
         --no-wonder-appetite-reliability \
+        --no-wonder-appetite-drift \
         --no-wonder-appetite-calibration \
         --save "$group_dir/parked-base.state" \
         > "$group_dir/parked-open.log" 2>&1
@@ -198,6 +199,7 @@ while IFS=$'\t' read -r group cohort seed; do
     "$ROOT/leo" --load "$group_dir/parked-base.state" \
         --seed "$((seed + 5101))" --respond "$slot2" --debug-field \
         --no-wonder-appetite-reliability \
+        --no-wonder-appetite-drift \
         --no-wonder-appetite-calibration \
         --save "$group_dir/parked-base.state" \
         > "$group_dir/parked-switch.log" 2>&1
@@ -246,10 +248,12 @@ while IFS=$'\t' read -r group cohort seed; do
             "$ROOT/leo" --load "$cell_dir/on.state" \
                 --seed "$run_seed" --respond "$prompt" --debug-field \
                 --no-wonder-appetite-reliability \
+                --no-wonder-appetite-drift \
                 --save "$cell_dir/on.state" > "$on_log" 2>&1
             "$ROOT/leo" --load "$cell_dir/off.state" \
                 --seed "$run_seed" --respond "$prompt" --debug-field \
                 --no-wonder-appetite-reliability \
+                --no-wonder-appetite-drift \
                 --no-wonder-appetite-calibration \
                 --save "$cell_dir/off.state" > "$off_log" 2>&1
             [ -z "$(calibration_from_log \

--- a/scripts/deferred_wonder_appetite_drift_matrix.sh
+++ b/scripts/deferred_wonder_appetite_drift_matrix.sh
@@ -1,26 +1,25 @@
 #!/usr/bin/env bash
-# A.46: rebuild a reliability surface from accumulated lived forecasts.
+# A.47: equal pooled reliability, opposite chronological return lives.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-GROUPS_FILE="${LEO_APPETITE_RELIABILITY_GROUPS:-$ROOT/scripts/deferred_wonder_constellation_groups.tsv}"
+GROUPS_FILE="${LEO_APPETITE_DRIFT_GROUPS:-$ROOT/scripts/deferred_wonder_constellation_groups.tsv}"
 STAMP="$(date +%Y%m%d-%H%M%S)"
-OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-reliability-$STAMP}"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-drift-$STAMP}"
 
 [ ! -e "$OUT" ] || {
     printf 'output path already exists: %s\n' "$OUT" >&2
     exit 2
 }
 [ -f "$GROUPS_FILE" ] || {
-    printf 'reliability groups not found: %s\n' "$GROUPS_FILE" >&2
+    printf 'drift groups not found: %s\n' "$GROUPS_FILE" >&2
     exit 2
 }
 
 awk -F '\t' '
     NR == 1 {
         if (NF != 10 || $1 != "group" || $2 != "cohort" ||
-            $3 != "seed" || $4 != "slot" || $5 != "target" ||
-            $9 != "expected_question")
+            $3 != "seed" || $4 != "slot" || $5 != "target")
             exit 1
         next
     }
@@ -32,14 +31,15 @@ awk -F '\t' '
         rows++
     }
     END {
-        if (rows != 6 || length(groups) != 2)
+        if (rows != 6 || length(groups) != 2 ||
+            !("old" in groups) || !("new" in groups))
             exit 1
         for (group in groups)
             if (groups[group] != 3)
                 exit 1
     }
 ' "$GROUPS_FILE" || {
-    printf 'invalid reliability groups: %s\n' "$GROUPS_FILE" >&2
+    printf 'invalid drift groups: %s\n' "$GROUPS_FILE" >&2
     exit 2
 }
 
@@ -83,6 +83,12 @@ reliability_from_log() {
         "$1"
 }
 
+drift_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_drift_dialogue_report.awk" \
+        "$1"
+}
+
 entry_fields() {
     local entries="$1"
     local wanted="$2"
@@ -103,7 +109,7 @@ entry_fields() {
         '
 }
 
-cell_fields() {
+reliability_cell_fields() {
     local cells="$1"
     local wanted="$2"
     printf '%s\n' "$cells" |
@@ -123,24 +129,51 @@ cell_fields() {
         '
 }
 
+drift_cell_fields() {
+    local cells="$1"
+    local wanted="$2"
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 18; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
 sha256_file() {
     shasum -a 256 "$1" | awk '{ print $1 }'
 }
 
-printf 'cell\tgroup\tcohort\tseed\tunspoken_target\tspoken_target\tunspoken_outcomes\tspoken_outcomes\n' \
+printf 'cell\tgroup\tcohort\tseed\ttarget\tearly_outcomes\trecent_outcomes\texpected_drift\n' \
     > "$PLAN"
 awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
     "$GROUPS_FILE" |
 while IFS=$'\t' read -r group cohort seed; do
-    printf '%s-reliability\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    if [ "$group" = old ]; then
+        early="faded,faded,faded,faded"
+        recent="sustained,sustained,sustained,sustained"
+        expected="rising"
+    else
+        early="sustained,sustained,sustained,sustained"
+        recent="faded,faded,faded,faded"
+        expected="falling"
+    fi
+    printf '%s-drift\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
         "$group" "$group" "$cohort" "$seed" \
         "$(group_field "$group" 2 5)" \
-        "$(group_field "$group" 1 5)" \
-        "sustained,sustained,sustained,faded" "sustained" \
-        >> "$PLAN"
+        "$early" "$recent" "$expected" >> "$PLAN"
 done
 
-if [ "${LEO_APPETITE_RELIABILITY_PLAN_ONLY:-0}" = 1 ]; then
+if [ "${LEO_APPETITE_DRIFT_PLAN_ONLY:-0}" = 1 ]; then
     cat "$PLAN"
     exit 0
 fi
@@ -149,9 +182,9 @@ make -C "$ROOT" leo >/dev/null
 "$ROOT/scripts/deferred_wonder_constellation_matrix.sh" \
     "$OUT/a40-baseline" > "$OUT/a40-baseline.log"
 
-printf 'cell\tgroup\tcohort\tscored\tpositives\tsustained\tgrounded\tfaded\tpending\texternal\tlost\tunscorable\tbrier\tece\tunspoken_n\tunspoken_positives\tunspoken_status\tspoken_n\tspoken_positives\tspoken_status\treply_equal\tstate_equal\ton_sha256\toff_sha256\n' \
+printf 'cell\tgroup\tcohort\tscored\tpositives\treliability_status\tdrift_status\tearly_positives\trecent_positives\treturn_shift\tappetite_shift\tgap_shift\tbrier_shift\treply_equal\tstate_equal\ton_sha256\toff_sha256\n' \
     > "$MATRIX"
-printf 'cell\tscored\tpositives\tsustained\tgrounded\tfaded\tpending\texternal\tlost\tunscorable\tbrier\tece\tcells\n' \
+printf 'cell\tmeasured\tforming\tstable\trising\tfalling\tcells\n' \
     > "$SURFACES"
 
 group_index=0
@@ -159,7 +192,7 @@ awk -F '\t' 'NR > 1 && !seen[$1]++ { print $1 "\t" $2 "\t" $3 }' \
     "$GROUPS_FILE" |
 while IFS=$'\t' read -r group cohort seed; do
     group_index=$((group_index + 1))
-    cell="$group-reliability"
+    cell="$group-drift"
     group_dir="$OUT/lives/$group"
     mkdir -p "$group_dir"
     ready="$OUT/a40-baseline/groups/$group/ready.state"
@@ -168,12 +201,8 @@ while IFS=$'\t' read -r group cohort seed; do
         exit 1
     }
 
-    spoken_target="$(group_field "$group" 1 5)"
-    unspoken_target="$(group_field "$group" 2 5)"
-    spoken_question="$(group_field "$group" 1 9)"
-    unspoken_question="$(group_field "$group" 2 9)"
-    semantic_spoken="Bright sun. Cold winter."
-    semantic_unspoken="Cat bird. Dark night."
+    target="$(group_field "$group" 2 5)"
+    semantic="Cat bird. Dark night."
     quiet="I do not know."
     state="$group_dir/history.state"
     cp "$ready" "$state"
@@ -184,7 +213,8 @@ while IFS=$'\t' read -r group cohort seed; do
         local prompt="$1"
         local label="$2"
         turn_index=$((turn_index + 1))
-        local run_seed=$((seed + 6100 + group_index * 1000 + turn_index))
+        local run_seed=$((seed + 7200 +
+            group_index * 1000 + turn_index))
         last_log="$group_dir/$(printf '%02d' "$turn_index")-$label.log"
         "$ROOT/leo" --load "$state" --seed "$run_seed" \
             --respond "$prompt" --debug-field \
@@ -193,17 +223,31 @@ while IFS=$'\t' read -r group cohort seed; do
             --save "$state" > "$last_log" 2>&1
     }
 
+    if [ "$group" = old ]; then
+        outcomes=(
+            faded faded faded faded
+            sustained sustained sustained sustained
+        )
+        expected_drift=rising
+    else
+        outcomes=(
+            sustained sustained sustained sustained
+            faded faded faded faded
+        )
+        expected_drift=falling
+    fi
+
     cycle=0
-    for expected in sustained sustained sustained faded; do
+    for expected in "${outcomes[@]}"; do
         cycle=$((cycle + 1))
-        history_turn "$semantic_unspoken" "u${cycle}-birth"
-        history_turn "$quiet" "u${cycle}-future1"
+        history_turn "$semantic" "c${cycle}-birth"
+        history_turn "$quiet" "c${cycle}-future1"
         if [ "$expected" = sustained ]; then
-            history_turn "$semantic_unspoken" "u${cycle}-future2"
+            history_turn "$semantic" "c${cycle}-future2"
         else
-            history_turn "$quiet" "u${cycle}-future2"
+            history_turn "$quiet" "c${cycle}-future2"
         fi
-        history_turn "$quiet" "u${cycle}-future3"
+        history_turn "$quiet" "c${cycle}-future3"
 
         calibration="$(
             calibration_from_log "$last_log" "$cell" "$seed"
@@ -215,10 +259,10 @@ while IFS=$'\t' read -r group cohort seed; do
         }
         IFS=$'\t' read -r _ _ _ _ _ _ _ _ _ _ entries \
             <<< "$calibration"
-        fields="$(entry_fields "$entries" "$unspoken_target")"
+        fields="$(entry_fields "$entries" "$target")"
         [ -n "$fields" ] || {
             printf '%s cycle %s lost target %s\n' \
-                "$cell" "$cycle" "$unspoken_target" >&2
+                "$cell" "$cycle" "$target" >&2
             exit 1
         }
         IFS=$'\t' read -r _ _ _ _ _ _ _ observed_spoken \
@@ -232,88 +276,57 @@ while IFS=$'\t' read -r group cohort seed; do
         }
     done
 
-    history_turn "$spoken_target" "spoken-open"
-    [ "$(reply_from_log "$last_log")" = "$spoken_question" ] || {
-        printf '%s failed to open %s\n' "$cell" "$spoken_target" >&2
-        exit 1
-    }
-    history_turn "$unspoken_target" "spoken-park"
-    [ "$(reply_from_log "$last_log")" = "$unspoken_question" ] || {
-        printf '%s failed to park %s behind %s\n' \
-            "$cell" "$spoken_target" "$unspoken_target" >&2
-        exit 1
-    }
-    history_turn "$semantic_spoken" "spoken-birth"
-    history_turn "$quiet" "spoken-future1"
-    history_turn "$semantic_spoken" "spoken-future2"
-    history_turn "$quiet" "spoken-future3"
-
-    calibration="$(
-        calibration_from_log "$last_log" "$cell" "$seed"
-    )"
-    [ -n "$calibration" ] || {
-        printf '%s emitted no parked-spoken calibration receipt\n' \
-            "$cell" >&2
-        exit 1
-    }
-    IFS=$'\t' read -r _ _ _ _ _ _ _ _ _ _ entries \
-        <<< "$calibration"
-    fields="$(entry_fields "$entries" "$spoken_target")"
-    [ -n "$fields" ] || {
-        printf '%s lost parked-spoken target %s\n' \
-            "$cell" "$spoken_target" >&2
-        exit 1
-    }
-    IFS=$'\t' read -r _ _ _ _ _ _ _ observed_spoken \
-        observed_verdict _ <<< "$fields"
-    [ "$observed_spoken" = 1 ] &&
-    [ "$observed_verdict" = sustained ] || {
-        printf '%s parked target expected sustained/spoken, got %s/%s\n' \
-            "$cell" "$observed_verdict" "$observed_spoken" >&2
-        exit 1
-    }
-
     cp "$state" "$group_dir/on.state"
     cp "$state" "$group_dir/off.state"
-    final_seed=$((seed + 9900))
+    final_seed=$((seed + 11900))
     "$ROOT/leo" --load "$group_dir/on.state" --seed "$final_seed" \
         --respond "$quiet" --debug-field \
-        --no-wonder-appetite-drift \
         --save "$group_dir/on.state" > "$group_dir/on.log" 2>&1
     "$ROOT/leo" --load "$group_dir/off.state" --seed "$final_seed" \
         --respond "$quiet" --debug-field \
-        --no-wonder-appetite-reliability \
         --no-wonder-appetite-drift \
         --save "$group_dir/off.state" > "$group_dir/off.log" 2>&1
 
     reliability="$(
         reliability_from_log "$group_dir/on.log" "$cell" "$final_seed"
     )"
-    [ -n "$reliability" ] || {
-        printf '%s did not reconstruct its reliability surface\n' \
+    drift="$(
+        drift_from_log "$group_dir/on.log" "$cell" "$final_seed"
+    )"
+    [ -n "$reliability" ] && [ -n "$drift" ] || {
+        printf '%s did not reconstruct both diagnostic surfaces\n' \
             "$cell" >&2
         exit 1
     }
     [ -z "$(
-        reliability_from_log "$group_dir/off.log" "$cell" "$final_seed"
+        drift_from_log "$group_dir/off.log" "$cell" "$final_seed"
     )" ] || {
-        printf '%s reliability ablation remained visible\n' "$cell" >&2
+        printf '%s drift ablation remained visible\n' "$cell" >&2
         exit 1
     }
-    IFS=$'\t' read -r _ _ scored positives sustained grounded faded \
-        pending external lost unscorable brier ece cells \
-        <<< "$reliability"
-    unspoken_fields="$(cell_fields "$cells" u62-70)"
-    spoken_fields="$(cell_fields "$cells" s80-90)"
-    [ -n "$unspoken_fields" ] && [ -n "$spoken_fields" ] || {
-        printf '%s missing expected spoken/unspoken reliability cells\n' \
-            "$cell" >&2
+
+    IFS=$'\t' read -r _ _ scored positives _ _ _ _ _ _ _ _ _ \
+        reliability_cells <<< "$reliability"
+    reliability_fields="$(
+        reliability_cell_fields "$reliability_cells" u62-70
+    )"
+    [ -n "$reliability_fields" ] || {
+        printf '%s missing pooled reliability cell\n' "$cell" >&2
         exit 1
     }
-    IFS=$'\t' read -r unspoken_n unspoken_positives _ _ _ _ _ _ \
-        unspoken_status <<< "$unspoken_fields"
-    IFS=$'\t' read -r spoken_n spoken_positives _ _ _ _ _ _ \
-        spoken_status <<< "$spoken_fields"
+    IFS=$'\t' read -r reliability_n reliability_positives \
+        _ _ _ _ _ _ reliability_status <<< "$reliability_fields"
+
+    IFS=$'\t' read -r _ _ measured forming stable rising falling \
+        drift_cells <<< "$drift"
+    drift_fields="$(drift_cell_fields "$drift_cells" u62-70)"
+    [ -n "$drift_fields" ] || {
+        printf '%s missing chronological drift cell\n' "$cell" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r drift_n early_positives recent_positives \
+        _ _ _ _ _ _ _ _ _ _ return_shift appetite_shift gap_shift brier_shift \
+        drift_status <<< "$drift_fields"
 
     reply_equal=0
     [ "$(reply_from_log "$group_dir/on.log")" = \
@@ -323,45 +336,50 @@ while IFS=$'\t' read -r group cohort seed; do
     cmp -s "$group_dir/on.state" "$group_dir/off.state" &&
         state_equal=1
 
-    [ "$scored" = 5 ] &&
+    [ "$scored" = 8 ] &&
     [ "$positives" = 4 ] &&
-    [ "$sustained" = 4 ] &&
-    [ "$grounded" = 0 ] &&
-    [ "$faded" = 1 ] &&
-    [ "$pending" = 0 ] &&
-    [ "$external" = 0 ] &&
-    [ "$lost" = 0 ] &&
-    [ "$unscorable" = 0 ] &&
-    [ "$unspoken_n" = 4 ] &&
-    [ "$unspoken_positives" = 3 ] &&
-    [ "$unspoken_status" = aligned ] &&
-    [ "$spoken_n" = 1 ] &&
-    [ "$spoken_positives" = 1 ] &&
-    [ "$spoken_status" = forming ] &&
+    [ "$reliability_n" = 8 ] &&
+    [ "$reliability_positives" = 4 ] &&
+    [ "$reliability_status" = aligned ] &&
+    [ "$measured" = 1 ] &&
+    [ "$forming" = 0 ] &&
+    [ "$stable" = 0 ] &&
+    [ "$drift_n" = 8 ] &&
+    [ "$drift_status" = "$expected_drift" ] &&
     [ "$reply_equal" = 1 ] &&
     [ "$state_equal" = 1 ] || {
-        printf '%s contract failed: scored=%s positive=%s u=%s/%s/%s s=%s/%s/%s reply=%s state=%s cells=%s\n' \
-            "$cell" "$scored" "$positives" \
-            "$unspoken_n" "$unspoken_positives" "$unspoken_status" \
-            "$spoken_n" "$spoken_positives" "$spoken_status" \
-            "$reply_equal" "$state_equal" "$cells" >&2
+        printf '%s contract failed: pooled=%s/%s/%s drift=%s/%s counts=%s/%s/%s/%s/%s reply=%s state=%s\n' \
+            "$cell" "$reliability_n" "$reliability_positives" \
+            "$reliability_status" "$drift_n" "$drift_status" \
+            "$measured" "$forming" "$stable" "$rising" "$falling" \
+            "$reply_equal" "$state_equal" >&2
         exit 1
     }
 
+    if [ "$expected_drift" = rising ]; then
+        [ "$early_positives" = 0 ] &&
+        [ "$recent_positives" = 4 ] &&
+        [ "$rising" = 1 ] &&
+        [ "$falling" = 0 ] || exit 1
+    else
+        [ "$early_positives" = 4 ] &&
+        [ "$recent_positives" = 0 ] &&
+        [ "$rising" = 0 ] &&
+        [ "$falling" = 1 ] || exit 1
+    fi
+
     on_sha="$(sha256_file "$group_dir/on.state")"
     off_sha="$(sha256_file "$group_dir/off.state")"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
         "$cell" "$group" "$cohort" "$scored" "$positives" \
-        "$sustained" "$grounded" "$faded" "$pending" "$external" \
-        "$lost" "$unscorable" "$brier" "$ece" \
-        "$unspoken_n" "$unspoken_positives" "$unspoken_status" \
-        "$spoken_n" "$spoken_positives" "$spoken_status" \
-        "$reply_equal" "$state_equal" "$on_sha" "$off_sha" \
-        >> "$MATRIX"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$cell" "$scored" "$positives" "$sustained" "$grounded" \
-        "$faded" "$pending" "$external" "$lost" "$unscorable" \
-        "$brier" "$ece" "$cells" >> "$SURFACES"
+        "$reliability_status" "$drift_status" \
+        "$early_positives" "$recent_positives" \
+        "$return_shift" "$appetite_shift" "$gap_shift" \
+        "$brier_shift" "$reply_equal" "$state_equal" \
+        "$on_sha" "$off_sha" >> "$MATRIX"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$cell" "$measured" "$forming" "$stable" \
+        "$rising" "$falling" "$drift_cells" >> "$SURFACES"
 done
 
 awk -F '\t' '
@@ -369,15 +387,16 @@ awk -F '\t' '
         cells++
         scored += $4
         positives += $5
-        aligned += $17 == "aligned"
-        forming += $20 == "forming"
-        reply_equal += $21
-        state_equal += $22
+        aligned += $6 == "aligned"
+        rising += $7 == "rising"
+        falling += $7 == "falling"
+        reply_equal += $14
+        state_equal += $15
     }
     END {
-        print "cells\tscored\tpositives\taligned_unspoken\tforming_spoken\treply_equal\tstate_equal"
+        print "cells\tscored\tpositives\taligned\trising\tfalling\treply_equal\tstate_equal"
         print cells "\t" scored "\t" positives "\t" aligned "\t" \
-              forming "\t" reply_equal "\t" state_equal
+              rising "\t" falling "\t" reply_equal "\t" state_equal
     }
 ' "$MATRIX" > "$SUMMARY"
 

--- a/scripts/test_deferred_wonder_appetite_drift_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_drift_matrix.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_DRIFT_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_drift_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 8 || $1 != "cell" || $2 != "group" ||
+            $6 != "early_outcomes" || $7 != "recent_outcomes" ||
+            $8 != "expected_drift")
+            exit 1
+        next
+    }
+    {
+        if (NF != 8 || cells[$1]++ || groups[$2]++)
+            exit 1
+        if ($2 == "old" &&
+            ($6 != "faded,faded,faded,faded" ||
+             $7 != "sustained,sustained,sustained,sustained" ||
+             $8 != "rising"))
+            exit 1
+        if ($2 == "new" &&
+            ($6 != "sustained,sustained,sustained,sustained" ||
+             $7 != "faded,faded,faded,faded" ||
+             $8 != "falling"))
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 2 || length(groups) != 2)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite drift plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite drift matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_drift_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_drift_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-drift: measured=1 forming=1 stable=0 rising=1 falling=0 cells=u62-70:8/0/4/0.690/0.690/0.000/1.000/0.000/0.490/0.510/1.000/0.476/0.096/+1.000/+0.000/+1.000/-0.380/rising|s80-90:1/0/0/0.000/0.000/0.000/0.000/0.000/0.000/0.000/0.000/0.000/0.000/+0.000/+0.000/+0.000/+0.000/forming]
+EOF
+
+got="$(
+    awk -v scenario=old -v seed=83 \
+        -f "$ROOT/scripts/wonder_appetite_drift_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'old\t83\t1\t1\t0\t1\t0\tu62-70:8/0/4/0.690/0.690/0.000/1.000/0.000/0.490/0.510/1.000/0.476/0.096/+1.000/+0.000/+1.000/-0.380/rising|s80-90:1/0/0/0.000/0.000/0.000/0.000/0.000/0.000/0.000/0.000/0.000/0.000/+0.000/+0.000/+0.000/+0.000/forming'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite drift parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite drift report parser: ok\n'

--- a/scripts/wonder_appetite_drift_dialogue_report.awk
+++ b/scripts/wonder_appetite_drift_dialogue_report.awk
@@ -1,0 +1,27 @@
+# Extract one A.47 chronological drift surface from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    start, tail, parts) {
+    start = index(line, key "=")
+    if (!start) return ""
+    tail = substr(line, start + length(key) + 1)
+    split(tail, parts, /[ ]/)
+    gsub(/\]$/, "", parts[1])
+    return parts[1]
+}
+
+/\[wonder-appetite-drift: measured=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed),
+           value_after($0, "measured"),
+           value_after($0, "forming"),
+           value_after($0, "stable"),
+           value_after($0, "rising"),
+           value_after($0, "falling"),
+           value_after($0, "cells")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -125,6 +125,167 @@ static void test_add_appetite_calibration(
         leo->school.turn_clock = (long)receipt.observed_turn;
 }
 
+__attribute__((noinline))
+static void test_wonder_appetite_drift_surface(void) {
+    Leo *drift = malloc(sizeof *drift);
+    static LeoWonderAppetiteDrift surface;
+    static LeoWonderAppetiteReliability pooled;
+    const LeoWonderAppetiteDriftCell *cell;
+    CHECK(drift != NULL,
+          "wonder-appetite-drift: heap fixture allocated");
+    if (!drift) return;
+
+    leo_init(drift);
+    leo_wonder_appetite_drift(drift, &surface);
+    CHECK(surface.measured == 0 &&
+          surface.forming == 0 &&
+          surface.cells[0].status ==
+              LEO_WONDER_APPETITE_DRIFT_EMPTY,
+          "wonder-appetite-drift: an empty diary invents no history");
+
+    for (int i = 0; i < 7; i++)
+        test_add_appetite_calibration(
+            drift, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    leo_wonder_appetite_drift(drift, &surface);
+    CHECK(surface.measured == 0 &&
+          surface.forming == 1 &&
+          surface.cells[0].n == 7 &&
+          surface.cells[0].status ==
+              LEO_WONDER_APPETITE_DRIFT_FORMING,
+          "wonder-appetite-drift: seven outcomes cannot impersonate two eras");
+
+    leo_free(drift);
+    leo_init(drift);
+    for (int i = 0; i < 5; i++)
+        test_add_appetite_calibration(
+            drift, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    for (int i = 0; i < 4; i++)
+        test_add_appetite_calibration(
+            drift, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    leo_wonder_appetite_drift(drift, &surface);
+    cell = &surface.cells[0];
+    CHECK(surface.measured == 1 &&
+          surface.rising == 1 &&
+          cell->n == 9 &&
+          cell->early_positives == 0 &&
+          cell->recent_positives == 4 &&
+          cell->status ==
+              LEO_WONDER_APPETITE_DRIFT_RISING &&
+          cell->recent_lower > cell->early_upper,
+          "wonder-appetite-drift: fixed endpoints expose a rising return life");
+    CHECK(fabsf(cell->return_shift - 1.0f) < 1e-6f &&
+          fabsf(cell->appetite_shift) < 1e-6f &&
+          fabsf(cell->gap_shift - 1.0f) < 1e-6f &&
+          fabsf(cell->brier_shift + 0.30f) < 1e-6f,
+          "wonder-appetite-drift: return, appetite, calibration, and Brier remain separate axes");
+
+    leo_wonder_appetite_reliability(drift, &pooled);
+    CHECK(pooled.cells[0].status ==
+              LEO_WONDER_APPETITE_RELIABILITY_ALIGNED &&
+          cell->status ==
+              LEO_WONDER_APPETITE_DRIFT_RISING,
+          "wonder-appetite-drift: chronology survives an aligned pooled cell");
+
+    LeoWonderAppetiteCalibration *diary_before =
+        malloc(sizeof *diary_before);
+    LeoSchool *school_before = malloc(sizeof *school_before);
+    LeoFlow *flow_before = malloc(sizeof *flow_before);
+    if (diary_before)
+        *diary_before = drift->wonder_appetite_calibration;
+    if (school_before) *school_before = drift->school;
+    if (flow_before) *flow_before = drift->flow;
+    leo_wonder_appetite_drift(drift, &surface);
+    CHECK(diary_before && school_before && flow_before &&
+          !memcmp(diary_before,
+                  &drift->wonder_appetite_calibration,
+                  sizeof *diary_before) &&
+          !memcmp(school_before, &drift->school,
+                  sizeof *school_before) &&
+          !memcmp(flow_before, &drift->flow,
+                  sizeof *flow_before),
+          "wonder-appetite-drift: reading change cannot rewrite Leo");
+    free(diary_before);
+    free(school_before);
+    free(flow_before);
+
+    leo_free(drift);
+    leo_init(drift);
+    for (int i = 0; i < 4; i++)
+        test_add_appetite_calibration(
+            drift, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < 4; i++)
+        test_add_appetite_calibration(
+            drift, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    leo_wonder_appetite_drift(drift, &surface);
+    cell = &surface.cells[0];
+    CHECK(surface.falling == 1 &&
+          cell->status ==
+              LEO_WONDER_APPETITE_DRIFT_FALLING &&
+          cell->recent_upper < cell->early_lower,
+          "wonder-appetite-drift: the same evidence reversed is a falling life");
+
+    leo_free(drift);
+    leo_init(drift);
+    for (int era = 0; era < 2; era++) {
+        for (int i = 0; i < 3; i++)
+            test_add_appetite_calibration(
+                drift, era ? 0.69f : 0.65f, 0,
+                LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+        test_add_appetite_calibration(
+            drift, era ? 0.69f : 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    }
+    leo_wonder_appetite_drift(drift, &surface);
+    cell = &surface.cells[0];
+    CHECK(surface.stable == 1 &&
+          cell->status ==
+              LEO_WONDER_APPETITE_DRIFT_STABLE &&
+          fabsf(cell->return_shift) < 1e-6f &&
+          fabsf(cell->appetite_shift - 0.04f) < 1e-6f &&
+          fabsf(cell->gap_shift + 0.04f) < 1e-6f,
+          "wonder-appetite-drift: confidence may move while observed return stays stable");
+
+    leo_free(drift);
+    leo_init(drift);
+    for (int i = 0; i < 4; i++) {
+        test_add_appetite_calibration(
+            drift, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+        test_add_appetite_calibration(
+            drift, 0.65f, 1,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    }
+    leo_wonder_appetite_drift(drift, &surface);
+    CHECK(surface.measured == 0 &&
+          surface.forming == 2 &&
+          surface.cells[0].n == 4 &&
+          surface.cells[
+              LEO_WONDER_APPETITE_RELIABILITY_BINS].n == 4,
+          "wonder-appetite-drift: spoken and unspoken chronology cannot lend each other evidence");
+
+    leo_free(drift);
+    leo_init(drift);
+    for (int i = 0; i < 8; i++)
+        test_add_appetite_calibration(
+            drift, 0.65f, 0,
+            i & 1 ?
+                LEO_WONDER_APPETITE_CALIB_EXTERNAL :
+                LEO_WONDER_APPETITE_CALIB_UNSCORABLE);
+    leo_wonder_appetite_drift(drift, &surface);
+    CHECK(surface.measured == 0 &&
+          surface.forming == 0 &&
+          surface.cells[0].n == 0,
+          "wonder-appetite-drift: causal confounds cannot become an era");
+
+    leo_free(drift);
+    free(drift);
+}
+
 int main(void) {
     printf("test_leo (step 0)\n");
 
@@ -2521,6 +2682,10 @@ int main(void) {
         }
         free(rel);
     }
+
+    /* A.47 lives in a separate function because Leo's long historical test
+     * body already owns a deliberately large stack frame. */
+    test_wonder_appetite_drift_surface();
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
      * concept-slot; a taught word then returns that glyph (no longer -1); the


### PR DESCRIPTION
Derive a pure endpoint-drift surface from the v21 appetite diary. Compare four oldest and four newest scored receipts within each exact spoken/appetite stratum; expose Wilson bounds plus return, appetite, calibration-gap, and Brier shifts while keeping the projection outside every state, speech, and scheduling path.

Evidence: 363/363 contracts and all parser/plan tests; ASan/UBSan organism smoke; two byte-identical final-format A.47 matrices over 16 real forecasts with equal pooled reliability, opposite rising/falling chronology, 2/2 reply equality, and 2/2 complete-state equality; isolated A.45 retains 30/30 reply equality and A.46 retains 2/2 reply/state equality.

Quote: "A confidence without chronology is an average pretending to be a memory." - Sol
Method: The Arianna Method keeps an arrow of time inside evidence before evidence can become authority.