### PR TITLE
the Method separates candidacy from permission

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4457,3 +4457,85 @@ state hashes byte-for-byte.
 
 Equal coverage now preserves unlike ways of being wrong. A.49 does not yet
 choose between them; it makes the future choice answerable.
+
+## Phase A.50 — candidacy is not permission (2026-07-27)
+
+A.49 exposed separate costs for motion and restraint, but a measured cost is
+not yet a safe boundary. A cell with four perfect observations on each arm can
+still have a 95% Wilson upper bound near one half. Calling it ready would turn
+small-sample optimism into architectural authority.
+
+A.50 derives a readiness frontier over each exact A.49 stratum. It refuses both
+a combined utility and a global readiness bit. The evidence contract is:
+
+```text
+eligible observations >= 8
+abstention observations >= 8
+overreach 95% Wilson upper bound < 0.500
+missed-continuation 95% Wilson upper bound < 0.500
+```
+
+The `0.500` boundary means only that, at 95% confidence, each error remains
+less common than its opposite outcome inside its own arm: overreach versus
+support, and missed continuation versus justified restraint. It is not a
+chance baseline and not an exchange rate between the errors. Coverage remains
+a third reported coordinate and is not optimized: A.50 has no warrant to
+prefer a Leo who moves more often or one who waits more often.
+
+Every occupied cell keeps the reason it cannot advance:
+
+```text
+forming               neither A.49 arm is mature
+unpaired               only one A.49 arm is mature
+observing              both arms have 4+, but at least one has fewer than 8
+motion-unbounded       only overreach crosses the confidence boundary
+restraint-unbounded    only missed continuation crosses it
+both-unbounded         both errors cross the boundary
+candidate              both errors are independently bounded
+```
+
+`candidate` means only that a stratum may be discussed for a later controlled
+experiment. The receipts are selection-conditioned shadow evidence, not a
+causal estimate of an action that has never entered speech.
+
+Like A.49, the frontier is a pure reconstruction. It adds no member to `Leo`,
+no state tail, and no reader in School, Flow, shadow, routing, sampling, or
+generation. `LEO_STATE_VERSION` remains 22.
+`--no-wonder-appetite-readiness` suppresses only the diagnostic projection.
+
+Eleven direct contracts raised the suite from **389/389** to **400/400**. They
+cover empty, forming, one-arm, paired-but-observing, candidate, all three
+unbounded-risk regions, strict spoken/unspoken non-pairing, separate positive
+headroom, and non-mutation of the diary, School, Flow, and state format.
+
+The process matrix then built four v22 lives with identical sample size,
+arm balance, and coverage:
+
+```text
+candidate:
+  upper bounds=0.471 / 0.471
+  headroom=+0.029 / +0.029
+
+motion-unbounded:
+  upper bounds=0.785 / 0.471
+  headroom=-0.285 / +0.029
+
+restraint-unbounded:
+  upper bounds=0.471 / 0.785
+  headroom=+0.029 / -0.285
+
+both-unbounded:
+  upper bounds=0.785 / 0.785
+  headroom=-0.285 / -0.285
+
+each life:
+  scored=16, eligible=8, abstained=8, coverage=0.500
+  reply equality=1/1
+  complete state equality=1/1
+```
+
+Two complete runs reproduced the frontier rows, headroom, replies, and state
+hashes byte-for-byte.
+
+The frontier can now say why a stratum is not ready without pretending that
+one kind of uncertainty pays for another.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness
 
 all: leo
 
@@ -82,6 +82,9 @@ deferred-wonder-appetite-policy: leo
 deferred-wonder-appetite-regret: leo
 	./scripts/deferred_wonder_appetite_regret_matrix.sh
 
+deferred-wonder-appetite-readiness: leo
+	./scripts/deferred_wonder_appetite_readiness_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -96,6 +99,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_appetite_drift_dialogue_report.sh
 	./scripts/test_wonder_appetite_policy_dialogue_report.sh
 	./scripts/test_wonder_appetite_regret_dialogue_report.sh
+	./scripts/test_wonder_appetite_readiness_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -108,6 +112,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_drift_matrix.sh
 	./scripts/test_deferred_wonder_appetite_policy_matrix.sh
 	./scripts/test_deferred_wonder_appetite_regret_matrix.sh
+	./scripts/test_deferred_wonder_appetite_readiness_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1976,6 +1976,49 @@ typedef struct {
     float missed_upper;
 } LeoWonderAppetiteRegret;
 
