### PR TITLE
the Method keeps motion and restraint on separate axes

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4390,3 +4390,70 @@ complete-state equality=4/4
 `--no-wonder-appetite-policy` suppresses the diagnostic and prevents new
 snapshots. No policy field is read by School, Flow, shadow, routing, sampling,
 or generation. A.48 has earned a falsifiable account of restraint, not a voice.
+
+## Phase A.49 — motion and restraint must keep separate debts (2026-07-27)
+
+A.48 could name a supported decision, an overreach, a missed continuation, or
+justified restraint. Counting those outcomes was not yet enough. A single
+utility or regret score would require an unsupported exchange rate between two
+different errors: moving when Leo should have waited, and waiting when a living
+continuation was available.
+
+A.49 therefore reconstructs three independent coordinates from frozen A.48
+receipts:
+
+```text
+coverage       = eligible / all causally scored policy decisions
+overreach      = overreach / eligible decisions
+missed         = missed / abstentions
+```
+
+The two error rates keep their own denominators and 95% Wilson intervals.
+Coverage remains visible but cannot compensate either error. The projection
+uses the same eight spoken/appetite strata as A.46-A.48, so a mature silent
+history cannot price a spoken question, and one appetite range cannot lend
+certainty to another.
+
+Arm maturity is also asymmetric. Four eligible observations make a cell
+`eligible-observed`; four abstentions make it `abstention-observed`; both arms
+must independently reach four before the cell is `paired`. Smaller occupied
+cells remain `forming`. `pending`, `confounded`, `legacy`, and `none` receipts
+are counted separately and excluded from policy pricing.
+
+The surface is a pure diagnostic reconstruction. It adds no member to `Leo`,
+no state tail, and no reader in School, Flow, shadow, routing, sampling, or
+generation. `LEO_STATE_VERSION` remains 22.
+`--no-wonder-appetite-regret` removes only the diagnostic projection.
+
+Eight direct contracts raised the suite from **381/381** to **389/389**. They
+cover an empty diary, a genuinely paired cell, independent Wilson-bearing
+error axes, one-arm maturity, spoken/unspoken isolation, aggregate-versus-cell
+separation, causal exclusions, and non-mutation of the diary, School, Flow,
+and state format.
+
+The process matrix then built two v22 lives with the same `8/16` policy
+coverage and crossed a real load/respond/save boundary:
+
+```text
+motion-heavy:
+  supported=5, overreach=3, missed=3, restraint=5
+  overreach=0.375 [0.137,0.694]
+  missed=0.375 [0.137,0.694]
+
+restraint-heavy:
+  supported=7, overreach=1, missed=5, restraint=3
+  overreach=0.125 [0.022,0.471]
+  missed=0.625 [0.306,0.863]
+
+each life:
+  paired cells=1, eligible-observed cells=1,
+  abstention-observed cells=1
+  reply equality=1/1
+  complete state equality=1/1
+```
+
+Two complete runs reproduced the matrix rows, Wilson intervals, replies, and
+state hashes byte-for-byte.
+
+Equal coverage now preserves unlike ways of being wrong. A.49 does not yet
+choose between them; it makes the future choice answerable.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret
 
 all: leo
 
@@ -79,6 +79,9 @@ deferred-wonder-appetite-drift: leo
 deferred-wonder-appetite-policy: leo
 	./scripts/deferred_wonder_appetite_policy_matrix.sh
 
+deferred-wonder-appetite-regret: leo
+	./scripts/deferred_wonder_appetite_regret_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -92,6 +95,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_appetite_reliability_dialogue_report.sh
 	./scripts/test_wonder_appetite_drift_dialogue_report.sh
 	./scripts/test_wonder_appetite_policy_dialogue_report.sh
+	./scripts/test_wonder_appetite_regret_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -103,6 +107,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_reliability_matrix.sh
 	./scripts/test_deferred_wonder_appetite_drift_matrix.sh
 	./scripts/test_deferred_wonder_appetite_policy_matrix.sh
+	./scripts/test_deferred_wonder_appetite_regret_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1911,6 +1911,71 @@ enum {
     LEO_WONDER_APPETITE_POLICY_RESULT_COUNT
 };
 
