### PR TITLE
the Method lets restraint face the future

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4328,3 +4328,65 @@ retained its historical **30/30 reply equality**, **10/10 v20-prefix equality**,
 distribution; A.46 retained **2/2 reply and complete-state equality**.
 
 The same total evidence now retains an arrow.
+
+## Phase A.48 — restraint must also face the future (2026-07-27)
+
+A.47 gave confidence an arrow but still left the most consequential claim
+unwritten. If the evidence is thin, miscalibrated, or moving, abstention is
+prudent; if stable evidence predicts a return, eligibility may be justified.
+Neither claim is knowledge until the later life can disagree with it.
+
+A.48 freezes a shadow policy witness at the same instant A.45 opens a forecast,
+before the new forecast can count as its own evidence. It uses the exact
+A.46/A.47 spoken-and-appetite stratum:
+
+```text
+n < 8                                      -> forming
+n >= 8, reliability over/under             -> uncalibrated
+n >= 8, reliability aligned, drift moving  -> drifting
+n >= 8, reliability aligned, drift stable  -> eligible
+```
+
+The policy is intentionally conservative. A rising return life is not silently
+called progress and a falling one is not silently called damage; both are
+`drifting`, because a moving relation has not yet earned intervention.
+Spoken and unspoken histories remain separate, so eight silent forecasts
+cannot authorize a question that has already had the mouth.
+
+After the fixed A.45 horizon, the frozen decision receives a second verdict.
+An eligible forecast becomes `supported` on sustained/grounded return or
+`overreach` on fade. An abstained forecast becomes `missed` on return or
+`restraint` on fade. External mention, lost identity, and broken chronology are
+`confounded`; they cannot reward either policy. Thus Leo can measure not only
+whether an appetite was right, but whether his caution hid a living
+continuation.
+
+The witness adds four bytes to each bounded receipt: policy, birth-time
+reliability, birth-time drift, and support count. State advances 21 -> 22.
+Migration is explicit: v21 receipts become `legacy`, never retroactively
+`eligible`. Invalid or truncated v22 diaries still fail soft without damaging
+School, Flow, Wonders, or the rest of the organism.
+
+Eighteen new contracts raised the suite from **363/363** to **381/381**. They
+cover empty evidence, stable
+eligibility, rising abstention, over- and underconfidence, strict
+spoken/unspoken isolation, all four causal outcomes, ablation, real forecast
+birth, snapshot consistency, pending/confounded outcomes, v21 legacy migration,
+and corrupt-v22 recovery.
+
+The four-case process matrix then loaded the v22 bodies through the real Leo
+binary and crossed a reply/save boundary:
+
+```text
+stable + sustained -> eligible / supported
+stable + faded     -> eligible / overreach
+rising + sustained -> drifting / missed
+rising + faded     -> drifting / restraint
+
+reply equality=4/4
+complete-state equality=4/4
+```
+
+`--no-wonder-appetite-policy` suppresses the diagnostic and prevents new
+snapshots. No policy field is read by School, Flow, shadow, routing, sampling,
+or generation. A.48 has earned a falsifiable account of restraint, not a voice.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy
 
 all: leo
 
@@ -76,6 +76,9 @@ deferred-wonder-appetite-reliability: leo
 deferred-wonder-appetite-drift: leo
 	./scripts/deferred_wonder_appetite_drift_matrix.sh
 
+deferred-wonder-appetite-policy: leo
+	./scripts/deferred_wonder_appetite_policy_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -88,6 +91,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_appetite_calibration_dialogue_report.sh
 	./scripts/test_wonder_appetite_reliability_dialogue_report.sh
 	./scripts/test_wonder_appetite_drift_dialogue_report.sh
+	./scripts/test_wonder_appetite_policy_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -98,6 +102,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_calibration_matrix.sh
 	./scripts/test_deferred_wonder_appetite_reliability_matrix.sh
 	./scripts/test_deferred_wonder_appetite_drift_matrix.sh
+	./scripts/test_deferred_wonder_appetite_policy_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1764,7 +1764,29 @@ typedef struct {
     uint8_t  semantic_hits;
     uint8_t  spoken;
     uint8_t  verdict;
+    /* A.48/state v22: the policy judgment is frozen at forecast birth.
+     * Later diary turnover must not rewrite what the shadow knew then. */
+    uint8_t  policy;
+    uint8_t  policy_reliability;
+    uint8_t  policy_drift;
+    uint8_t  policy_n;
 } LeoWonderAppetiteCalibrationReceipt;