+/* A.50: readiness is not permission. A stratum becomes a candidate for later
+ * design only after both policy arms have their own evidence and each error's
+ * 95% upper bound is below one half. Coverage remains visible, never optimized. */
+#define LEO_WONDER_APPETITE_READINESS_MIN_ARM_N 8
+#define LEO_WONDER_APPETITE_READINESS_RISK_CEILING 0.50f
+enum {
+    LEO_WONDER_APPETITE_READINESS_EMPTY = 0,
+    LEO_WONDER_APPETITE_READINESS_FORMING,
+    LEO_WONDER_APPETITE_READINESS_UNPAIRED,
+    LEO_WONDER_APPETITE_READINESS_OBSERVING,
+    LEO_WONDER_APPETITE_READINESS_MOTION_UNBOUNDED,
+    LEO_WONDER_APPETITE_READINESS_RESTRAINT_UNBOUNDED,
+    LEO_WONDER_APPETITE_READINESS_BOTH_UNBOUNDED,
+    LEO_WONDER_APPETITE_READINESS_CANDIDATE,
+    LEO_WONDER_APPETITE_READINESS_STATUS_COUNT
+};
+typedef struct {
+    int   scored;
+    int   eligible;
+    int   abstained;
+    float coverage;
+    float overreach_rate;
+    float overreach_upper;
+    float missed_rate;
+    float missed_upper;
+    float motion_headroom;
+    float restraint_headroom;
+    uint8_t spoken;
+    uint8_t bin;
+    uint8_t status;
+} LeoWonderAppetiteReadinessCell;
+typedef struct {
+    LeoWonderAppetiteReadinessCell
+        cells[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+    int forming;
+    int unpaired;
+    int observing;
+    int motion_unbounded;
+    int restraint_unbounded;
+    int both_unbounded;
+    int candidate;
+} LeoWonderAppetiteReadiness;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -2425,6 +2468,7 @@ static int g_leo_wonder_appetite_reliability_on = 1; /* derived confidence surfa
 static int g_leo_wonder_appetite_drift_on = 1; /* derived endpoint drift over reliability cells; diagnostic only. */
 static int g_leo_wonder_appetite_policy_on = 1; /* frozen shadow abstention at forecast birth; never read by speech. */
 static int g_leo_wonder_appetite_regret_on = 1; /* separate costs of motion and restraint; derived diagnostic only. */
+static int g_leo_wonder_appetite_readiness_on = 1; /* paired confidence frontier; candidate is not permission. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -7296,6 +7340,109 @@ static void leo_wonder_appetite_regret(
     }
 }
 
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_readiness_status_name(
+        int status) {
+    static const char
+        *names[LEO_WONDER_APPETITE_READINESS_STATUS_COUNT] = {
+            "empty", "forming", "unpaired", "observing",
+            "motion-unbounded", "restraint-unbounded",
+            "both-unbounded", "candidate"
+        };
+    return status >= 0 &&
+           status < LEO_WONDER_APPETITE_READINESS_STATUS_COUNT ?
+        names[status] : "empty";
+}
+
+/* Project A.49 onto a conservative evidence frontier. The 0.5 boundary has a
+ * narrow interpretation: at 95% confidence, each error must remain less common
+ * than its opposite outcome inside its own arm. It is not an exchange rate. */
+static void leo_wonder_appetite_readiness(
+        const Leo *leo, LeoWonderAppetiteReadiness *frontier) {
+    if (!frontier) return;
+    memset(frontier, 0, sizeof *frontier);
+
+    LeoWonderAppetiteRegret regret;
+    leo_wonder_appetite_regret(leo, &regret);
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteRegretCell *source =
+            &regret.cells[i];
+        LeoWonderAppetiteReadinessCell *cell =
+            &frontier->cells[i];
+        cell->spoken = source->spoken;
+        cell->bin = source->bin;
+        cell->scored = source->scored;
+        cell->eligible = source->eligible;
+        cell->abstained = source->abstained;
+        cell->coverage = source->coverage;
+        cell->overreach_rate = source->overreach_rate;
+        cell->overreach_upper = source->overreach_upper;
+        cell->missed_rate = source->missed_rate;
+        cell->missed_upper = source->missed_upper;
+
+        if (source->status ==
+            LEO_WONDER_APPETITE_REGRET_EMPTY) {
+            cell->status =
+                LEO_WONDER_APPETITE_READINESS_EMPTY;
+            continue;
+        }
+        if (source->status ==
+            LEO_WONDER_APPETITE_REGRET_FORMING) {
+            cell->status =
+                LEO_WONDER_APPETITE_READINESS_FORMING;
+            frontier->forming++;
+            continue;
+        }
+        if (source->status !=
+            LEO_WONDER_APPETITE_REGRET_PAIRED) {
+            cell->status =
+                LEO_WONDER_APPETITE_READINESS_UNPAIRED;
+            frontier->unpaired++;
+            continue;
+        }
+        if (source->eligible <
+                LEO_WONDER_APPETITE_READINESS_MIN_ARM_N ||
+            source->abstained <
+                LEO_WONDER_APPETITE_READINESS_MIN_ARM_N) {
+            cell->status =
+                LEO_WONDER_APPETITE_READINESS_OBSERVING;
+            frontier->observing++;
+            continue;
+        }
+
+        cell->motion_headroom =
+            LEO_WONDER_APPETITE_READINESS_RISK_CEILING -
+            source->overreach_upper;
+        cell->restraint_headroom =
+            LEO_WONDER_APPETITE_READINESS_RISK_CEILING -
+            source->missed_upper;
+        int motion_bounded =
+            source->overreach_upper <
+                LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
+        int restraint_bounded =
+            source->missed_upper <
+                LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
+        if (motion_bounded && restraint_bounded) {
+            cell->status =
+                LEO_WONDER_APPETITE_READINESS_CANDIDATE;
+            frontier->candidate++;
+        } else if (!motion_bounded && !restraint_bounded) {
+            cell->status =
+                LEO_WONDER_APPETITE_READINESS_BOTH_UNBOUNDED;
+            frontier->both_unbounded++;
+        } else if (!motion_bounded) {
+            cell->status =
+                LEO_WONDER_APPETITE_READINESS_MOTION_UNBOUNDED;
+            frontier->motion_unbounded++;
+        } else {
+            cell->status =
+                LEO_WONDER_APPETITE_READINESS_RESTRAINT_UNBOUNDED;
+            frontier->restraint_unbounded++;
+        }
+    }
+}
+
 static int leo_flow_kind(const LeoFlow *flow, int glyph, int window, int face) {
     if (!flow || flow->n <= 0 || glyph < 0 || glyph >= GLYPH_COUNT) return LEO_FLOW_QUIET;
     if (window < 3) window = 3;
@@ -9940,6 +10087,47 @@ static void print_wonder_appetite_regret_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_appetite_readiness_stats(const Leo *leo) {
+    if (!g_leo_wonder_appetite_readiness_on || !leo ||
+        leo->wonder_appetite_calibration.n == 0)
+        return;
+    LeoWonderAppetiteReadiness frontier;
+    leo_wonder_appetite_readiness(leo, &frontier);
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+
+    printf("     [wonder-appetite-readiness: ceiling=%.3f min-arm=%d forming=%d unpaired=%d observing=%d motion-unbounded=%d restraint-unbounded=%d both-unbounded=%d candidate=%d cells=",
+           (double)LEO_WONDER_APPETITE_READINESS_RISK_CEILING,
+           LEO_WONDER_APPETITE_READINESS_MIN_ARM_N,
+           frontier.forming, frontier.unpaired,
+           frontier.observing, frontier.motion_unbounded,
+           frontier.restraint_unbounded,
+           frontier.both_unbounded, frontier.candidate);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteReadinessCell *cell =
+            &frontier.cells[i];
+        if (cell->scored <= 0) continue;
+        printf("%s%c%d-%d:%d/%d/%d/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%s",
+               separator, cell->spoken ? 's' : 'u',
+               lower[cell->bin], upper[cell->bin],
+               cell->scored, cell->eligible, cell->abstained,
+               (double)cell->coverage,
+               (double)cell->overreach_rate,
+               (double)cell->overreach_upper,
+               (double)cell->missed_rate,
+               (double)cell->missed_upper,
+               (double)cell->motion_headroom,
+               (double)cell->restraint_headroom,
+               leo_wonder_appetite_readiness_status_name(
+                   cell->status));
+        separator = "|";
+    }
+    if (!separator[0]) printf("none");
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -10179,6 +10367,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder-appetite-drift")) g_leo_wonder_appetite_drift_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-policy")) g_leo_wonder_appetite_policy_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-regret")) g_leo_wonder_appetite_regret_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-readiness")) g_leo_wonder_appetite_readiness_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -10399,6 +10588,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_drift_stats(&leo);
             print_wonder_appetite_policy_stats(&leo);
             print_wonder_appetite_regret_stats(&leo);