+/* A.49: the cost of restraint has two axes which must not be collapsed into
+ * one utility scalar. Overreach is measured among eligible forecasts; missed
+ * continuation is measured among abstentions. Coverage remains a third axis.
+ * The surface is reconstructed from frozen A.48 receipts and is never saved. */
+#define LEO_WONDER_APPETITE_REGRET_MIN_ARM_N 4
+enum {
+    LEO_WONDER_APPETITE_REGRET_EMPTY = 0,
+    LEO_WONDER_APPETITE_REGRET_FORMING,
+    LEO_WONDER_APPETITE_REGRET_ELIGIBLE_OBSERVED,
+    LEO_WONDER_APPETITE_REGRET_ABSTENTION_OBSERVED,
+    LEO_WONDER_APPETITE_REGRET_PAIRED,
+    LEO_WONDER_APPETITE_REGRET_STATUS_COUNT
+};
+typedef struct {
+    int   scored;
+    int   eligible;
+    int   abstained;
+    int   supported;
+    int   overreach;
+    int   missed;
+    int   restraint;
+    int   policy_forming;
+    int   policy_uncalibrated;
+    int   policy_drifting;
+    float coverage;
+    float overreach_rate;
+    float overreach_lower;
+    float overreach_upper;
+    float missed_rate;
+    float missed_lower;
+    float missed_upper;
+    uint8_t spoken;
+    uint8_t bin;
+    uint8_t status;
+} LeoWonderAppetiteRegretCell;
+typedef struct {
+    LeoWonderAppetiteRegretCell
+        cells[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+    int scored;
+    int eligible;
+    int abstained;
+    int supported;
+    int overreach;
+    int missed;
+    int restraint;
+    int policy_forming;
+    int policy_uncalibrated;
+    int policy_drifting;
+    int pending;
+    int confounded;
+    int legacy;
+    int none;
+    int forming_cells;
+    int eligible_observed_cells;
+    int abstention_observed_cells;
+    int paired_cells;
+    float coverage;
+    float overreach_rate;
+    float overreach_lower;
+    float overreach_upper;
+    float missed_rate;
+    float missed_lower;
+    float missed_upper;
+} LeoWonderAppetiteRegret;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -2359,6 +2424,7 @@ static int g_leo_wonder_appetite_calibration_on = 1; /* persistent slow verdicts
 static int g_leo_wonder_appetite_reliability_on = 1; /* derived confidence surface over scored forecasts; diagnostic only. */
 static int g_leo_wonder_appetite_drift_on = 1; /* derived endpoint drift over reliability cells; diagnostic only. */
 static int g_leo_wonder_appetite_policy_on = 1; /* frozen shadow abstention at forecast birth; never read by speech. */
+static int g_leo_wonder_appetite_regret_on = 1; /* separate costs of motion and restraint; derived diagnostic only. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -7050,6 +7116,186 @@ static void leo_wonder_appetite_drift(
     }
 }
 
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_regret_status_name(
+        int status) {
+    static const char
+        *names[LEO_WONDER_APPETITE_REGRET_STATUS_COUNT] = {
+            "empty", "forming", "eligible-observed",
+            "abstention-observed", "paired"
+        };
+    return status >= 0 &&
+           status < LEO_WONDER_APPETITE_REGRET_STATUS_COUNT ?
+        names[status] : "empty";
+}
+
+static void leo_wonder_appetite_regret_finish_cell(
+        LeoWonderAppetiteRegretCell *cell) {
+    if (!cell || cell->scored <= 0) return;
+    cell->coverage =
+        (float)cell->eligible / (float)cell->scored;
+    if (cell->eligible > 0) {
+        cell->overreach_rate =
+            (float)cell->overreach / (float)cell->eligible;
+        leo_wilson_interval(
+            cell->overreach, cell->eligible,
+            &cell->overreach_lower, &cell->overreach_upper);
+    }
+    if (cell->abstained > 0) {
+        cell->missed_rate =
+            (float)cell->missed / (float)cell->abstained;
+        leo_wilson_interval(
+            cell->missed, cell->abstained,
+            &cell->missed_lower, &cell->missed_upper);
+    }
+
+    int eligible_observed =
+        cell->eligible >= LEO_WONDER_APPETITE_REGRET_MIN_ARM_N;
+    int abstention_observed =
+        cell->abstained >= LEO_WONDER_APPETITE_REGRET_MIN_ARM_N;
+    if (eligible_observed && abstention_observed)
+        cell->status = LEO_WONDER_APPETITE_REGRET_PAIRED;
+    else if (eligible_observed)
+        cell->status =
+            LEO_WONDER_APPETITE_REGRET_ELIGIBLE_OBSERVED;
+    else if (abstention_observed)
+        cell->status =
+            LEO_WONDER_APPETITE_REGRET_ABSTENTION_OBSERVED;
+    else
+        cell->status = LEO_WONDER_APPETITE_REGRET_FORMING;
+}
+
+/* Reconstruct the two error axes from decisions which were frozen before
+ * their outcomes. A missed continuation and an overreach remain separate
+ * denominators: this layer has no warrant to say they cost the same. */
+static void leo_wonder_appetite_regret(
+        const Leo *leo, LeoWonderAppetiteRegret *surface) {
+    if (!surface) return;
+    memset(surface, 0, sizeof *surface);
+    for (int spoken = 0; spoken <= 1; spoken++)
+        for (int bin = 0;
+             bin < LEO_WONDER_APPETITE_RELIABILITY_BINS; bin++) {
+            int cell_index =
+                spoken * LEO_WONDER_APPETITE_RELIABILITY_BINS + bin;
+            surface->cells[cell_index].spoken = (uint8_t)spoken;
+            surface->cells[cell_index].bin = (uint8_t)bin;
+        }
+    if (!leo) return;
+
+    for (int i = 0;
+         i < leo->wonder_appetite_calibration.n; i++) {
+        const LeoWonderAppetiteCalibrationReceipt *receipt =
+            leo_wonder_appetite_calibration_at(
+                &leo->wonder_appetite_calibration, i);
+        int result = leo_wonder_appetite_policy_result(receipt);
+        if (result == LEO_WONDER_APPETITE_POLICY_RESULT_NONE) {
+            surface->none++;
+            continue;
+        }
+        if (result == LEO_WONDER_APPETITE_POLICY_RESULT_LEGACY) {
+            surface->legacy++;
+            continue;
+        }
+        if (result == LEO_WONDER_APPETITE_POLICY_RESULT_PENDING) {
+            surface->pending++;
+            continue;
+        }
+        if (result == LEO_WONDER_APPETITE_POLICY_RESULT_CONFOUNDED) {
+            surface->confounded++;
+            continue;
+        }
+
+        int bin = leo_wonder_appetite_reliability_bin(
+            receipt ? receipt->appetite : 0.0f);
+        if (!receipt || bin < 0) continue;
+        int cell_index =
+            (receipt->spoken ?
+                 LEO_WONDER_APPETITE_RELIABILITY_BINS : 0) + bin;
+        LeoWonderAppetiteRegretCell *cell =
+            &surface->cells[cell_index];
+        cell->scored++;
+        surface->scored++;
+
+        if (receipt->policy ==
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+            cell->eligible++;
+            surface->eligible++;
+        } else {
+            cell->abstained++;
+            surface->abstained++;
+            if (receipt->policy ==
+                LEO_WONDER_APPETITE_POLICY_FORMING) {
+                cell->policy_forming++;
+                surface->policy_forming++;
+            } else if (receipt->policy ==
+                       LEO_WONDER_APPETITE_POLICY_UNCALIBRATED) {
+                cell->policy_uncalibrated++;
+                surface->policy_uncalibrated++;
+            } else if (receipt->policy ==
+                       LEO_WONDER_APPETITE_POLICY_DRIFTING) {
+                cell->policy_drifting++;
+                surface->policy_drifting++;
+            }
+        }
+
+        if (result ==
+            LEO_WONDER_APPETITE_POLICY_RESULT_SUPPORTED) {
+            cell->supported++;
+            surface->supported++;
+        } else if (
+            result ==
+            LEO_WONDER_APPETITE_POLICY_RESULT_OVERREACH) {
+            cell->overreach++;
+            surface->overreach++;
+        } else if (
+            result == LEO_WONDER_APPETITE_POLICY_RESULT_MISSED) {
+            cell->missed++;
+            surface->missed++;
+        } else if (
+            result ==
+            LEO_WONDER_APPETITE_POLICY_RESULT_RESTRAINT) {
+            cell->restraint++;
+            surface->restraint++;
+        }
+    }
+
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        LeoWonderAppetiteRegretCell *cell = &surface->cells[i];
+        leo_wonder_appetite_regret_finish_cell(cell);
+        if (cell->status == LEO_WONDER_APPETITE_REGRET_FORMING)
+            surface->forming_cells++;
+        else if (
+            cell->status ==
+            LEO_WONDER_APPETITE_REGRET_ELIGIBLE_OBSERVED)
+            surface->eligible_observed_cells++;
+        else if (
+            cell->status ==
+            LEO_WONDER_APPETITE_REGRET_ABSTENTION_OBSERVED)
+            surface->abstention_observed_cells++;
+        else if (cell->status == LEO_WONDER_APPETITE_REGRET_PAIRED)
+            surface->paired_cells++;
+    }
+
+    if (surface->scored > 0)
+        surface->coverage =
+            (float)surface->eligible / (float)surface->scored;
+    if (surface->eligible > 0) {
+        surface->overreach_rate =
+            (float)surface->overreach / (float)surface->eligible;
+        leo_wilson_interval(
+            surface->overreach, surface->eligible,
+            &surface->overreach_lower, &surface->overreach_upper);
+    }
+    if (surface->abstained > 0) {
+        surface->missed_rate =
+            (float)surface->missed / (float)surface->abstained;
+        leo_wilson_interval(
+            surface->missed, surface->abstained,
+            &surface->missed_lower, &surface->missed_upper);
+    }
+}
+
 static int leo_flow_kind(const LeoFlow *flow, int glyph, int window, int face) {
     if (!flow || flow->n <= 0 || glyph < 0 || glyph >= GLYPH_COUNT) return LEO_FLOW_QUIET;
     if (window < 3) window = 3;
@@ -9640,6 +9886,60 @@ static void print_wonder_appetite_policy_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_appetite_regret_stats(const Leo *leo) {
+    if (!g_leo_wonder_appetite_regret_on || !leo ||
+        leo->wonder_appetite_calibration.n == 0)
+        return;
+    LeoWonderAppetiteRegret surface;
+    leo_wonder_appetite_regret(leo, &surface);
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+
+    printf("     [wonder-appetite-regret: scored=%d eligible=%d abstained=%d supported=%d overreach=%d missed=%d restraint=%d policy-forming=%d policy-uncalibrated=%d policy-drifting=%d pending=%d confounded=%d legacy=%d none=%d coverage=%.3f overreach-axis=%.3f/%.3f/%.3f missed-axis=%.3f/%.3f/%.3f forming-cells=%d eligible-cells=%d abstention-cells=%d paired-cells=%d cells=",
+           surface.scored, surface.eligible, surface.abstained,
+           surface.supported, surface.overreach, surface.missed,
+           surface.restraint, surface.policy_forming,
+           surface.policy_uncalibrated, surface.policy_drifting,
+           surface.pending, surface.confounded, surface.legacy,
+           surface.none, (double)surface.coverage,
+           (double)surface.overreach_rate,
+           (double)surface.overreach_lower,
+           (double)surface.overreach_upper,
+           (double)surface.missed_rate,
+           (double)surface.missed_lower,
+           (double)surface.missed_upper,
+           surface.forming_cells,
+           surface.eligible_observed_cells,
+           surface.abstention_observed_cells,
+           surface.paired_cells);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteRegretCell *cell =
+            &surface.cells[i];
+        if (cell->scored <= 0) continue;
+        printf("%s%c%d-%d:%d/%d/%d/%d/%d/%d/%d/%d/%d/%d/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%s",
+               separator, cell->spoken ? 's' : 'u',
+               lower[cell->bin], upper[cell->bin],
+               cell->scored, cell->eligible, cell->abstained,
+               cell->supported, cell->overreach, cell->missed,
+               cell->restraint, cell->policy_forming,
+               cell->policy_uncalibrated, cell->policy_drifting,
+               (double)cell->coverage,
+               (double)cell->overreach_rate,
+               (double)cell->overreach_lower,
+               (double)cell->overreach_upper,
+               (double)cell->missed_rate,
+               (double)cell->missed_lower,
+               (double)cell->missed_upper,
+               leo_wonder_appetite_regret_status_name(
+                   cell->status));
+        separator = "|";
+    }
+    if (!separator[0]) printf("none");
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -9878,6 +10178,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder-appetite-reliability")) g_leo_wonder_appetite_reliability_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-drift")) g_leo_wonder_appetite_drift_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-policy")) g_leo_wonder_appetite_policy_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-regret")) g_leo_wonder_appetite_regret_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -10097,6 +10398,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_reliability_stats(&leo);
             print_wonder_appetite_drift_stats(&leo);
             print_wonder_appetite_policy_stats(&leo);