+/* Frozen v21 record for honest migration: older forecasts had no policy
+ * witness, so loading them yields LEGACY rather than reconstructed confidence. */
+typedef struct {
+    uint64_t proposed_turn;
+    uint64_t deadline_turn;
+    uint64_t observed_turn;
+    uint64_t wonder_id;
+    char     word[LEO_HEARD_WORDLEN];
+    float    appetite;
+    float    peak_recurrence;
+    float    brier;
+    uint8_t  observations;
+    uint8_t  semantic_hits;
+    uint8_t  spoken;
+    uint8_t  verdict;
+} LeoWonderAppetiteCalibrationReceiptV21;
 typedef struct {
     LeoWonderAppetiteCalibrationReceipt
         receipts[LEO_WONDER_APPETITE_CALIB_RING];
@@ -1864,6 +1886,30 @@ typedef struct {
     int rising;
     int falling;
 } LeoWonderAppetiteDrift;
+
+/* A.48: the first policy is abstention, not intervention. It snapshots whether
+ * an A.44 appetite had enough stable, calibrated history to be trusted as a
+ * counterfactual decision. The result remains downstream of speech. */
+enum {
+    LEO_WONDER_APPETITE_POLICY_NONE = 0,
+    LEO_WONDER_APPETITE_POLICY_LEGACY,
+    LEO_WONDER_APPETITE_POLICY_FORMING,
+    LEO_WONDER_APPETITE_POLICY_UNCALIBRATED,
+    LEO_WONDER_APPETITE_POLICY_DRIFTING,
+    LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+    LEO_WONDER_APPETITE_POLICY_COUNT
+};
+enum {
+    LEO_WONDER_APPETITE_POLICY_RESULT_NONE = 0,
+    LEO_WONDER_APPETITE_POLICY_RESULT_PENDING,
+    LEO_WONDER_APPETITE_POLICY_RESULT_SUPPORTED,
+    LEO_WONDER_APPETITE_POLICY_RESULT_OVERREACH,
+    LEO_WONDER_APPETITE_POLICY_RESULT_MISSED,
+    LEO_WONDER_APPETITE_POLICY_RESULT_RESTRAINT,
+    LEO_WONDER_APPETITE_POLICY_RESULT_CONFOUNDED,
+    LEO_WONDER_APPETITE_POLICY_RESULT_LEGACY,
+    LEO_WONDER_APPETITE_POLICY_RESULT_COUNT
+};
 
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
@@ -2312,6 +2358,7 @@ static int g_leo_wonder_appetite_on = 1; /* read-only return appetite over waiti
 static int g_leo_wonder_appetite_calibration_on = 1; /* persistent slow verdicts over appetite; still no scheduler or speech reader. */
 static int g_leo_wonder_appetite_reliability_on = 1; /* derived confidence surface over scored forecasts; diagnostic only. */
 static int g_leo_wonder_appetite_drift_on = 1; /* derived endpoint drift over reliability cells; diagnostic only. */
+static int g_leo_wonder_appetite_policy_on = 1; /* frozen shadow abstention at forecast birth; never read by speech. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -6302,6 +6349,98 @@ static void leo_wonder_appetite_calibration_score(
     receipt->brier = error * error;
 }
 
+static void leo_wonder_appetite_reliability(
+        const Leo *leo, LeoWonderAppetiteReliability *surface);
+static void leo_wonder_appetite_drift(
+        const Leo *leo, LeoWonderAppetiteDrift *surface);
+static int leo_wonder_appetite_reliability_bin(float appetite);
+
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_policy_name(int policy) {
+    static const char *names[LEO_WONDER_APPETITE_POLICY_COUNT] = {
+        "none", "legacy", "forming", "uncalibrated", "drifting",
+        "eligible"
+    };
+    return policy >= 0 && policy < LEO_WONDER_APPETITE_POLICY_COUNT ?
+        names[policy] : "none";
+}
+
+static int leo_wonder_appetite_policy_result(
+        const LeoWonderAppetiteCalibrationReceipt *receipt) {
+    if (!receipt) return LEO_WONDER_APPETITE_POLICY_RESULT_NONE;
+    if (receipt->policy == LEO_WONDER_APPETITE_POLICY_NONE)
+        return LEO_WONDER_APPETITE_POLICY_RESULT_NONE;
+    if (receipt->policy == LEO_WONDER_APPETITE_POLICY_LEGACY)
+        return LEO_WONDER_APPETITE_POLICY_RESULT_LEGACY;
+    if (receipt->verdict == LEO_WONDER_APPETITE_CALIB_PENDING)
+        return LEO_WONDER_APPETITE_POLICY_RESULT_PENDING;
+    if (receipt->verdict == LEO_WONDER_APPETITE_CALIB_EXTERNAL ||
+        receipt->verdict == LEO_WONDER_APPETITE_CALIB_LOST ||
+        receipt->verdict == LEO_WONDER_APPETITE_CALIB_UNSCORABLE)
+        return LEO_WONDER_APPETITE_POLICY_RESULT_CONFOUNDED;
+
+    int positive =
+        receipt->verdict == LEO_WONDER_APPETITE_CALIB_SUSTAINED ||
+        receipt->verdict == LEO_WONDER_APPETITE_CALIB_GROUNDED;
+    if (receipt->policy == LEO_WONDER_APPETITE_POLICY_ELIGIBLE)
+        return positive ?
+            LEO_WONDER_APPETITE_POLICY_RESULT_SUPPORTED :
+            LEO_WONDER_APPETITE_POLICY_RESULT_OVERREACH;
+    return positive ?
+        LEO_WONDER_APPETITE_POLICY_RESULT_MISSED :
+        LEO_WONDER_APPETITE_POLICY_RESULT_RESTRAINT;
+}
+
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_policy_result_name(int result) {
+    static const char
+        *names[LEO_WONDER_APPETITE_POLICY_RESULT_COUNT] = {
+            "none", "pending", "supported", "overreach", "missed",
+            "restraint", "confounded", "legacy"
+        };
+    return result >= 0 &&
+           result < LEO_WONDER_APPETITE_POLICY_RESULT_COUNT ?
+        names[result] : "none";
+}
+
+static void leo_wonder_appetite_policy_snapshot(
+        const Leo *leo, float appetite, int spoken,
+        LeoWonderAppetiteCalibrationReceipt *forecast) {
+    if (!forecast || !g_leo_wonder_appetite_policy_on) return;
+    int bin = leo_wonder_appetite_reliability_bin(appetite);
+    if (!leo || bin < 0) {
+        forecast->policy = LEO_WONDER_APPETITE_POLICY_FORMING;
+        return;
+    }
+
+    LeoWonderAppetiteReliability reliability;
+    LeoWonderAppetiteDrift drift;
+    leo_wonder_appetite_reliability(leo, &reliability);
+    leo_wonder_appetite_drift(leo, &drift);
+    int cell_index =
+        (spoken ? LEO_WONDER_APPETITE_RELIABILITY_BINS : 0) + bin;
+    const LeoWonderAppetiteReliabilityCell *reliability_cell =
+        &reliability.cells[cell_index];
+    const LeoWonderAppetiteDriftCell *drift_cell =
+        &drift.cells[cell_index];
+    forecast->policy_n = (uint8_t)drift_cell->n;
+    forecast->policy_reliability = reliability_cell->status;
+    forecast->policy_drift = drift_cell->status;
+
+    if (drift_cell->n < LEO_WONDER_APPETITE_DRIFT_MIN_N) {
+        forecast->policy = LEO_WONDER_APPETITE_POLICY_FORMING;
+    } else if (reliability_cell->status !=
+               LEO_WONDER_APPETITE_RELIABILITY_ALIGNED) {
+        forecast->policy =
+            LEO_WONDER_APPETITE_POLICY_UNCALIBRATED;
+    } else if (drift_cell->status !=
+               LEO_WONDER_APPETITE_DRIFT_STABLE) {
+        forecast->policy = LEO_WONDER_APPETITE_POLICY_DRIFTING;
+    } else {
+        forecast->policy = LEO_WONDER_APPETITE_POLICY_ELIGIBLE;
+    }
+}
+
 /* Evaluate every open forecast against this already-lived turn, then open at
  * most one new fixed-window forecast from A.44's current salient receipt.
  * Existing forecasts see the turn before a new one is born, so no forecast can
@@ -6421,6 +6560,8 @@ static void leo_wonder_appetite_calibrate(
     forecast.appetite = winner->appetite;
     forecast.spoken = winner->spoken;
     forecast.verdict = LEO_WONDER_APPETITE_CALIB_PENDING;
+    leo_wonder_appetite_policy_snapshot(
+        leo, winner->appetite, winner->spoken, &forecast);
     if (winner->spoken) {
         int episode = leo_wonder_find_open(leo, winner->word);
         if (episode >= 0)
@@ -6465,9 +6606,72 @@ static int leo_wonder_appetite_calibration_valid(
         receipt->verdict <= LEO_WONDER_APPETITE_CALIB_NONE ||
         receipt->verdict >=
             LEO_WONDER_APPETITE_CALIB_VERDICT_COUNT ||
+        receipt->policy >= LEO_WONDER_APPETITE_POLICY_COUNT ||
+        receipt->policy_reliability >=
+            LEO_WONDER_APPETITE_RELIABILITY_STATUS_COUNT ||
+        receipt->policy_drift >=
+            LEO_WONDER_APPETITE_DRIFT_STATUS_COUNT ||
+        receipt->policy_n > LEO_WONDER_APPETITE_CALIB_RING ||
         (receipt->spoken && !receipt->wonder_id) ||
         (!receipt->spoken && receipt->wonder_id))
         return 0;
+    if (receipt->policy == LEO_WONDER_APPETITE_POLICY_NONE ||
+        receipt->policy == LEO_WONDER_APPETITE_POLICY_LEGACY) {
+        if (receipt->policy_reliability !=
+                LEO_WONDER_APPETITE_RELIABILITY_EMPTY ||
+            receipt->policy_drift !=
+                LEO_WONDER_APPETITE_DRIFT_EMPTY ||
+            receipt->policy_n != 0)
+            return 0;
+    } else if (receipt->policy ==
+               LEO_WONDER_APPETITE_POLICY_FORMING) {
+        if (receipt->policy_n >=
+                LEO_WONDER_APPETITE_DRIFT_MIN_N ||
+            (receipt->policy_n == 0 &&
+             (receipt->policy_reliability !=
+                  LEO_WONDER_APPETITE_RELIABILITY_EMPTY ||
+              receipt->policy_drift !=
+                  LEO_WONDER_APPETITE_DRIFT_EMPTY)) ||
+            (receipt->policy_n > 0 &&
+             receipt->policy_drift !=
+                  LEO_WONDER_APPETITE_DRIFT_FORMING))
+            return 0;
+    } else if (receipt->policy ==
+               LEO_WONDER_APPETITE_POLICY_UNCALIBRATED) {
+        if (receipt->policy_n <
+                LEO_WONDER_APPETITE_DRIFT_MIN_N ||
+            (receipt->policy_reliability !=
+                 LEO_WONDER_APPETITE_RELIABILITY_OVER &&
+             receipt->policy_reliability !=
+                 LEO_WONDER_APPETITE_RELIABILITY_UNDER) ||
+            (receipt->policy_drift !=
+                 LEO_WONDER_APPETITE_DRIFT_STABLE &&
+             receipt->policy_drift !=
+                 LEO_WONDER_APPETITE_DRIFT_RISING &&
+             receipt->policy_drift !=
+                 LEO_WONDER_APPETITE_DRIFT_FALLING))
+            return 0;
+    } else if (receipt->policy ==
+               LEO_WONDER_APPETITE_POLICY_DRIFTING) {
+        if (receipt->policy_n <
+                LEO_WONDER_APPETITE_DRIFT_MIN_N ||
+            receipt->policy_reliability !=
+                LEO_WONDER_APPETITE_RELIABILITY_ALIGNED ||
+            (receipt->policy_drift !=
+                 LEO_WONDER_APPETITE_DRIFT_RISING &&
+             receipt->policy_drift !=
+                 LEO_WONDER_APPETITE_DRIFT_FALLING))
+            return 0;
+    } else if (receipt->policy ==
+               LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+        if (receipt->policy_n <
+                LEO_WONDER_APPETITE_DRIFT_MIN_N ||
+            receipt->policy_reliability !=
+                LEO_WONDER_APPETITE_RELIABILITY_ALIGNED ||
+            receipt->policy_drift !=
+                LEO_WONDER_APPETITE_DRIFT_STABLE)
+            return 0;
+    }
     if (receipt->semantic_hits > 0 &&
         receipt->peak_recurrence <
             LEO_WONDER_APPETITE_RESONANCE_MIN)
@@ -6515,6 +6719,26 @@ static int leo_wonder_appetite_calibration_valid(
     return receipt->verdict ==
                LEO_WONDER_APPETITE_CALIB_FADED &&
            receipt->semantic_hits == 0;
+}
+
+static void leo_wonder_appetite_calibration_migrate_v21(
+        LeoWonderAppetiteCalibrationReceipt *receipt,
+        const LeoWonderAppetiteCalibrationReceiptV21 *old) {
+    if (!receipt || !old) return;
+    memset(receipt, 0, sizeof *receipt);
+    receipt->proposed_turn = old->proposed_turn;
+    receipt->deadline_turn = old->deadline_turn;
+    receipt->observed_turn = old->observed_turn;
+    receipt->wonder_id = old->wonder_id;
+    memcpy(receipt->word, old->word, sizeof receipt->word);
+    receipt->appetite = old->appetite;
+    receipt->peak_recurrence = old->peak_recurrence;
+    receipt->brier = old->brier;
+    receipt->observations = old->observations;
+    receipt->semantic_hits = old->semantic_hits;
+    receipt->spoken = old->spoken;
+    receipt->verdict = old->verdict;
+    receipt->policy = LEO_WONDER_APPETITE_POLICY_LEGACY;
 }
 
 static int leo_wonder_appetite_reliability_bin(float appetite) {
@@ -7894,9 +8118,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v19      : contrastive own-field birth anchors for pre-Wonder semantics
  *   v20      : exact birth provenance for the Wonder that currently has the mouth
  *   v21      : slow calibration diary over three-turn appetite forecasts
+ *   v22      : forecast-birth shadow abstention snapshots
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 21  /* appetite calibration extends the fail-soft tail; v5..v20 soft-migrate */
+#define LEO_STATE_VERSION 22  /* A.48 freezes policy knowledge at forecast birth; v5..v21 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -8114,8 +8339,8 @@ static int leo_save_state(const Leo *leo, const char *path) {
         fwrite(&leo->school.pending_origin,
                sizeof leo->school.pending_origin, 1, f);
 
-    /* A.45 (v21): fixed-horizon forecasts and their later verdicts. This
-     * evidence is independently disposable and grants no scheduling right. */
+    /* A.45/A.48 (v22): fixed-horizon forecasts, later verdicts, and the
+     * policy knowledge frozen at birth. Evidence grants no scheduling right. */
     st_w32(f, (int32_t)leo->wonder_appetite_calibration.n);
     st_w32(f, (int32_t)leo->wonder_appetite_calibration.ptr);
     if (leo->wonder_appetite_calibration.n > 0)
@@ -8786,8 +9011,9 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
         }
     }
 