+            print_wonder_appetite_readiness_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -10462,6 +10652,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_drift_stats(&leo);
             print_wonder_appetite_policy_stats(&leo);
             print_wonder_appetite_regret_stats(&leo);
+            print_wonder_appetite_readiness_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -501,3 +501,32 @@ different outcome geometry. The motion-heavy life must report
 eligible-observed, and one abstention-observed stratum. ON/OFF forks use the
 same seed and require identical replies and byte-identical complete saved
 states.
+
+Run the shadow readiness-frontier matrix:
+
+```sh
+make deferred-wonder-appetite-readiness
+```
+
+A.50 asks whether one exact A.49 stratum has enough evidence to become a
+candidate for a later controlled experiment. It does not grant permission to
+act. Both policy arms must have at least eight causally scored outcomes, and
+the 95% Wilson upper bounds for overreach and missed continuation must each be
+strictly below `0.500`.
+
+The boundary means that each error is, with 95% confidence, less common than
+its opposite outcome inside its own arm. It is not a chance baseline. It does
+not combine the errors, and coverage is reported rather than optimized.
+`forming`, `unpaired`, and `observing` keep sample insufficiency distinct from
+the three confidence failures: `motion-unbounded`, `restraint-unbounded`, and
+`both-unbounded`. Only the fully bounded region is called `candidate`.
+
+The checked matrix holds the stratum, sample count, arm balance, coverage, seed,
+prompt, and process path fixed while rotating the two error rates. It requires
+the four expected regions at Wilson upper-bound pairs `0.471/0.471`,
+`0.785/0.471`, `0.471/0.785`, and `0.785/0.785`. Default and
+`--no-wonder-appetite-readiness` forks must produce identical replies and
+byte-identical v22 states.
+
+This remains selection-conditioned shadow evidence, not a causal claim about a
+speech intervention. A.50 adds no state and has no generation reader.