+            print_wonder_appetite_regret_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -10159,6 +10461,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_reliability_stats(&leo);
             print_wonder_appetite_drift_stats(&leo);
             print_wonder_appetite_policy_stats(&leo);
+            print_wonder_appetite_regret_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -467,3 +467,37 @@ baselines. `local-v1` is genuinely adaptive within its nine predeclared phases,
 but only through the narrow visible sensors above. Selecting a move from shadow
 diagnostics would leak the judge into the stimulus, while sending Leo's private
 dialogue to an external API remains outside this protocol.
+
+Run the two-axis policy-regret matrix:
+
+```sh
+make deferred-wonder-appetite-regret
+```
+
+A.49 derives a policy cost surface from settled A.48 receipts without changing
+their frozen decisions. It deliberately refuses a single utility score:
+
+```text
+coverage  = eligible / scored
+overreach = overreach / eligible
+missed    = missed / abstained
+```
+
+Both error axes expose separate 95% Wilson intervals. The projection preserves
+the exact A.46-A.48 spoken/appetite strata. A cell is
+`eligible-observed` after four eligible decisions,
+`abstention-observed` after four abstentions, and `paired` only after both arms
+independently reach four. Smaller occupied cells remain `forming`.
+
+Pending, confounded, legacy, and ablated receipts are reported but excluded
+from the denominators. The surface is reconstructed only for diagnostics:
+there is no new persisted field, state remains v22, and no speech or scheduler
+path reads it. `--no-wonder-appetite-regret` suppresses only this line.
+
+The checked matrix builds two v22 fixtures with identical `0.500` coverage but
+different outcome geometry. The motion-heavy life must report
+`overreach=0.375, missed=0.375`; the restraint-heavy life must report
+`overreach=0.125, missed=0.625`. Both must contain one paired, one
+eligible-observed, and one abstention-observed stratum. ON/OFF forks use the
+same seed and require identical replies and byte-identical complete saved
+states.