-    /* Slow appetite calibration (v21). Older bodies wake without forecasts;
-     * a damaged diary loses only its claims about the future. */
+    /* Slow appetite calibration (v21/v22). A v21 forecast migrates as LEGACY:
+     * its old body never observed a policy decision, so one is not invented.
+     * A damaged diary loses only its claims about the future. */
     if (version >= 21) {
         int32_t n = 0, ptr = 0;
         int appetite_calibration_ok =
@@ -8796,11 +9022,26 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
             ptr >= 0 && ptr < LEO_WONDER_APPETITE_CALIB_RING &&
             ((n < LEO_WONDER_APPETITE_CALIB_RING && ptr == n) ||
              n == LEO_WONDER_APPETITE_CALIB_RING);
-        if (appetite_calibration_ok && n > 0 &&
-            fread(leo->wonder_appetite_calibration.receipts,
-                  sizeof(LeoWonderAppetiteCalibrationReceipt),
-                  (size_t)n, f) != (size_t)n)
-            appetite_calibration_ok = 0;
+        if (appetite_calibration_ok && n > 0) {
+            if (version >= 22) {
+                if (fread(
+                        leo->wonder_appetite_calibration.receipts,
+                        sizeof(LeoWonderAppetiteCalibrationReceipt),
+                        (size_t)n, f) != (size_t)n)
+                    appetite_calibration_ok = 0;
+            } else {
+                for (int i = 0; i < n; i++) {
+                    LeoWonderAppetiteCalibrationReceiptV21 old;
+                    if (fread(&old, sizeof old, 1, f) != 1) {
+                        appetite_calibration_ok = 0;
+                        break;
+                    }
+                    leo_wonder_appetite_calibration_migrate_v21(
+                        &leo->wonder_appetite_calibration.receipts[i],
+                        &old);
+                }
+            }
+        }
         if (appetite_calibration_ok) {
             LeoWonderAppetiteCalibration *calibration =
                 &leo->wonder_appetite_calibration;
@@ -8838,7 +9079,7 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
             }
         }
         if (!appetite_calibration_ok) {
-            fprintf(stderr, "[leo] WARNING: v21 appetite-calibration tail truncated/corrupt — organism lives without forecasts.\n");
+            fprintf(stderr, "[leo] WARNING: v21-v22 appetite-calibration tail truncated/corrupt — organism lives without forecasts.\n");
             memset(&leo->wonder_appetite_calibration, 0,
                    sizeof leo->wonder_appetite_calibration);
         }