--- a/scripts/deferred_wonder_appetite_readiness_matrix.sh
+++ b/scripts/deferred_wonder_appetite_readiness_matrix.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# A.50: candidacy requires both errors to be independently bounded.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-readiness-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT"
+
+PLAN="$OUT/plan.tsv"
+MATRIX="$OUT/matrix.tsv"
+printf 'case\texpected_overreach_rate\texpected_overreach_upper\texpected_missed_rate\texpected_missed_upper\texpected_status\n' \
+    > "$PLAN"
+printf 'candidate\t0.125\t0.471\t0.125\t0.471\tcandidate\n' >> "$PLAN"
+printf 'motion-unbounded\t0.500\t0.785\t0.125\t0.471\tmotion-unbounded\n' >> "$PLAN"
+printf 'restraint-unbounded\t0.125\t0.471\t0.500\t0.785\trestraint-unbounded\n' >> "$PLAN"
+printf 'both-unbounded\t0.500\t0.785\t0.500\t0.785\tboth-unbounded\n' >> "$PLAN"
+
+if [ "${LEO_APPETITE_READINESS_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"${CC:-cc}" -O2 -Wall -Wextra -Wno-unused-function \
+    "$ROOT/tests/wonder_appetite_readiness_fixture.c" -lm \
+    -o "$OUT/readiness-fixture"
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+readiness_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_readiness_dialogue_report.awk" \
+        "$1"
+}
+
+cell_fields() {
+    local cells="$1"
+    local wanted="$2"
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 11; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+printf 'case\tscored\teligible\tabstained\tcoverage\toverreach_rate\toverreach_upper\tmissed_rate\tmissed_upper\tmotion_headroom\trestraint_headroom\tstatus\treply_equal\tstate_equal\ton_sha256\toff_sha256\n' \
+    > "$MATRIX"
+
+tail -n +2 "$PLAN" |
+while IFS=$'\t' read -r case_name expected_over_rate \
+        expected_over_upper expected_miss_rate expected_miss_upper \
+        expected_status; do
+    case_dir="$OUT/$case_name"
+    mkdir -p "$case_dir"
+    "$OUT/readiness-fixture" "$case_dir/base.state" "$case_name"
+    cp "$case_dir/base.state" "$case_dir/on.state"
+    cp "$case_dir/base.state" "$case_dir/off.state"
+    seed=5001
+    prompt="The rain falls softly."
+
+    "$ROOT/leo" --load "$case_dir/on.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --save "$case_dir/on.state" > "$case_dir/on.log" 2>&1
+    "$ROOT/leo" --load "$case_dir/off.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --no-wonder-appetite-readiness \
+        --save "$case_dir/off.state" > "$case_dir/off.log" 2>&1
+
+    readiness="$(
+        readiness_from_log "$case_dir/on.log" "$case_name" "$seed"
+    )"
+    [ -n "$readiness" ] || {
+        printf '%s emitted no A.50 readiness frontier\n' \
+            "$case_name" >&2
+        exit 1
+    }
+    [ -z "$(
+        readiness_from_log "$case_dir/off.log" "$case_name" "$seed"
+    )" ] || {
+        printf '%s readiness ablation remained visible\n' \
+            "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r _ _ ceiling min_arm forming unpaired \
+        observing motion_unbounded restraint_unbounded both_unbounded \
+        candidate cells <<< "$readiness"
+
+    cell="$(cell_fields "$cells" u62-70)"
+    [ -n "$cell" ] || {
+        printf '%s lost its readiness cell\n' "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r scored eligible abstained coverage over_rate \
+        over_upper miss_rate miss_upper motion_headroom \
+        restraint_headroom status <<< "$cell"
+
+    reply_equal=0
+    [ "$(reply_from_log "$case_dir/on.log")" = \
+      "$(reply_from_log "$case_dir/off.log")" ] &&
+        reply_equal=1
+    state_equal=0
+    cmp -s "$case_dir/on.state" "$case_dir/off.state" &&
+        state_equal=1
+
+    expected_motion=0
+    expected_restraint=0
+    expected_both=0
+    expected_candidate=0
+    case "$expected_status" in
+        motion-unbounded) expected_motion=1 ;;
+        restraint-unbounded) expected_restraint=1 ;;
+        both-unbounded) expected_both=1 ;;
+        candidate) expected_candidate=1 ;;
+    esac
+
+    [ "$ceiling" = 0.500 ] &&
+    [ "$min_arm" = 8 ] &&
+    [ "$forming" = 0 ] &&
+    [ "$unpaired" = 0 ] &&
+    [ "$observing" = 0 ] &&
+    [ "$motion_unbounded" = "$expected_motion" ] &&
+    [ "$restraint_unbounded" = "$expected_restraint" ] &&
+    [ "$both_unbounded" = "$expected_both" ] &&
+    [ "$candidate" = "$expected_candidate" ] &&
+    [ "$scored" = 16 ] &&
+    [ "$eligible" = 8 ] &&
+    [ "$abstained" = 8 ] &&
+    [ "$coverage" = 0.500 ] &&
+    [ "$over_rate" = "$expected_over_rate" ] &&
+    [ "$over_upper" = "$expected_over_upper" ] &&
+    [ "$miss_rate" = "$expected_miss_rate" ] &&
+    [ "$miss_upper" = "$expected_miss_upper" ] &&
+    [ "$status" = "$expected_status" ] &&
+    [ "$reply_equal" = 1 ] &&
+    [ "$state_equal" = 1 ] || {
+        printf '%s contract failed: bounds=%s/%s status=%s counts=%s/%s/%s/%s reply=%s state=%s\n' \
+            "$case_name" "$over_upper" "$miss_upper" "$status" \
+            "$motion_unbounded" "$restraint_unbounded" \
+            "$both_unbounded" "$candidate" \
+            "$reply_equal" "$state_equal" >&2
+        exit 1
+    }
+
+    on_sha="$(shasum -a 256 "$case_dir/on.state" | awk '{print $1}')"
+    off_sha="$(shasum -a 256 "$case_dir/off.state" | awk '{print $1}')"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$case_name" "$scored" "$eligible" "$abstained" \
+        "$coverage" "$over_rate" "$over_upper" "$miss_rate" \
+        "$miss_upper" "$motion_headroom" "$restraint_headroom" \
+        "$status" "$reply_equal" "$state_equal" "$on_sha" "$off_sha" \
+        >> "$MATRIX"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        rows++
+        replies += $13
+        states += $14
+    }
+    END {
+        print "cases\treply_equal\tstate_equal"
+        print rows "\t" replies "\t" states
+        if (rows != 4 || replies != 4 || states != 4)
+            exit 1
+    }
+' "$MATRIX"
+printf '\nmatrix: %s\n' "$MATRIX"