--- a/scripts/deferred_wonder_appetite_regret_matrix.sh
+++ b/scripts/deferred_wonder_appetite_regret_matrix.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# A.49: keep the costs of motion and restraint on separate axes.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-regret-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT"
+
+PLAN="$OUT/plan.tsv"
+MATRIX="$OUT/matrix.tsv"
+printf 'case\texpected_supported\texpected_overreach\texpected_missed\texpected_restraint\texpected_overreach_axis\texpected_missed_axis\n' \
+    > "$PLAN"
+printf 'motion-heavy\t5\t3\t3\t5\t0.375\t0.375\n' >> "$PLAN"
+printf 'restraint-heavy\t7\t1\t5\t3\t0.125\t0.625\n' >> "$PLAN"
+
+if [ "${LEO_APPETITE_REGRET_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"${CC:-cc}" -O2 -Wall -Wextra -Wno-unused-function \
+    "$ROOT/tests/wonder_appetite_regret_fixture.c" -lm \
+    -o "$OUT/regret-fixture"
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+regret_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_regret_dialogue_report.awk" \
+        "$1"
+}
+
+cell_fields() {
+    local cells="$1"
+    local wanted="$2"
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 18; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+printf 'case\tscored\teligible\tabstained\tsupported\toverreach\tmissed\trestraint\tcoverage\toverreach_axis\tmissed_axis\tpaired_status\teligible_status\tabstention_status\treply_equal\tstate_equal\ton_sha256\toff_sha256\n' \
+    > "$MATRIX"
+
+tail -n +2 "$PLAN" |
+while IFS=$'\t' read -r case_name expected_supported expected_overreach \
+        expected_missed expected_restraint expected_over_axis expected_miss_axis; do
+    case_dir="$OUT/$case_name"
+    mkdir -p "$case_dir"
+    "$OUT/regret-fixture" "$case_dir/base.state" "$case_name"
+    cp "$case_dir/base.state" "$case_dir/on.state"
+    cp "$case_dir/base.state" "$case_dir/off.state"
+    seed=4901
+    prompt="The rain falls softly."
+
+    "$ROOT/leo" --load "$case_dir/on.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --save "$case_dir/on.state" > "$case_dir/on.log" 2>&1
+    "$ROOT/leo" --load "$case_dir/off.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --no-wonder-appetite-regret \
+        --save "$case_dir/off.state" > "$case_dir/off.log" 2>&1
+
+    regret="$(regret_from_log "$case_dir/on.log" "$case_name" "$seed")"
+    [ -n "$regret" ] || {
+        printf '%s emitted no A.49 regret surface\n' "$case_name" >&2
+        exit 1
+    }
+    [ -z "$(regret_from_log "$case_dir/off.log" "$case_name" "$seed")" ] || {
+        printf '%s regret ablation remained visible\n' "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r _ _ scored eligible abstained supported overreach \
+        missed restraint policy_forming policy_uncalibrated policy_drifting \
+        pending confounded legacy none coverage over_axis miss_axis \
+        forming_cells eligible_cells abstention_cells paired_cells cells \
+        <<< "$regret"
+
+    paired="$(cell_fields "$cells" u62-70)"
+    eligible_only="$(cell_fields "$cells" s80-90)"
+    abstention_only="$(cell_fields "$cells" u80-90)"
+    [ -n "$paired" ] && [ -n "$eligible_only" ] &&
+    [ -n "$abstention_only" ] || {
+        printf '%s lost a stratified arm\n' "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ paired_status \
+        <<< "$paired"
+    IFS=$'\t' read -r _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ eligible_status \
+        <<< "$eligible_only"
+    IFS=$'\t' read -r _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ abstention_status \
+        <<< "$abstention_only"
+
+    reply_equal=0
+    [ "$(reply_from_log "$case_dir/on.log")" = \
+      "$(reply_from_log "$case_dir/off.log")" ] &&
+        reply_equal=1
+    state_equal=0
+    cmp -s "$case_dir/on.state" "$case_dir/off.state" &&
+        state_equal=1
+
+    over_rate="${over_axis%%/*}"
+    miss_rate="${miss_axis%%/*}"
+    [ "$scored" = 16 ] &&
+    [ "$eligible" = 8 ] &&
+    [ "$abstained" = 8 ] &&
+    [ "$supported" = "$expected_supported" ] &&
+    [ "$overreach" = "$expected_overreach" ] &&
+    [ "$missed" = "$expected_missed" ] &&
+    [ "$restraint" = "$expected_restraint" ] &&
+    [ "$policy_forming" = 4 ] &&
+    [ "$policy_uncalibrated" = 0 ] &&
+    [ "$policy_drifting" = 4 ] &&
+    [ "$pending" = 0 ] &&
+    [ "$confounded" = 0 ] &&
+    [ "$legacy" = 0 ] &&
+    [ "$none" = 0 ] &&
+    [ "$coverage" = 0.500 ] &&
+    [ "$over_rate" = "$expected_over_axis" ] &&
+    [ "$miss_rate" = "$expected_miss_axis" ] &&
+    [ "$forming_cells" = 0 ] &&
+    [ "$eligible_cells" = 1 ] &&
+    [ "$abstention_cells" = 1 ] &&
+    [ "$paired_cells" = 1 ] &&
+    [ "$paired_status" = paired ] &&
+    [ "$eligible_status" = eligible-observed ] &&
+    [ "$abstention_status" = abstention-observed ] &&
+    [ "$reply_equal" = 1 ] &&
+    [ "$state_equal" = 1 ] || {
+        printf '%s contract failed: scored=%s arms=%s/%s outcomes=%s/%s/%s/%s axes=%s/%s statuses=%s/%s/%s reply=%s state=%s\n' \
+            "$case_name" "$scored" "$eligible" "$abstained" \
+            "$supported" "$overreach" "$missed" "$restraint" \
+            "$over_axis" "$miss_axis" "$paired_status" \
+            "$eligible_status" "$abstention_status" \
+            "$reply_equal" "$state_equal" >&2
+        exit 1
+    }
+
+    on_sha="$(shasum -a 256 "$case_dir/on.state" | awk '{print $1}')"
+    off_sha="$(shasum -a 256 "$case_dir/off.state" | awk '{print $1}')"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$case_name" "$scored" "$eligible" "$abstained" \
+        "$supported" "$overreach" "$missed" "$restraint" \
+        "$coverage" "$over_axis" "$miss_axis" "$paired_status" \
+        "$eligible_status" "$abstention_status" "$reply_equal" \
+        "$state_equal" "$on_sha" "$off_sha" >> "$MATRIX"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        rows++
+        replies += $15
+        states += $16
+    }
+    END {
+        print "cases\treply_equal\tstate_equal"
+        print rows "\t" replies "\t" states
+        if (rows != 2 || replies != 2 || states != 2)
+            exit 1
+    }
+' "$MATRIX"
+printf '\nmatrix: %s\n' "$MATRIX"

--- a/scripts/test_deferred_wonder_appetite_regret_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_regret_matrix.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_REGRET_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_regret_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 7 || $1 != "case" ||
+            $6 != "expected_overreach_axis" ||
+            $7 != "expected_missed_axis")
+            exit 1
+        next
+    }
+    {
+        if (NF != 7 || seen[$1]++)
+            exit 1
+        if ($1 == "motion-heavy" &&
+            ($3 != 3 || $4 != 3 || $6 != "0.375" ||
+             $7 != "0.375"))
+            exit 1
+        if ($1 == "restraint-heavy" &&
+            ($3 != 1 || $4 != 5 || $6 != "0.125" ||
+             $7 != "0.625"))
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 2)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite regret plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite regret matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_regret_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_regret_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-regret: scored=16 eligible=8 abstained=8 supported=5 overreach=3 missed=3 restraint=5 policy-forming=4 policy-uncalibrated=0 policy-drifting=4 pending=0 confounded=0 legacy=0 none=0 coverage=0.500 overreach-axis=0.375/0.137/0.694 missed-axis=0.375/0.137/0.694 forming-cells=0 eligible-cells=1 abstention-cells=1 paired-cells=1 cells=u62-70:8/4/4/1/3/1/3/4/0/0/0.500/0.750/0.301/0.954/0.250/0.046/0.699/paired]
+EOF
+
+got="$(
+    awk -v scenario=motion-heavy -v seed=83 \
+        -f "$ROOT/scripts/wonder_appetite_regret_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'motion-heavy\t83\t16\t8\t8\t5\t3\t3\t5\t4\t0\t4\t0\t0\t0\t0\t0.500\t0.375/0.137/0.694\t0.375/0.137/0.694\t0\t1\t1\t1\tu62-70:8/4/4/1/3/1/3/4/0/0/0.500/0.750/0.301/0.954/0.250/0.046/0.699/paired'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite regret parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite regret report parser: ok\n'