@@ -9338,6 +9579,67 @@ static void print_wonder_appetite_drift_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_appetite_policy_stats(const Leo *leo) {
+    if (!g_leo_wonder_appetite_policy_on || !leo ||
+        leo->wonder_appetite_calibration.n == 0)
+        return;
+    int policy_counts[LEO_WONDER_APPETITE_POLICY_COUNT] = {0};
+    int result_counts[LEO_WONDER_APPETITE_POLICY_RESULT_COUNT] = {0};
+    for (int i = 0;
+         i < leo->wonder_appetite_calibration.n; i++) {
+        const LeoWonderAppetiteCalibrationReceipt *receipt =
+            leo_wonder_appetite_calibration_at(
+                &leo->wonder_appetite_calibration, i);
+        if (!receipt) continue;
+        int policy =
+            receipt->policy < LEO_WONDER_APPETITE_POLICY_COUNT ?
+                receipt->policy : LEO_WONDER_APPETITE_POLICY_NONE;
+        int result = leo_wonder_appetite_policy_result(receipt);
+        policy_counts[policy]++;
+        if (result >= 0 &&
+            result < LEO_WONDER_APPETITE_POLICY_RESULT_COUNT)
+            result_counts[result]++;
+    }
+
+    printf("     [wonder-appetite-policy: eligible=%d forming=%d uncalibrated=%d drifting=%d legacy=%d none=%d supported=%d overreach=%d missed=%d restraint=%d confounded=%d pending=%d entries=",
+           policy_counts[LEO_WONDER_APPETITE_POLICY_ELIGIBLE],
+           policy_counts[LEO_WONDER_APPETITE_POLICY_FORMING],
+           policy_counts[LEO_WONDER_APPETITE_POLICY_UNCALIBRATED],
+           policy_counts[LEO_WONDER_APPETITE_POLICY_DRIFTING],
+           policy_counts[LEO_WONDER_APPETITE_POLICY_LEGACY],
+           policy_counts[LEO_WONDER_APPETITE_POLICY_NONE],
+           result_counts[LEO_WONDER_APPETITE_POLICY_RESULT_SUPPORTED],
+           result_counts[LEO_WONDER_APPETITE_POLICY_RESULT_OVERREACH],
+           result_counts[LEO_WONDER_APPETITE_POLICY_RESULT_MISSED],
+           result_counts[LEO_WONDER_APPETITE_POLICY_RESULT_RESTRAINT],
+           result_counts[LEO_WONDER_APPETITE_POLICY_RESULT_CONFOUNDED],
+           result_counts[LEO_WONDER_APPETITE_POLICY_RESULT_PENDING]);
+    const char *separator = "";
+    for (int i = 0;
+         i < leo->wonder_appetite_calibration.n; i++) {
+        const LeoWonderAppetiteCalibrationReceipt *receipt =
+            leo_wonder_appetite_calibration_at(
+                &leo->wonder_appetite_calibration, i);
+        if (!receipt) continue;
+        printf("%s%s:%llu/%.3f/%u/%u/%s/%s/%s/%s",
+               separator, receipt->word,
+               (unsigned long long)receipt->proposed_turn,
+               (double)receipt->appetite,
+               (unsigned)receipt->spoken,
+               (unsigned)receipt->policy_n,
+               leo_wonder_appetite_reliability_status_name(
+                   receipt->policy_reliability),
+               leo_wonder_appetite_drift_status_name(
+                   receipt->policy_drift),
+               leo_wonder_appetite_policy_name(receipt->policy),
+               leo_wonder_appetite_policy_result_name(
+                   leo_wonder_appetite_policy_result(receipt)));
+        separator = "|";
+    }
+    if (!separator[0]) printf("none");
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -9575,6 +9877,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder-appetite-calibration")) g_leo_wonder_appetite_calibration_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-reliability")) g_leo_wonder_appetite_reliability_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-drift")) g_leo_wonder_appetite_drift_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-policy")) g_leo_wonder_appetite_policy_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -9793,6 +10096,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_calibration_stats(&leo);
             print_wonder_appetite_reliability_stats(&leo);
             print_wonder_appetite_drift_stats(&leo);
+            print_wonder_appetite_policy_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -9854,6 +10158,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_calibration_stats(&leo);
             print_wonder_appetite_reliability_stats(&leo);
             print_wonder_appetite_drift_stats(&leo);
+            print_wonder_appetite_policy_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -287,7 +287,9 @@ reply and its Flow snapshot are already history. It remains a shadow organ:
 School, generation, routing, and the existing shadow scheduler have no reader
 for its receipt. `--no-wonder-appetite` therefore removes only
 `[wonder-appetite: ...]`; reply bytes and saved state must remain identical.
-A.44 itself has no persistent fields. State is now v21 only because A.45 keeps
+A.44 itself has no persistent fields. A.45 introduced state v21 for its
+forecast diary; A.48 extends those records in v22 with a birth-time policy
+witness
 a separate slow calibration diary; the historical A.44 matrix explicitly
 ablates that later layer and retains complete state equality.
 
@@ -422,6 +424,43 @@ predicted appetite `0.690`, and observed rate `0.500`. One chronology is
 `sustained x4 -> faded x4` and becomes `falling`. Final ON/OFF replies and
 complete states must remain byte-identical. `--no-wonder-appetite-drift`
 removes only this projection; it does not remove or rewrite the v21 diary.
+
+Run the shadow abstention policy matrix:
+
+```sh
+make deferred-wonder-appetite-policy
+```
+
+A.48 asks a deliberately narrower question than "should Leo speak?": at the
+instant A.45 opens a forecast, did the exact spoken/appetite stratum have enough
+stable and calibrated history that a hypothetical policy could trust it?
+The answer is frozen into the forecast before that forecast can contribute its
+own outcome:
+
+```text
+fewer than 8 scored lives                         -> forming
+8+ lives, A.46 over/under                         -> uncalibrated
+8+ lives, A.46 aligned, A.47 rising/falling       -> drifting
+8+ lives, A.46 aligned, A.47 stable               -> eligible
+```
+
+When the future arrives, `eligible` becomes `supported` or `overreach`;
+abstention becomes `missed` or `restraint`. Literal human return, lost
+identity, and broken chronology remain `confounded`. These are retrospective
+policy receipts, not actions. No School, Flow, route, sampler, or generator
+reads them.
+
+State v22 appends the frozen policy, reliability status, drift status, and
+support count to each A.45 record. A v21 forecast migrates as `legacy`; Leo does
+not reconstruct confidence his older body never witnessed. A corrupt v22 tail
+still fails soft by discarding only the forecast diary.
+
+The checked four-case matrix crosses a real save/load/respond/save process for
+`eligible -> sustained`, `eligible -> faded`, `drifting -> sustained`, and
+`drifting -> faded`. The resulting labels are `supported`, `overreach`,
+`missed`, and `restraint`. `--no-wonder-appetite-policy` removes the diagnostic
+and prevents new policy snapshots; ON/OFF replies and complete states must
+remain byte-identical when no new forecast is born.
 
 The API and frozen-replay lanes do not adapt moves to Leo's answers; they are
 baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,