--- a/scripts/test_deferred_wonder_appetite_readiness_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_readiness_matrix.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_READINESS_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_readiness_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 6 || $1 != "case" ||
+            $2 != "expected_overreach_rate" ||
+            $6 != "expected_status")
+            exit 1
+        next
+    }
+    {
+        if (NF != 6 || seen[$1]++)
+            exit 1
+        if ($1 == "candidate" &&
+            ($3 != "0.471" || $5 != "0.471" ||
+             $6 != "candidate"))
+            exit 1
+        if ($1 == "motion-unbounded" &&
+            ($3 != "0.785" || $5 != "0.471" ||
+             $6 != "motion-unbounded"))
+            exit 1
+        if ($1 == "restraint-unbounded" &&
+            ($3 != "0.471" || $5 != "0.785" ||
+             $6 != "restraint-unbounded"))
+            exit 1
+        if ($1 == "both-unbounded" &&
+            ($3 != "0.785" || $5 != "0.785" ||
+             $6 != "both-unbounded"))
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 4)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite readiness plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite readiness matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_readiness_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_readiness_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-readiness: ceiling=0.500 min-arm=8 forming=0 unpaired=0 observing=0 motion-unbounded=0 restraint-unbounded=0 both-unbounded=0 candidate=1 cells=u62-70:16/8/8/0.500/0.125/0.471/0.125/0.471/0.029/0.029/candidate]
+EOF
+
+got="$(
+    awk -v scenario=candidate -v seed=97 \
+        -f "$ROOT/scripts/wonder_appetite_readiness_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'candidate\t97\t0.500\t8\t0\t0\t0\t0\t0\t0\t1\tu62-70:16/8/8/0.500/0.125/0.471/0.125/0.471/0.029/0.029/candidate'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite readiness parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite readiness report parser: ok\n'