--- a/scripts/wonder_appetite_regret_dialogue_report.awk
+++ b/scripts/wonder_appetite_regret_dialogue_report.awk
@@ -1,0 +1,47 @@
+# Extract one A.49 two-axis regret surface from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    fields, i, n, prefix, value) {
+    prefix = key "="
+    n = split(line, fields, /[ ]+/)
+    for (i = 1; i <= n; i++) {
+        if (index(fields[i], prefix) != 1)
+            continue
+        value = substr(fields[i], length(prefix) + 1)
+        gsub(/\]$/, "", value)
+        return value
+    }
+    return ""
+}
+
+/\[wonder-appetite-regret: scored=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed),
+           value_after($0, "scored"),
+           value_after($0, "eligible"),
+           value_after($0, "abstained"),
+           value_after($0, "supported"),
+           value_after($0, "overreach"),
+           value_after($0, "missed"),
+           value_after($0, "restraint"),
+           value_after($0, "policy-forming"),
+           value_after($0, "policy-uncalibrated"),
+           value_after($0, "policy-drifting"),
+           value_after($0, "pending"),
+           value_after($0, "confounded"),
+           value_after($0, "legacy"),
+           value_after($0, "none"),
+           value_after($0, "coverage"),
+           value_after($0, "overreach-axis"),
+           value_after($0, "missed-axis"),
+           value_after($0, "forming-cells"),
+           value_after($0, "eligible-cells"),
+           value_after($0, "abstention-cells"),
+           value_after($0, "paired-cells"),
+           value_after($0, "cells")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -125,6 +125,81 @@ static void test_add_appetite_calibration(
         leo->school.turn_clock = (long)receipt.observed_turn;
 }
 