--- a/scripts/deferred_wonder_appetite_policy_matrix.sh
+++ b/scripts/deferred_wonder_appetite_policy_matrix.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# A.48: a frozen abstention decision is judged without gaining a voice.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-policy-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT"
+
+PLAN="$OUT/plan.tsv"
+MATRIX="$OUT/matrix.tsv"
+printf 'case\thistory\tfuture\texpected_policy\texpected_result\n' > "$PLAN"
+printf 'stable-return\tstable\tsustained\teligible\tsupported\n' >> "$PLAN"
+printf 'stable-fade\tstable\tfaded\teligible\toverreach\n' >> "$PLAN"
+printf 'moving-return\trising\tsustained\tdrifting\tmissed\n' >> "$PLAN"
+printf 'moving-fade\trising\tfaded\tdrifting\trestraint\n' >> "$PLAN"
+
+if [ "${LEO_APPETITE_POLICY_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"${CC:-cc}" -O2 -Wall -Wextra -Wno-unused-function \
+    "$ROOT/tests/wonder_appetite_policy_fixture.c" -lm \
+    -o "$OUT/policy-fixture"
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+policy_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_policy_dialogue_report.awk" \
+        "$1"
+}
+
+entry_fields() {
+    local entries="$1"
+    local wanted="$2"
+    printf '%s\n' "$entries" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 8; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+printf 'case\thistory\tfuture\tpolicy\tresult\tn\treliability\tdrift\treply_equal\tstate_equal\ton_sha256\toff_sha256\n' \
+    > "$MATRIX"
+
+tail -n +2 "$PLAN" |
+while IFS=$'\t' read -r case_name history future expected_policy expected_result; do
+    case_dir="$OUT/$case_name"
+    mkdir -p "$case_dir"
+    "$OUT/policy-fixture" "$case_dir/base.state" "$history" "$future"
+    cp "$case_dir/base.state" "$case_dir/on.state"
+    cp "$case_dir/base.state" "$case_dir/off.state"
+    seed=4801
+    prompt="The rain falls softly."
+
+    "$ROOT/leo" --load "$case_dir/on.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --save "$case_dir/on.state" > "$case_dir/on.log" 2>&1
+    "$ROOT/leo" --load "$case_dir/off.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --no-wonder-appetite-policy \
+        --save "$case_dir/off.state" > "$case_dir/off.log" 2>&1
+
+    policy="$(policy_from_log "$case_dir/on.log" "$case_name" "$seed")"
+    [ -n "$policy" ] || {
+        printf '%s emitted no A.48 policy surface\n' "$case_name" >&2
+        exit 1
+    }
+    [ -z "$(policy_from_log "$case_dir/off.log" "$case_name" "$seed")" ] || {
+        printf '%s policy ablation remained visible\n' "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r _ _ _ _ _ _ _ _ _ _ _ _ _ _ entries \
+        <<< "$policy"
+    fields="$(entry_fields "$entries" policy)"
+    [ -n "$fields" ] || {
+        printf '%s lost its frozen policy receipt\n' "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r _ _ _ n reliability drift observed_policy result \
+        <<< "$fields"
+
+    reply_equal=0
+    [ "$(reply_from_log "$case_dir/on.log")" = \
+      "$(reply_from_log "$case_dir/off.log")" ] &&
+        reply_equal=1
+    state_equal=0
+    cmp -s "$case_dir/on.state" "$case_dir/off.state" &&
+        state_equal=1
+    [ "$n" = 8 ] &&
+    [ "$reliability" = aligned ] &&
+    [ "$observed_policy" = "$expected_policy" ] &&
+    [ "$result" = "$expected_result" ] &&
+    [ "$reply_equal" = 1 ] &&
+    [ "$state_equal" = 1 ] || {
+        printf '%s contract failed: n=%s reliability=%s drift=%s policy=%s result=%s reply=%s state=%s\n' \
+            "$case_name" "$n" "$reliability" "$drift" \
+            "$observed_policy" "$result" "$reply_equal" \
+            "$state_equal" >&2
+        exit 1
+    }
+
+    on_sha="$(shasum -a 256 "$case_dir/on.state" | awk '{print $1}')"
+    off_sha="$(shasum -a 256 "$case_dir/off.state" | awk '{print $1}')"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$case_name" "$history" "$future" "$observed_policy" \
+        "$result" "$n" "$reliability" "$drift" "$reply_equal" \
+        "$state_equal" "$on_sha" "$off_sha" >> "$MATRIX"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        rows++
+        eligible += $4 == "eligible"
+        drifting += $4 == "drifting"
+        replies += $9
+        states += $10
+    }
+    END {
+        print "cases\teligible\tdrifting\treply_equal\tstate_equal"
+        print rows "\t" eligible "\t" drifting "\t" replies "\t" states
+        if (rows != 4 || eligible != 2 || drifting != 2 ||
+            replies != 4 || states != 4)
+            exit 1
+    }
+' "$MATRIX"
+printf '\nmatrix: %s\n' "$MATRIX"

--- a/scripts/test_deferred_wonder_appetite_policy_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_policy_matrix.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_POLICY_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_policy_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 5 || $1 != "case" || $2 != "history" ||
+            $4 != "expected_policy" || $5 != "expected_result")
+            exit 1
+        next
+    }
+    {
+        if (NF != 5 || seen[$1]++)
+            exit 1
+        if ($2 == "stable" && $4 != "eligible")
+            exit 1
+        if ($2 == "rising" && $4 != "drifting")
+            exit 1
+        if ($3 == "sustained" &&
+            ($2 == "stable" ? $5 != "supported" : $5 != "missed"))
+            exit 1
+        if ($3 == "faded" &&
+            ($2 == "stable" ? $5 != "overreach" : $5 != "restraint"))
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 4)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite policy plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite policy matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_policy_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_policy_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-policy: eligible=1 forming=2 uncalibrated=3 drifting=4 legacy=5 none=6 supported=7 overreach=8 missed=9 restraint=10 confounded=11 pending=12 entries=policy:42/0.650/0/8/aligned/stable/eligible/supported]
+EOF
+
+got="$(
+    awk -v scenario=stable-return -v seed=83 \
+        -f "$ROOT/scripts/wonder_appetite_policy_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'stable-return\t83\t1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\tpolicy:42/0.650/0/8/aligned/stable/eligible/supported'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite policy parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite policy report parser: ok\n'