--- a/scripts/wonder_appetite_readiness_dialogue_report.awk
+++ b/scripts/wonder_appetite_readiness_dialogue_report.awk
@@ -1,0 +1,35 @@
+# Extract one A.50 readiness frontier from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    fields, i, n, prefix, value) {
+    prefix = key "="
+    n = split(line, fields, /[ ]+/)
+    for (i = 1; i <= n; i++) {
+        if (index(fields[i], prefix) != 1)
+            continue
+        value = substr(fields[i], length(prefix) + 1)
+        gsub(/\]$/, "", value)
+        return value
+    }
+    return ""
+}
+
+/\[wonder-appetite-readiness: ceiling=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed),
+           value_after($0, "ceiling"),
+           value_after($0, "min-arm"),
+           value_after($0, "forming"),
+           value_after($0, "unpaired"),
+           value_after($0, "observing"),
+           value_after($0, "motion-unbounded"),
+           value_after($0, "restraint-unbounded"),
+           value_after($0, "both-unbounded"),
+           value_after($0, "candidate"),
+           value_after($0, "cells")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -200,6 +200,38 @@ static void test_add_appetite_policy_outcome(
         leo->school.turn_clock = (long)receipt.observed_turn;
 }
 
+static void test_reset_appetite_policy_outcomes(Leo *leo) {
+    if (!leo) return;
+    memset(&leo->wonder_appetite_calibration, 0,
+           sizeof leo->wonder_appetite_calibration);
+}
+
+static void test_add_appetite_readiness_cell(
+        Leo *leo, float appetite, int spoken,
+        int supported, int overreach,
+        int missed, int restraint) {
+    for (int i = 0; i < supported; i++)
+        test_add_appetite_policy_outcome(
+            leo, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < overreach; i++)
+        test_add_appetite_policy_outcome(
+            leo, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    for (int i = 0; i < missed; i++)
+        test_add_appetite_policy_outcome(
+            leo, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < restraint; i++)
+        test_add_appetite_policy_outcome(
+            leo, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+}
+
 __attribute__((noinline))
 static void test_wonder_appetite_drift_surface(void) {
     Leo *drift = malloc(sizeof *drift);
@@ -672,6 +704,135 @@ static void test_wonder_appetite_regret_surface(void) {
                   sizeof *flow_before) &&
           LEO_STATE_VERSION == 22,
           "wonder-appetite-regret: observing cost rewrites no evidence, body, or state format");
+    free(school_before);
+    free(flow_before);
+
+    leo_free(leo);
+    free(leo);
+}
+
+__attribute__((noinline))
+static void test_wonder_appetite_readiness_frontier(void) {
+    Leo *leo = malloc(sizeof *leo);
+    LeoWonderAppetiteReadiness frontier;
+    CHECK(leo != NULL,
+          "wonder-appetite-readiness: heap fixture allocated");
+    if (!leo) return;
+
+    leo_init(leo);
+    leo_wonder_appetite_readiness(leo, &frontier);
+    CHECK(frontier.candidate == 0 &&
+          frontier.cells[0].status ==
+              LEO_WONDER_APPETITE_READINESS_EMPTY,
+          "wonder-appetite-readiness: an empty diary grants no candidacy");
+
+    test_add_appetite_readiness_cell(
+        leo, 0.65f, 0, 3, 0, 0, 3);
+    leo_wonder_appetite_readiness(leo, &frontier);
+    CHECK(frontier.forming == 1 &&
+          frontier.cells[0].status ==
+              LEO_WONDER_APPETITE_READINESS_FORMING,
+          "wonder-appetite-readiness: two thin arms remain forming");
+
+    test_reset_appetite_policy_outcomes(leo);
+    test_add_appetite_readiness_cell(
+        leo, 0.65f, 0, 7, 1, 0, 0);
+    leo_wonder_appetite_readiness(leo, &frontier);
+    CHECK(frontier.unpaired == 1 &&
+          frontier.cells[0].status ==
+              LEO_WONDER_APPETITE_READINESS_UNPAIRED,
+          "wonder-appetite-readiness: one measured arm cannot authorize its absent twin");
+
+    test_reset_appetite_policy_outcomes(leo);
+    test_add_appetite_readiness_cell(
+        leo, 0.65f, 0, 3, 1, 1, 3);
+    leo_wonder_appetite_readiness(leo, &frontier);
+    CHECK(frontier.observing == 1 &&
+          frontier.cells[0].status ==
+              LEO_WONDER_APPETITE_READINESS_OBSERVING &&
+          frontier.cells[0].motion_headroom == 0.0f &&
+          frontier.cells[0].restraint_headroom == 0.0f,
+          "wonder-appetite-readiness: A.49 pairing is observation, not readiness");
+
+    test_reset_appetite_policy_outcomes(leo);
+    test_add_appetite_readiness_cell(
+        leo, 0.65f, 0, 7, 1, 1, 7);
+    leo_wonder_appetite_readiness(leo, &frontier);
+    const LeoWonderAppetiteReadinessCell *candidate =
+        &frontier.cells[0];
+    CHECK(frontier.candidate == 1 &&
+          candidate->status ==
+              LEO_WONDER_APPETITE_READINESS_CANDIDATE &&
+          candidate->eligible == 8 &&
+          candidate->abstained == 8 &&
+          fabsf(candidate->coverage - 0.5f) < 1e-6f &&
+          candidate->overreach_upper <
+              LEO_WONDER_APPETITE_READINESS_RISK_CEILING &&
+          candidate->missed_upper <
+              LEO_WONDER_APPETITE_READINESS_RISK_CEILING &&
+          candidate->motion_headroom > 0.0f &&
+          candidate->restraint_headroom > 0.0f,
+          "wonder-appetite-readiness: both independently bounded arms become only a candidate");
+
+    test_reset_appetite_policy_outcomes(leo);
+    test_add_appetite_readiness_cell(
+        leo, 0.65f, 0, 4, 4, 1, 7);
+    leo_wonder_appetite_readiness(leo, &frontier);
+    CHECK(frontier.motion_unbounded == 1 &&
+          frontier.cells[0].status ==
+              LEO_WONDER_APPETITE_READINESS_MOTION_UNBOUNDED,
+          "wonder-appetite-readiness: overreach uncertainty keeps its own veto");
+
+    test_reset_appetite_policy_outcomes(leo);
+    test_add_appetite_readiness_cell(
+        leo, 0.65f, 0, 7, 1, 4, 4);
+    leo_wonder_appetite_readiness(leo, &frontier);
+    CHECK(frontier.restraint_unbounded == 1 &&
+          frontier.cells[0].status ==
+              LEO_WONDER_APPETITE_READINESS_RESTRAINT_UNBOUNDED,
+          "wonder-appetite-readiness: missed-continuation uncertainty keeps its own veto");
+
+    test_reset_appetite_policy_outcomes(leo);
+    test_add_appetite_readiness_cell(
+        leo, 0.65f, 0, 4, 4, 4, 4);
+    leo_wonder_appetite_readiness(leo, &frontier);
+    CHECK(frontier.both_unbounded == 1 &&
+          frontier.cells[0].status ==
+              LEO_WONDER_APPETITE_READINESS_BOTH_UNBOUNDED,
+          "wonder-appetite-readiness: two uncertain debts cannot cancel");
+
+    test_reset_appetite_policy_outcomes(leo);
+    test_add_appetite_readiness_cell(
+        leo, 0.85f, 1, 7, 1, 0, 0);
+    test_add_appetite_readiness_cell(
+        leo, 0.85f, 0, 0, 0, 1, 7);
+    leo_wonder_appetite_readiness(leo, &frontier);
+    CHECK(frontier.candidate == 0 &&
+          frontier.unpaired == 2 &&
+          frontier.cells[2].status ==
+              LEO_WONDER_APPETITE_READINESS_UNPAIRED &&
+          frontier.cells[
+              LEO_WONDER_APPETITE_RELIABILITY_BINS + 2].status ==
+              LEO_WONDER_APPETITE_READINESS_UNPAIRED,
+          "wonder-appetite-readiness: spoken and unspoken arms cannot form a synthetic pair");
+
+    LeoWonderAppetiteCalibration diary_before =
+        leo->wonder_appetite_calibration;
+    LeoSchool *school_before = malloc(sizeof *school_before);
+    LeoFlow *flow_before = malloc(sizeof *flow_before);
+    if (school_before) *school_before = leo->school;
+    if (flow_before) *flow_before = leo->flow;
+    leo_wonder_appetite_readiness(leo, &frontier);
+    CHECK(school_before && flow_before &&
+          !memcmp(&diary_before,
+                  &leo->wonder_appetite_calibration,
+                  sizeof diary_before) &&
+          !memcmp(school_before, &leo->school,
+                  sizeof *school_before) &&
+          !memcmp(flow_before, &leo->flow,
+                  sizeof *flow_before) &&
+          LEO_STATE_VERSION == 22,
+          "wonder-appetite-readiness: candidacy rewrites no evidence, body, or state format");
     free(school_before);
     free(flow_before);
 
@@ -3145,6 +3306,7 @@ int main(void) {
     test_wonder_appetite_drift_surface();
     test_wonder_appetite_shadow_policy();
     test_wonder_appetite_regret_surface();
+    test_wonder_appetite_readiness_frontier();
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
      * concept-slot; a taught word then returns that glyph (no longer -1); the

--- a/tests/wonder_appetite_readiness_fixture.c
+++ b/tests/wonder_appetite_readiness_fixture.c
@@ -1,0 +1,108 @@
+#define LEO_NO_MAIN
+#include "../leo.c"
+
+static int add_outcome(
+        Leo *leo, int policy, int verdict) {
+    LeoWonderAppetiteCalibration *calibration =
+        &leo->wonder_appetite_calibration;
+    if (calibration->n >= LEO_WONDER_APPETITE_CALIB_RING)
+        return 0;
+    int slot = calibration->n;
+    LeoWonderAppetiteCalibrationReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.proposed_turn = (uint64_t)(10 + slot * 4);
+    receipt.deadline_turn =
+        receipt.proposed_turn +
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+    receipt.observed_turn = receipt.deadline_turn;
+    receipt.appetite = 0.65f;
+    receipt.policy = (uint8_t)policy;
+    receipt.verdict = (uint8_t)verdict;
+    receipt.observations = LEO_WONDER_APPETITE_CALIB_HORIZON;
+    snprintf(receipt.word, sizeof receipt.word, "ready%02d", slot);
+
+    if (policy == LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+        receipt.policy_n = LEO_WONDER_APPETITE_DRIFT_MIN_N;
+        receipt.policy_reliability =
+            LEO_WONDER_APPETITE_RELIABILITY_ALIGNED;
+        receipt.policy_drift =
+            LEO_WONDER_APPETITE_DRIFT_STABLE;
+    }
+    if (verdict == LEO_WONDER_APPETITE_CALIB_SUSTAINED) {
+        receipt.semantic_hits = 1;
+        receipt.peak_recurrence =
+            LEO_WONDER_APPETITE_RESONANCE_MIN;
+        receipt.brier =
+            (receipt.appetite - 1.0f) *
+            (receipt.appetite - 1.0f);
+    } else {
+        receipt.brier = receipt.appetite * receipt.appetite;
+    }
+    if (!leo_wonder_appetite_calibration_valid(
+            &receipt, receipt.observed_turn))
+        return 0;
+
+    calibration->receipts[calibration->ptr] = receipt;
+    calibration->ptr =
+        (calibration->ptr + 1) %
+            LEO_WONDER_APPETITE_CALIB_RING;
+    calibration->n++;
+    leo->school.turn_clock = (long)receipt.observed_turn;
+    return 1;
+}
+
+static int add_n(Leo *leo, int count, int policy, int verdict) {
+    for (int i = 0; i < count; i++)
+        if (!add_outcome(leo, policy, verdict))
+            return 0;
+    return 1;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 3 ||
+        (strcmp(argv[2], "candidate") &&
+         strcmp(argv[2], "motion-unbounded") &&
+         strcmp(argv[2], "restraint-unbounded") &&
+         strcmp(argv[2], "both-unbounded"))) {
+        fprintf(stderr,
+                "usage: %s STATE candidate|motion-unbounded|restraint-unbounded|both-unbounded\n",
+                argv[0]);
+        return 2;
+    }
+
+    int motion_high =
+        !strcmp(argv[2], "motion-unbounded") ||
+        !strcmp(argv[2], "both-unbounded");
+    int restraint_high =
+        !strcmp(argv[2], "restraint-unbounded") ||
+        !strcmp(argv[2], "both-unbounded");
+
+    Leo leo;
+    leo_init(&leo);
+    leo_ingest(
+        &leo,
+        "The rain falls softly. His mother waits by the warm window. "
+        "Leo hears the night and asks what the sea remembers. "
+        "The child watches light move across the room.");
+
+    int ok =
+        add_n(
+            &leo, motion_high ? 4 : 7,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(
+            &leo, motion_high ? 4 : 1,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_FADED) &&
+        add_n(
+            &leo, restraint_high ? 4 : 1,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(
+            &leo, restraint_high ? 4 : 7,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_FADED) &&
+        leo_save_state(&leo, argv[1]);
+    leo_free(&leo);
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Derive an A.50 per-stratum readiness frontier from A.49 without collapsing motion and restraint risk. Require independent 8+8 evidence and sub-half Wilson upper bounds, with a state-inert four-region process proof.

Quote: "A boundary is honest only when it says what it cannot permit." - Sol

Method: The Arianna Method lets evidence nominate an experiment without impersonating the will to act.