+static void test_add_appetite_policy_outcome(
+        Leo *leo, float appetite, int spoken,
+        int policy, int verdict) {
+    if (!leo ||
+        leo->wonder_appetite_calibration.n >=
+            LEO_WONDER_APPETITE_CALIB_RING)
+        return;
+    LeoWonderAppetiteCalibration *calibration =
+        &leo->wonder_appetite_calibration;
+    int slot = calibration->n;
+    LeoWonderAppetiteCalibrationReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.proposed_turn = (uint64_t)(10 + slot * 4);
+    receipt.deadline_turn =
+        receipt.proposed_turn +
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+    receipt.observed_turn = receipt.proposed_turn;
+    receipt.appetite = appetite;
+    receipt.spoken = spoken ? 1 : 0;
+    receipt.wonder_id = spoken ? (uint64_t)(slot + 1) : 0;
+    receipt.policy = (uint8_t)policy;
+    receipt.verdict = (uint8_t)verdict;
+    snprintf(receipt.word, sizeof receipt.word, "p%02d", slot);
+
+    if (policy == LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+        receipt.policy_n = LEO_WONDER_APPETITE_DRIFT_MIN_N;
+        receipt.policy_reliability =
+            LEO_WONDER_APPETITE_RELIABILITY_ALIGNED;
+        receipt.policy_drift =
+            LEO_WONDER_APPETITE_DRIFT_STABLE;
+    } else if (
+        policy == LEO_WONDER_APPETITE_POLICY_DRIFTING) {
+        receipt.policy_n = LEO_WONDER_APPETITE_DRIFT_MIN_N;
+        receipt.policy_reliability =
+            LEO_WONDER_APPETITE_RELIABILITY_ALIGNED;
+        receipt.policy_drift =
+            LEO_WONDER_APPETITE_DRIFT_RISING;
+    } else if (
+        policy == LEO_WONDER_APPETITE_POLICY_UNCALIBRATED) {
+        receipt.policy_n = LEO_WONDER_APPETITE_DRIFT_MIN_N;
+        receipt.policy_reliability =
+            LEO_WONDER_APPETITE_RELIABILITY_OVER;
+        receipt.policy_drift =
+            LEO_WONDER_APPETITE_DRIFT_STABLE;
+    }
+
+    if (verdict == LEO_WONDER_APPETITE_CALIB_SUSTAINED) {
+        receipt.observed_turn = receipt.deadline_turn;
+        receipt.observations =
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+        receipt.semantic_hits = 1;
+        receipt.peak_recurrence =
+            LEO_WONDER_APPETITE_RESONANCE_MIN;
+        float error = appetite - 1.0f;
+        receipt.brier = error * error;
+    } else if (
+        verdict == LEO_WONDER_APPETITE_CALIB_FADED) {
+        receipt.observed_turn = receipt.deadline_turn;
+        receipt.observations =
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+        receipt.brier = appetite * appetite;
+    } else if (
+        verdict == LEO_WONDER_APPETITE_CALIB_EXTERNAL) {
+        receipt.observed_turn++;
+        receipt.observations = 1;
+    }
+
+    calibration->receipts[slot] = receipt;
+    calibration->n++;
+    calibration->ptr =
+        calibration->n % LEO_WONDER_APPETITE_CALIB_RING;
+    if ((uint64_t)leo->school.turn_clock < receipt.observed_turn)
+        leo->school.turn_clock = (long)receipt.observed_turn;
+}
+
 __attribute__((noinline))
 static void test_wonder_appetite_drift_surface(void) {
     Leo *drift = malloc(sizeof *drift);
@@ -447,6 +522,158 @@ static void test_wonder_appetite_shadow_policy(void) {
           forecast.policy_n == 0,
           "wonder-appetite-policy: ablation leaves no hidden decision");
     g_leo_wonder_appetite_policy_on = previous_policy;
+
+    leo_free(leo);
+    free(leo);
+}
+
+__attribute__((noinline))
+static void test_wonder_appetite_regret_surface(void) {
+    Leo *leo = malloc(sizeof *leo);
+    LeoWonderAppetiteRegret surface;
+    CHECK(leo != NULL,
+          "wonder-appetite-regret: heap fixture allocated");
+    if (!leo) return;
+
+    leo_init(leo);
+    leo_wonder_appetite_regret(leo, &surface);
+    CHECK(surface.scored == 0 &&
+          surface.cells[0].status ==
+              LEO_WONDER_APPETITE_REGRET_EMPTY,
+          "wonder-appetite-regret: an empty diary invents no cost");
+
+    for (int i = 0; i < 3; i++)
+        test_add_appetite_policy_outcome(
+            leo, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    test_add_appetite_policy_outcome(
+        leo, 0.65f, 0,
+        LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+        LEO_WONDER_APPETITE_CALIB_FADED);
+    test_add_appetite_policy_outcome(
+        leo, 0.65f, 0,
+        LEO_WONDER_APPETITE_POLICY_FORMING,
+        LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < 3; i++)
+        test_add_appetite_policy_outcome(
+            leo, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    leo_wonder_appetite_regret(leo, &surface);
+    const LeoWonderAppetiteRegretCell *paired =
+        &surface.cells[0];
+    CHECK(paired->scored == 8 &&
+          paired->eligible == 4 &&
+          paired->abstained == 4 &&
+          paired->supported == 3 &&
+          paired->overreach == 1 &&
+          paired->missed == 1 &&
+          paired->restraint == 3 &&
+          paired->status ==
+              LEO_WONDER_APPETITE_REGRET_PAIRED,
+          "wonder-appetite-regret: paired evidence preserves all four outcomes");
+    CHECK(fabsf(paired->coverage - 0.5f) < 1e-6f &&
+          fabsf(paired->overreach_rate - 0.25f) < 1e-6f &&
+          fabsf(paired->missed_rate - 0.25f) < 1e-6f &&
+          paired->overreach_lower < paired->overreach_rate &&
+          paired->overreach_upper > paired->overreach_rate &&
+          paired->missed_lower < paired->missed_rate &&
+          paired->missed_upper > paired->missed_rate,
+          "wonder-appetite-regret: coverage and both Wilson-bearing costs remain separate");
+
+    for (int i = 0; i < 4; i++)
+        test_add_appetite_policy_outcome(
+            leo, 0.85f, 1,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < 2; i++)
+        test_add_appetite_policy_outcome(
+            leo, 0.85f, 0,
+            LEO_WONDER_APPETITE_POLICY_DRIFTING,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < 2; i++)
+        test_add_appetite_policy_outcome(
+            leo, 0.85f, 0,
+            LEO_WONDER_APPETITE_POLICY_DRIFTING,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    leo_wonder_appetite_regret(leo, &surface);
+    const LeoWonderAppetiteRegretCell *abstention =
+        &surface.cells[2];
+    const LeoWonderAppetiteRegretCell *eligible =
+        &surface.cells[
+            LEO_WONDER_APPETITE_RELIABILITY_BINS + 2];
+    CHECK(abstention->status ==
+              LEO_WONDER_APPETITE_REGRET_ABSTENTION_OBSERVED &&
+          abstention->eligible == 0 &&
+          abstention->abstained == 4 &&
+          abstention->missed == 2 &&
+          abstention->restraint == 2 &&
+          eligible->status ==
+              LEO_WONDER_APPETITE_REGRET_ELIGIBLE_OBSERVED &&
+          eligible->eligible == 4 &&
+          eligible->abstained == 0,
+          "wonder-appetite-regret: spoken and unspoken arms cannot lend each other maturity");
+    CHECK(surface.scored == 16 &&
+          surface.eligible == 8 &&
+          surface.abstained == 8 &&
+          surface.supported == 7 &&
+          surface.overreach == 1 &&
+          surface.missed == 3 &&
+          surface.restraint == 5 &&
+          fabsf(surface.coverage - 0.5f) < 1e-6f &&
+          fabsf(surface.overreach_rate - 0.125f) < 1e-6f &&
+          fabsf(surface.missed_rate - 0.375f) < 1e-6f &&
+          surface.paired_cells == 1 &&
+          surface.eligible_observed_cells == 1 &&
+          surface.abstention_observed_cells == 1,
+          "wonder-appetite-regret: aggregate coverage cannot erase the stratified tradeoff");
+
+    test_add_appetite_policy_outcome(
+        leo, 0.75f, 0,
+        LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+        LEO_WONDER_APPETITE_CALIB_PENDING);
+    test_add_appetite_policy_outcome(
+        leo, 0.75f, 0,
+        LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+        LEO_WONDER_APPETITE_CALIB_EXTERNAL);
+    test_add_appetite_policy_outcome(
+        leo, 0.75f, 0,
+        LEO_WONDER_APPETITE_POLICY_LEGACY,
+        LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    test_add_appetite_policy_outcome(
+        leo, 0.75f, 0,
+        LEO_WONDER_APPETITE_POLICY_NONE,
+        LEO_WONDER_APPETITE_CALIB_FADED);
+    leo_wonder_appetite_regret(leo, &surface);
+    CHECK(surface.scored == 16 &&
+          surface.pending == 1 &&
+          surface.confounded == 1 &&
+          surface.legacy == 1 &&
+          surface.none == 1 &&
+          surface.cells[1].status ==
+              LEO_WONDER_APPETITE_REGRET_EMPTY,
+          "wonder-appetite-regret: pending, confounded, legacy, and ablated lives cannot price policy");
+
+    LeoWonderAppetiteCalibration diary_before =
+        leo->wonder_appetite_calibration;
+    LeoSchool *school_before = malloc(sizeof *school_before);
+    LeoFlow *flow_before = malloc(sizeof *flow_before);
+    if (school_before) *school_before = leo->school;
+    if (flow_before) *flow_before = leo->flow;
+    leo_wonder_appetite_regret(leo, &surface);
+    CHECK(school_before && flow_before &&
+          !memcmp(&diary_before,
+                  &leo->wonder_appetite_calibration,
+                  sizeof diary_before) &&
+          !memcmp(school_before, &leo->school,
+                  sizeof *school_before) &&
+          !memcmp(flow_before, &leo->flow,
+                  sizeof *flow_before) &&
+          LEO_STATE_VERSION == 22,
+          "wonder-appetite-regret: observing cost rewrites no evidence, body, or state format");
+    free(school_before);
+    free(flow_before);
 
     leo_free(leo);
     free(leo);
@@ -2917,6 +3144,7 @@ int main(void) {
      * body already owns a deliberately large stack frame. */
     test_wonder_appetite_drift_surface();
     test_wonder_appetite_shadow_policy();
+    test_wonder_appetite_regret_surface();
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
      * concept-slot; a taught word then returns that glyph (no longer -1); the

--- a/tests/wonder_appetite_regret_fixture.c
+++ b/tests/wonder_appetite_regret_fixture.c
@@ -1,0 +1,125 @@
+#define LEO_NO_MAIN
+#include "../leo.c"
+
+static int add_outcome(
+        Leo *leo, float appetite, int spoken,
+        int policy, int verdict) {
+    LeoWonderAppetiteCalibration *calibration =
+        &leo->wonder_appetite_calibration;
+    if (calibration->n >= LEO_WONDER_APPETITE_CALIB_RING)
+        return 0;
+    int slot = calibration->n;
+    LeoWonderAppetiteCalibrationReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.proposed_turn = (uint64_t)(10 + slot * 4);
+    receipt.deadline_turn =
+        receipt.proposed_turn +
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+    receipt.observed_turn = receipt.deadline_turn;
+    receipt.appetite = appetite;
+    receipt.spoken = spoken ? 1 : 0;
+    receipt.wonder_id = spoken ? (uint64_t)(slot + 1) : 0;
+    receipt.policy = (uint8_t)policy;
+    receipt.verdict = (uint8_t)verdict;
+    receipt.observations = LEO_WONDER_APPETITE_CALIB_HORIZON;
+    snprintf(receipt.word, sizeof receipt.word, "regret%02d", slot);
+
+    if (policy == LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+        receipt.policy_n = LEO_WONDER_APPETITE_DRIFT_MIN_N;
+        receipt.policy_reliability =
+            LEO_WONDER_APPETITE_RELIABILITY_ALIGNED;
+        receipt.policy_drift =
+            LEO_WONDER_APPETITE_DRIFT_STABLE;
+    } else if (
+        policy == LEO_WONDER_APPETITE_POLICY_DRIFTING) {
+        receipt.policy_n = LEO_WONDER_APPETITE_DRIFT_MIN_N;
+        receipt.policy_reliability =
+            LEO_WONDER_APPETITE_RELIABILITY_ALIGNED;
+        receipt.policy_drift =
+            LEO_WONDER_APPETITE_DRIFT_RISING;
+    }
+
+    if (verdict == LEO_WONDER_APPETITE_CALIB_SUSTAINED) {
+        receipt.semantic_hits = 1;
+        receipt.peak_recurrence =
+            LEO_WONDER_APPETITE_RESONANCE_MIN;
+        receipt.brier =
+            (appetite - 1.0f) * (appetite - 1.0f);
+    } else {
+        receipt.brier = appetite * appetite;
+    }
+    if (!leo_wonder_appetite_calibration_valid(
+            &receipt, receipt.observed_turn))
+        return 0;
+
+    calibration->receipts[calibration->ptr] = receipt;
+    calibration->ptr =
+        (calibration->ptr + 1) %
+            LEO_WONDER_APPETITE_CALIB_RING;
+    calibration->n++;
+    leo->school.turn_clock = (long)receipt.observed_turn;
+    return 1;
+}
+
+static int add_n(
+        Leo *leo, int count, float appetite, int spoken,
+        int policy, int verdict) {
+    for (int i = 0; i < count; i++)
+        if (!add_outcome(
+                leo, appetite, spoken, policy, verdict))
+            return 0;
+    return 1;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 3 ||
+        (strcmp(argv[2], "motion-heavy") &&
+         strcmp(argv[2], "restraint-heavy"))) {
+        fprintf(stderr,
+                "usage: %s STATE motion-heavy|restraint-heavy\n",
+                argv[0]);
+        return 2;
+    }
+
+    Leo leo;
+    leo_init(&leo);
+    leo_ingest(
+        &leo,
+        "The rain falls softly. His mother waits by the warm window. "
+        "Leo hears the night and asks what the sea remembers. "
+        "The child watches light move across the room.");
+
+    int motion_heavy = !strcmp(argv[2], "motion-heavy");
+    int ok =
+        add_n(
+            &leo, motion_heavy ? 1 : 3, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(
+            &leo, motion_heavy ? 3 : 1, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_FADED) &&
+        add_n(
+            &leo, motion_heavy ? 1 : 3, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(
+            &leo, motion_heavy ? 3 : 1, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_FADED) &&
+        add_n(
+            &leo, 4, 0.85f, 1,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(
+            &leo, 2, 0.85f, 0,
+            LEO_WONDER_APPETITE_POLICY_DRIFTING,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(
+            &leo, 2, 0.85f, 0,
+            LEO_WONDER_APPETITE_POLICY_DRIFTING,
+            LEO_WONDER_APPETITE_CALIB_FADED) &&
+        leo_save_state(&leo, argv[1]);
+    leo_free(&leo);
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Derive an eight-cell A.49 regret surface from frozen A.48 receipts, with independent Wilson intervals for overreach and missed continuation. Add state-inert process proofs, parser contracts, and the phase record.

Quote: "A missed continuation and an overreach are not the same wound." - Sol

Method: The Arianna Method preserves unlike errors until lived evidence can price each one honestly.