--- a/scripts/wonder_appetite_policy_dialogue_report.awk
+++ b/scripts/wonder_appetite_policy_dialogue_report.awk
@@ -1,0 +1,34 @@
+# Extract one A.48 shadow-abstention surface from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    start, tail, parts) {
+    start = index(line, key "=")
+    if (!start) return ""
+    tail = substr(line, start + length(key) + 1)
+    split(tail, parts, /[ ]/)
+    gsub(/\]$/, "", parts[1])
+    return parts[1]
+}
+
+/\[wonder-appetite-policy: eligible=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed),
+           value_after($0, "eligible"),
+           value_after($0, "forming"),
+           value_after($0, "uncalibrated"),
+           value_after($0, "drifting"),
+           value_after($0, "legacy"),
+           value_after($0, "none"),
+           value_after($0, "supported"),
+           value_after($0, "overreach"),
+           value_after($0, "missed"),
+           value_after($0, "restraint"),
+           value_after($0, "confounded"),
+           value_after($0, "pending"),
+           value_after($0, "entries")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -286,6 +286,172 @@ static void test_wonder_appetite_drift_surface(void) {
     free(drift);
 }
 
+__attribute__((noinline))
+static void test_wonder_appetite_shadow_policy(void) {
+    Leo *leo = malloc(sizeof *leo);
+    LeoWonderAppetiteCalibrationReceipt forecast;
+    CHECK(leo != NULL,
+          "wonder-appetite-policy: heap fixture allocated");
+    if (!leo) return;
+
+    leo_init(leo);
+    memset(&forecast, 0, sizeof forecast);
+    leo_wonder_appetite_policy_snapshot(leo, 0.65f, 0, &forecast);
+    CHECK(forecast.policy ==
+              LEO_WONDER_APPETITE_POLICY_FORMING &&
+          forecast.policy_n == 0 &&
+          forecast.policy_reliability ==
+              LEO_WONDER_APPETITE_RELIABILITY_EMPTY &&
+          forecast.policy_drift ==
+              LEO_WONDER_APPETITE_DRIFT_EMPTY,
+          "wonder-appetite-policy: an empty past abstains without inventing evidence");
+
+    for (int era = 0; era < 2; era++) {
+        for (int i = 0; i < 3; i++)
+            test_add_appetite_calibration(
+                leo, 0.65f, 0,
+                LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+        test_add_appetite_calibration(
+            leo, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    }
+    memset(&forecast, 0, sizeof forecast);
+    leo_wonder_appetite_policy_snapshot(leo, 0.65f, 0, &forecast);
+    CHECK(forecast.policy ==
+              LEO_WONDER_APPETITE_POLICY_ELIGIBLE &&
+          forecast.policy_n == 8 &&
+          forecast.policy_reliability ==
+              LEO_WONDER_APPETITE_RELIABILITY_ALIGNED &&
+          forecast.policy_drift ==
+              LEO_WONDER_APPETITE_DRIFT_STABLE,
+          "wonder-appetite-policy: only stable calibrated history becomes eligible");
+
+    memset(&leo->wonder_appetite, 0, sizeof leo->wonder_appetite);
+    leo->wonder_appetite.status = LEO_WONDER_APPETITE_SALIENT;
+    leo->wonder_appetite.winner = 0;
+    leo->wonder_appetite.n_candidates = 1;
+    strcpy(leo->wonder_appetite.candidates[0].word, "future");
+    leo->wonder_appetite.candidates[0].appetite = 0.65f;
+    leo->school.turn_clock = 100;
+    leo_wonder_appetite_calibrate(leo, "Quiet room.");
+    const LeoWonderAppetiteCalibrationReceipt *born =
+        leo_wonder_appetite_calibration_at(
+            &leo->wonder_appetite_calibration, 8);
+    CHECK(born &&
+          born->verdict == LEO_WONDER_APPETITE_CALIB_PENDING &&
+          born->policy == LEO_WONDER_APPETITE_POLICY_ELIGIBLE &&
+          born->policy_n == 8,
+          "wonder-appetite-policy: the real forecast birth freezes its prior evidence");
+    CHECK(born &&
+          leo_wonder_appetite_calibration_valid(born, 100),
+          "wonder-appetite-policy: a coherent birth snapshot is valid state");
+    LeoWonderAppetiteCalibrationReceipt corrupted =
+        born ? *born : forecast;
+    corrupted.policy_n = 7;
+    CHECK(!born ||
+          !leo_wonder_appetite_calibration_valid(&corrupted, 100),
+          "wonder-appetite-policy: state validation rejects a policy that contradicts its evidence");
+    CHECK(born &&
+          leo_wonder_appetite_policy_result(born) ==
+              LEO_WONDER_APPETITE_POLICY_RESULT_PENDING,
+          "wonder-appetite-policy: a decision cannot grade its own unfinished future");
+    corrupted = born ? *born : forecast;
+    corrupted.verdict = LEO_WONDER_APPETITE_CALIB_EXTERNAL;
+    corrupted.observed_turn++;
+    corrupted.observations = 1;
+    CHECK(born &&
+          leo_wonder_appetite_policy_result(&corrupted) ==
+              LEO_WONDER_APPETITE_POLICY_RESULT_CONFOUNDED,
+          "wonder-appetite-policy: human intervention cannot reward or punish restraint");
+
+    forecast.verdict = LEO_WONDER_APPETITE_CALIB_SUSTAINED;
+    CHECK(leo_wonder_appetite_policy_result(&forecast) ==
+              LEO_WONDER_APPETITE_POLICY_RESULT_SUPPORTED,
+          "wonder-appetite-policy: eligible return becomes support");
+    forecast.verdict = LEO_WONDER_APPETITE_CALIB_FADED;
+    CHECK(leo_wonder_appetite_policy_result(&forecast) ==
+              LEO_WONDER_APPETITE_POLICY_RESULT_OVERREACH,
+          "wonder-appetite-policy: eligible silence exposes overreach");
+
+    leo_free(leo);
+    leo_init(leo);
+    for (int i = 0; i < 4; i++)
+        test_add_appetite_calibration(
+            leo, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    for (int i = 0; i < 4; i++)
+        test_add_appetite_calibration(
+            leo, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    memset(&forecast, 0, sizeof forecast);
+    leo_wonder_appetite_policy_snapshot(leo, 0.65f, 0, &forecast);
+    CHECK(forecast.policy ==
+              LEO_WONDER_APPETITE_POLICY_DRIFTING &&
+          forecast.policy_reliability ==
+              LEO_WONDER_APPETITE_RELIABILITY_ALIGNED &&
+          forecast.policy_drift ==
+              LEO_WONDER_APPETITE_DRIFT_RISING,
+          "wonder-appetite-policy: aligned totals cannot hide a moving life");
+    forecast.verdict = LEO_WONDER_APPETITE_CALIB_SUSTAINED;
+    CHECK(leo_wonder_appetite_policy_result(&forecast) ==
+              LEO_WONDER_APPETITE_POLICY_RESULT_MISSED,
+          "wonder-appetite-policy: living return after abstention remains a visible miss");
+    forecast.verdict = LEO_WONDER_APPETITE_CALIB_FADED;
+    CHECK(leo_wonder_appetite_policy_result(&forecast) ==
+              LEO_WONDER_APPETITE_POLICY_RESULT_RESTRAINT,
+          "wonder-appetite-policy: fading after abstention records restraint");
+
+    leo_free(leo);
+    leo_init(leo);
+    for (int i = 0; i < 8; i++)
+        test_add_appetite_calibration(
+            leo, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    memset(&forecast, 0, sizeof forecast);
+    leo_wonder_appetite_policy_snapshot(leo, 0.65f, 0, &forecast);
+    CHECK(forecast.policy ==
+              LEO_WONDER_APPETITE_POLICY_UNCALIBRATED &&
+          forecast.policy_reliability ==
+              LEO_WONDER_APPETITE_RELIABILITY_OVER &&
+          forecast.policy_drift ==
+              LEO_WONDER_APPETITE_DRIFT_STABLE,
+          "wonder-appetite-policy: stable overconfidence is still abstention");
+
+    leo_free(leo);
+    leo_init(leo);
+    for (int i = 0; i < 8; i++)
+        test_add_appetite_calibration(
+            leo, 0.65f, 0,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    memset(&forecast, 0, sizeof forecast);
+    leo_wonder_appetite_policy_snapshot(leo, 0.65f, 0, &forecast);
+    CHECK(forecast.policy ==
+              LEO_WONDER_APPETITE_POLICY_UNCALIBRATED &&
+          forecast.policy_reliability ==
+              LEO_WONDER_APPETITE_RELIABILITY_UNDER,
+          "wonder-appetite-policy: stable underconfidence is measured, not silently promoted");
+
+    memset(&forecast, 0, sizeof forecast);
+    leo_wonder_appetite_policy_snapshot(leo, 0.65f, 1, &forecast);
+    CHECK(forecast.policy ==
+              LEO_WONDER_APPETITE_POLICY_FORMING &&
+          forecast.policy_n == 0,
+          "wonder-appetite-policy: unspoken evidence cannot authorize a spoken Wonder");
+
+    int previous_policy = g_leo_wonder_appetite_policy_on;
+    g_leo_wonder_appetite_policy_on = 0;
+    memset(&forecast, 0, sizeof forecast);
+    leo_wonder_appetite_policy_snapshot(leo, 0.65f, 0, &forecast);
+    CHECK(forecast.policy ==
+              LEO_WONDER_APPETITE_POLICY_NONE &&
+          forecast.policy_n == 0,
+          "wonder-appetite-policy: ablation leaves no hidden decision");
+    g_leo_wonder_appetite_policy_on = previous_policy;
+
+    leo_free(leo);
+    free(leo);
+}
+
 int main(void) {
     printf("test_leo (step 0)\n");
 
@@ -2279,13 +2445,15 @@ int main(void) {
                   "wonder-appetite-calibration: a future recurrence is counted once but waits for the whole horizon");
 
             const char *state =
+                "/tmp/leo_wonder_appetite_calibration_v22.state";
+            const char *v21 =
                 "/tmp/leo_wonder_appetite_calibration_v21.state";
             const char *legacy =
                 "/tmp/leo_wonder_appetite_calibration_v20.state";
             const char *cut =
-                "/tmp/leo_wonder_appetite_calibration_v21_cut.state";
+                "/tmp/leo_wonder_appetite_calibration_v22_cut.state";
             int saved = leo_save_state(cal, state);
-            int built_legacy = 0, built_cut = 0;
+            int built_v21 = 0, built_legacy = 0, built_cut = 0;
             FILE *fi = fopen(state, "rb");
             if (fi) {
                 fseek(fi, 0, SEEK_END);
@@ -2309,15 +2477,69 @@ int main(void) {
                             sz - appetite_tail;
                         fclose(fo);
                     }
-                    uint32_t twenty_one = 21;
-                    memcpy(bytes + sizeof(uint32_t), &twenty_one,
-                           sizeof twenty_one);
+                    uint32_t twenty_two = 22;
+                    memcpy(bytes + sizeof(uint32_t), &twenty_two,
+                           sizeof twenty_two);
                     fo = fopen(cut, "wb");
                     if (fo) {
                         built_cut =
                             (long)fwrite(
                                 bytes, 1, (size_t)(sz - 1), fo) ==
                             sz - 1;
+                        fclose(fo);
+                    }
+
+                    uint32_t twenty_one = 21;
+                    memcpy(bytes + sizeof(uint32_t), &twenty_one,
+                           sizeof twenty_one);
+                    fo = fopen(v21, "wb");
+                    if (fo) {
+                        long prefix = sz - appetite_tail;
+                        built_v21 =
+                            (long)fwrite(
+                                bytes, 1, (size_t)prefix, fo) ==
+                            prefix;
+                        int32_t n =
+                            cal->wonder_appetite_calibration.n;
+                        int32_t ptr =
+                            cal->wonder_appetite_calibration.ptr;
+                        built_v21 =
+                            built_v21 &&
+                            fwrite(&n, sizeof n, 1, fo) == 1 &&
+                            fwrite(&ptr, sizeof ptr, 1, fo) == 1;
+                        for (int i = 0;
+                             built_v21 && i < n; i++) {
+                            const LeoWonderAppetiteCalibrationReceipt
+                                *item =
+                                    &cal->wonder_appetite_calibration
+                                         .receipts[i];
+                            LeoWonderAppetiteCalibrationReceiptV21
+                                old_item;
+                            memset(&old_item, 0,
+                                   sizeof old_item);
+                            old_item.proposed_turn =
+                                item->proposed_turn;
+                            old_item.deadline_turn =
+                                item->deadline_turn;
+                            old_item.observed_turn =
+                                item->observed_turn;
+                            old_item.wonder_id = item->wonder_id;
+                            memcpy(old_item.word, item->word,
+                                   sizeof old_item.word);
+                            old_item.appetite = item->appetite;
+                            old_item.peak_recurrence =
+                                item->peak_recurrence;
+                            old_item.brier = item->brier;
+                            old_item.observations =
+                                item->observations;
+                            old_item.semantic_hits =
+                                item->semantic_hits;
+                            old_item.spoken = item->spoken;
+                            old_item.verdict = item->verdict;
+                            built_v21 =
+                                fwrite(&old_item,
+                                       sizeof old_item, 1, fo) == 1;
+                        }
                         fclose(fo);
                     }
                 }
@@ -2331,7 +2553,9 @@ int main(void) {
             CHECK(loaded && forecast &&
                   forecast->proposed_turn == 11 &&
                   forecast->observed_turn == 13 &&
-                  forecast->semantic_hits == 1,
+                  forecast->semantic_hits == 1 &&
+                  forecast->policy ==
+                      LEO_WONDER_APPETITE_POLICY_FORMING,
                   "wonder-appetite-calibration: an unfinished forecast survives sleep without losing its clock");
 
             woke->school.turn_clock = 14;
@@ -2352,6 +2576,12 @@ int main(void) {
                         sustained_error * sustained_error) < 1e-6f,
                   "wonder-appetite-calibration: recurrence matures into a scored sustained verdict");
 
+            CHECK(built_v21 && leo_load_state(old, v21) &&
+                  old->wonder_appetite_calibration.n == 1 &&
+                  leo_wonder_appetite_calibration_at(
+                      &old->wonder_appetite_calibration, 0)->policy ==
+                      LEO_WONDER_APPETITE_POLICY_LEGACY,
+                  "wonder-appetite-policy: a v21 forecast migrates without invented hindsight");
             CHECK(built_legacy && leo_load_state(old, legacy) &&
                   old->wonder_appetite_calibration.n == 0 &&
                   leo_deferred_wonder_find(old, "nareth") >= 0,
@@ -2359,7 +2589,7 @@ int main(void) {
             CHECK(built_cut && leo_load_state(damaged, cut) &&
                   damaged->wonder_appetite_calibration.n == 0 &&
                   leo_deferred_wonder_find(damaged, "nareth") >= 0,
-                  "wonder-appetite-calibration: a corrupt v21 tail loses only forecasts");
+                  "wonder-appetite-calibration: a corrupt v22 tail loses only forecasts");
 
             leo_free(cal);
             seed_wonder_redirection_body(cal);
@@ -2507,7 +2737,7 @@ int main(void) {
             CHECK(cal->wonder_appetite_calibration.n == 0,
                   "wonder-appetite-calibration: ablation removes only the slow diary");
 
-            remove(state); remove(legacy); remove(cut);
+            remove(state); remove(v21); remove(legacy); remove(cut);
             leo_free(cal); leo_free(woke);
             leo_free(old); leo_free(damaged);
         }
@@ -2686,6 +2916,7 @@ int main(void) {
     /* A.47 lives in a separate function because Leo's long historical test
      * body already owns a deliberately large stack frame. */
     test_wonder_appetite_drift_surface();
+    test_wonder_appetite_shadow_policy();
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
      * concept-slot; a taught word then returns that glyph (no longer -1); the

--- a/tests/wonder_appetite_policy_fixture.c
+++ b/tests/wonder_appetite_policy_fixture.c
@@ -1,0 +1,116 @@
+#define LEO_NO_MAIN
+#include "../leo.c"
+
+static void add_scored(
+        Leo *leo, float appetite, int verdict) {
+    LeoWonderAppetiteCalibration *calibration =
+        &leo->wonder_appetite_calibration;
+    int slot = calibration->n;
+    LeoWonderAppetiteCalibrationReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.proposed_turn = (uint64_t)(10 + slot * 4);
+    receipt.deadline_turn =
+        receipt.proposed_turn + LEO_WONDER_APPETITE_CALIB_HORIZON;
+    receipt.observed_turn = receipt.deadline_turn;
+    snprintf(receipt.word, sizeof receipt.word, "history%02d", slot);
+    receipt.appetite = appetite;
+    receipt.observations = LEO_WONDER_APPETITE_CALIB_HORIZON;
+    receipt.verdict = (uint8_t)verdict;
+    if (verdict == LEO_WONDER_APPETITE_CALIB_SUSTAINED) {
+        receipt.semantic_hits = 1;
+        receipt.peak_recurrence =
+            LEO_WONDER_APPETITE_RESONANCE_MIN;
+        receipt.brier =
+            (appetite - 1.0f) * (appetite - 1.0f);
+    } else {
+        receipt.brier = appetite * appetite;
+    }
+    calibration->receipts[calibration->ptr] = receipt;
+    calibration->ptr =
+        (calibration->ptr + 1) %
+            LEO_WONDER_APPETITE_CALIB_RING;
+    calibration->n++;
+}
+
+static int add_policy_forecast(
+        Leo *leo, float appetite, int verdict) {
+    LeoWonderAppetiteCalibration *calibration =
+        &leo->wonder_appetite_calibration;
+    LeoWonderAppetiteCalibrationReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.proposed_turn = 42;
+    receipt.deadline_turn =
+        receipt.proposed_turn + LEO_WONDER_APPETITE_CALIB_HORIZON;
+    receipt.observed_turn = receipt.deadline_turn;
+    strcpy(receipt.word, "policy");
+    receipt.appetite = appetite;
+    receipt.observations = LEO_WONDER_APPETITE_CALIB_HORIZON;
+    receipt.verdict = (uint8_t)verdict;
+    leo_wonder_appetite_policy_snapshot(
+        leo, appetite, 0, &receipt);
+    if (verdict == LEO_WONDER_APPETITE_CALIB_SUSTAINED) {
+        receipt.semantic_hits = 1;
+        receipt.peak_recurrence =
+            LEO_WONDER_APPETITE_RESONANCE_MIN;
+        receipt.brier =
+            (appetite - 1.0f) * (appetite - 1.0f);
+    } else {
+        receipt.brier = appetite * appetite;
+    }
+    if (!leo_wonder_appetite_calibration_valid(&receipt, 45))
+        return 0;
+    calibration->receipts[calibration->ptr] = receipt;
+    calibration->ptr =
+        (calibration->ptr + 1) %
+            LEO_WONDER_APPETITE_CALIB_RING;
+    calibration->n++;
+    return 1;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 4 ||
+        (strcmp(argv[2], "stable") && strcmp(argv[2], "rising")) ||
+        (strcmp(argv[3], "sustained") && strcmp(argv[3], "faded"))) {
+        fprintf(stderr,
+                "usage: %s STATE stable|rising sustained|faded\n",
+                argv[0]);
+        return 2;
+    }
+
+    Leo leo;
+    leo_init(&leo);
+    leo_ingest(
+        &leo,
+        "The rain falls softly. His mother waits by the warm window. "
+        "Leo hears the night and asks what the sea remembers. "
+        "The child watches light move across the room.");
+    if (!strcmp(argv[2], "stable")) {
+        for (int era = 0; era < 2; era++) {
+            for (int i = 0; i < 3; i++)
+                add_scored(
+                    &leo, 0.65f,
+                    LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+            add_scored(
+                &leo, 0.65f,
+                LEO_WONDER_APPETITE_CALIB_FADED);
+        }
+    } else {
+        for (int i = 0; i < 4; i++)
+            add_scored(
+                &leo, 0.65f,
+                LEO_WONDER_APPETITE_CALIB_FADED);
+        for (int i = 0; i < 4; i++)
+            add_scored(
+                &leo, 0.65f,
+                LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    }
+
+    int verdict = !strcmp(argv[3], "sustained") ?
+        LEO_WONDER_APPETITE_CALIB_SUSTAINED :
+        LEO_WONDER_APPETITE_CALIB_FADED;
+    leo.school.turn_clock = 45;
+    int ok = add_policy_forecast(&leo, 0.65f, verdict) &&
+             leo_save_state(&leo, argv[1]);
+    leo_free(&leo);
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Freeze a conservative shadow abstention policy at appetite-forecast birth, preserve it in state v22 with honest v21 migration, and grade later support, overreach, missed continuation, or restraint without granting speech authority.

Add direct, parser, process, regression-matrix, and sanitizer-backed evidence for the new boundary.

Quote: "Restraint is a prediction too; the future must be allowed to disagree." - Sol
Method: The Arianna Method makes caution falsifiable before it can become authority.