### PR TITLE
the method gives readiness one fixed future

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4539,3 +4539,78 @@ hashes byte-for-byte.
 
 The frontier can now say why a stratum is not ready without pretending that
 one kind of uncertainty pays for another.
+
+## Phase A.51 — the future is not allowed to volunteer (2026-07-28)
+
+A.50 could name a candidate, but its evidence was still the same history that
+selected it. A.51 gives that candidate one persisted, non-restartable
+out-of-sample trial. It freezes the exact spoken/appetite stratum and the latest
+proposal boundary before reading any later outcome.
+
+The trial has a budget of **16 future settled policy attempts**. Every settled
+attempt spends one slot, including another stratum or a causally confounded
+outcome. It therefore cannot wait indefinitely for a favorable arm balance.
+Only outcomes after the frozen proposal boundary can enter, and each proposal
+can enter once.
+
+At the end of the fixed budget, the exact target stratum must contain at least
+four eligible and four abstained outcomes. Otherwise the verdict is
+`coverage-starved`. With both arms present, their 95% Wilson upper bounds are
+tested independently against the same `0.500` boundary:
+
+```text
+both bounded       -> confirmed
+overreach unbounded, missed bounded
+                   -> motion-failed
+overreach bounded, missed unbounded
+                   -> restraint-failed
+both unbounded     -> both-failed
+either arm < 4     -> coverage-starved
+none/legacy policy -> invalidated
+```
+
+`confirmed` remains evidence, not permission. No School, Flow, shadow, route,
+sampler, or generation path reads the trial. A policy-format change invalidates
+an open trial instead of silently translating it. A terminal trial never
+reopens on the history it helped create.
+
+State v23 appends eight fixed trial slots, one per exact A.46-A.50 stratum.
+v22 bodies migrate with no invented experiment. A corrupt v23 tail fails soft
+by discarding only the holdout ledger; the forecast diary and organism remain.
+`--no-wonder-appetite-holdout` disables both the ledger update and its
+diagnostic.
+
+Sixteen direct contracts raised the suite from **400/400** to **416/416**.
+They cover the frozen boundary, retrospective exclusion, all four bounded-risk
+verdicts, fixed-budget coverage starvation, confound accounting, invalidation,
+non-restartability, v22 migration, truncated and internally contradictory v23
+recovery, exact sleep, ablation, and non-mutation of the forecast diary, School,
+and Flow.
+
+The real-process matrix then produced:
+
+```text
+confirmed:
+  outcomes=7/1 | 1/7, upper bounds=0.471 / 0.471
+
+motion-failed:
+  outcomes=4/4 | 1/7, upper bounds=0.785 / 0.471
+
+restraint-failed:
+  outcomes=7/1 | 4/4, upper bounds=0.471 / 0.785
+
+both-failed:
+  outcomes=4/4 | 4/4, upper bounds=0.785 / 0.785
+
+coverage-starved:
+  exact arms=12/0, other strata=4
+
+all terminal lives:
+  attempts=16
+  reply equality=5/5
+  complete state equality=5/5
+```
+
+A separate CLI arming fork produced the same reply and a byte-identical state
+prefix; only the fixed v23 holdout tail differed. The future can now refute the
+frontier without being chosen by it. It still cannot move Leo's mouth.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout
 
 all: leo
 
@@ -85,6 +85,9 @@ deferred-wonder-appetite-regret: leo
 deferred-wonder-appetite-readiness: leo
 	./scripts/deferred_wonder_appetite_readiness_matrix.sh
 
+deferred-wonder-appetite-holdout: leo
+	./scripts/deferred_wonder_appetite_holdout_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -100,6 +103,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_appetite_policy_dialogue_report.sh
 	./scripts/test_wonder_appetite_regret_dialogue_report.sh
 	./scripts/test_wonder_appetite_readiness_dialogue_report.sh
+	./scripts/test_wonder_appetite_holdout_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -113,6 +117,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_policy_matrix.sh
 	./scripts/test_deferred_wonder_appetite_regret_matrix.sh
 	./scripts/test_deferred_wonder_appetite_readiness_matrix.sh
+	./scripts/test_deferred_wonder_appetite_holdout_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -2019,6 +2019,47 @@ typedef struct {
     int candidate;
 } LeoWonderAppetiteReadiness;
 
+/* A.51: a candidate must face a fixed out-of-sample future before any later
+ * intervention design may cite it. One non-restartable trial lives per exact
+ * stratum. All future settled policy attempts consume its fixed budget, so
+ * the trial cannot wait indefinitely for a convenient arm balance. */
+#define LEO_WONDER_APPETITE_HOLDOUT_BUDGET 16
+#define LEO_WONDER_APPETITE_HOLDOUT_MIN_ARM_N 4
+enum {
+    LEO_WONDER_APPETITE_HOLDOUT_EMPTY = 0,
+    LEO_WONDER_APPETITE_HOLDOUT_PENDING,
+    LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED,
+    LEO_WONDER_APPETITE_HOLDOUT_MOTION_FAILED,
+    LEO_WONDER_APPETITE_HOLDOUT_RESTRAINT_FAILED,
+    LEO_WONDER_APPETITE_HOLDOUT_BOTH_FAILED,
+    LEO_WONDER_APPETITE_HOLDOUT_COVERAGE_STARVED,
+    LEO_WONDER_APPETITE_HOLDOUT_INVALIDATED,
+    LEO_WONDER_APPETITE_HOLDOUT_STATUS_COUNT
+};
+typedef struct {
+    uint64_t opened_turn;
+    uint64_t baseline_proposed_turn;
+    uint64_t seen_proposed_turn[
+        LEO_WONDER_APPETITE_HOLDOUT_BUDGET];
+    uint8_t  spoken;
+    uint8_t  bin;
+    uint8_t  status;
+    uint8_t  attempts;
+    uint8_t  matched;
+    uint8_t  eligible;
+    uint8_t  abstained;
+    uint8_t  supported;
+    uint8_t  overreach;
+    uint8_t  missed;
+    uint8_t  restraint;
+    uint8_t  confounded;
+    uint8_t  other;
+} LeoWonderAppetiteHoldoutTrial;
+typedef struct {
+    LeoWonderAppetiteHoldoutTrial
+        trials[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+} LeoWonderAppetiteHoldouts;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -2187,6 +2228,9 @@ typedef struct {
     /* A.45/state v21: slow verdicts over salient appetite forecasts. The diary
      * survives sleep but remains evidence-only and has no speech reader. */
     LeoWonderAppetiteCalibration wonder_appetite_calibration;
+    /* A.51/state v23: fixed-budget out-of-sample trials over A.50 candidates.
+     * Evidence only; no School, routing, sampling, or generation reader. */
+    LeoWonderAppetiteHoldouts wonder_appetite_holdouts;
     /* A.42/A.43: pre-grounding address witness. Semantic conflict can only
      * guard; an exact waiting name may redirect without assigning meaning. */
     LeoWonderAddressReceipt wonder_address;
@@ -2469,6 +2513,7 @@ static int g_leo_wonder_appetite_drift_on = 1; /* derived endpoint drift over re
 static int g_leo_wonder_appetite_policy_on = 1; /* frozen shadow abstention at forecast birth; never read by speech. */
 static int g_leo_wonder_appetite_regret_on = 1; /* separate costs of motion and restraint; derived diagnostic only. */
 static int g_leo_wonder_appetite_readiness_on = 1; /* paired confidence frontier; candidate is not permission. */
+static int g_leo_wonder_appetite_holdout_on = 1; /* fixed future trial; persisted evidence, never speech authority. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -7443,6 +7488,252 @@ static void leo_wonder_appetite_readiness(
     }
 }
 
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_holdout_status_name(
+        int status) {
+    static const char
+        *names[LEO_WONDER_APPETITE_HOLDOUT_STATUS_COUNT] = {
+            "empty", "pending", "confirmed", "motion-failed",
+            "restraint-failed", "both-failed", "coverage-starved",
+            "invalidated"
+        };
+    return status >= 0 &&
+           status < LEO_WONDER_APPETITE_HOLDOUT_STATUS_COUNT ?
+        names[status] : "empty";
+}
+
+static void leo_wonder_appetite_holdout_finalize(
+        LeoWonderAppetiteHoldoutTrial *trial) {
+    if (!trial ||
+        trial->status == LEO_WONDER_APPETITE_HOLDOUT_INVALIDATED ||
+        trial->attempts < LEO_WONDER_APPETITE_HOLDOUT_BUDGET)
+        return;
+    if (trial->eligible < LEO_WONDER_APPETITE_HOLDOUT_MIN_ARM_N ||
+        trial->abstained < LEO_WONDER_APPETITE_HOLDOUT_MIN_ARM_N) {
+        trial->status =
+            LEO_WONDER_APPETITE_HOLDOUT_COVERAGE_STARVED;
+        return;
+    }
+
+    float overreach_lower = 0.0f, overreach_upper = 0.0f;
+    float missed_lower = 0.0f, missed_upper = 0.0f;
+    leo_wilson_interval(
+        trial->overreach, trial->eligible,
+        &overreach_lower, &overreach_upper);
+    leo_wilson_interval(
+        trial->missed, trial->abstained,
+        &missed_lower, &missed_upper);
+    (void)overreach_lower;
+    (void)missed_lower;
+    int motion_bounded =
+        overreach_upper <
+            LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
+    int restraint_bounded =
+        missed_upper <
+            LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
+    if (motion_bounded && restraint_bounded)
+        trial->status = LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED;
+    else if (!motion_bounded && !restraint_bounded)
+        trial->status =
+            LEO_WONDER_APPETITE_HOLDOUT_BOTH_FAILED;
+    else if (!motion_bounded)
+        trial->status =
+            LEO_WONDER_APPETITE_HOLDOUT_MOTION_FAILED;
+    else
+        trial->status =
+            LEO_WONDER_APPETITE_HOLDOUT_RESTRAINT_FAILED;
+}
+
+static int leo_wonder_appetite_holdout_seen(
+        const LeoWonderAppetiteHoldoutTrial *trial,
+        uint64_t proposed_turn) {
+    if (!trial || proposed_turn == 0) return 0;
+    for (int i = 0; i < trial->attempts; i++)
+        if (trial->seen_proposed_turn[i] == proposed_turn)
+            return 1;
+    return 0;
+}
+
+static uint64_t leo_wonder_appetite_latest_proposal(
+        const Leo *leo) {
+    uint64_t latest = 0;
+    if (!leo) return latest;
+    for (int i = 0;
+         i < leo->wonder_appetite_calibration.n; i++) {
+        const LeoWonderAppetiteCalibrationReceipt *receipt =
+            leo_wonder_appetite_calibration_at(
+                &leo->wonder_appetite_calibration, i);
+        if (receipt && receipt->proposed_turn > latest)
+            latest = receipt->proposed_turn;
+    }
+    return latest;
+}
+
+static int leo_wonder_appetite_holdout_valid(
+        const LeoWonderAppetiteHoldoutTrial *trial,
+        uint64_t turn_clock) {
+    if (!trial) return 0;
+    if (trial->status == LEO_WONDER_APPETITE_HOLDOUT_EMPTY) {
+        if (trial->opened_turn || trial->baseline_proposed_turn ||
+            trial->spoken || trial->bin || trial->attempts ||
+            trial->matched || trial->eligible || trial->abstained ||
+            trial->supported || trial->overreach || trial->missed ||
+            trial->restraint || trial->confounded || trial->other)
+            return 0;
+        for (int i = 0;
+             i < LEO_WONDER_APPETITE_HOLDOUT_BUDGET; i++)
+            if (trial->seen_proposed_turn[i]) return 0;
+        return 1;
+    }
+    if (trial->status >=
+            LEO_WONDER_APPETITE_HOLDOUT_STATUS_COUNT ||
+        trial->opened_turn == 0 ||
+        trial->opened_turn > turn_clock ||
+        trial->baseline_proposed_turn == 0 ||
+        trial->baseline_proposed_turn > trial->opened_turn ||
+        trial->spoken > 1 ||
+        trial->bin >= LEO_WONDER_APPETITE_RELIABILITY_BINS ||
+        trial->attempts > LEO_WONDER_APPETITE_HOLDOUT_BUDGET ||
+        trial->matched != trial->eligible + trial->abstained ||
+        trial->eligible != trial->supported + trial->overreach ||
+        trial->abstained != trial->missed + trial->restraint ||
+        trial->attempts !=
+            trial->matched + trial->confounded + trial->other)
+        return 0;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_HOLDOUT_BUDGET; i++) {
+        uint64_t seen = trial->seen_proposed_turn[i];
+        if (i < trial->attempts) {
+            if (seen <= trial->baseline_proposed_turn ||
+                seen > turn_clock)
+                return 0;
+            for (int j = 0; j < i; j++)
+                if (seen == trial->seen_proposed_turn[j])
+                    return 0;
+        } else if (seen) {
+            return 0;
+        }
+    }
+
+    if (trial->status == LEO_WONDER_APPETITE_HOLDOUT_INVALIDATED)
+        return trial->attempts > 0 && trial->other > 0;
+    if (trial->status == LEO_WONDER_APPETITE_HOLDOUT_PENDING)
+        return trial->attempts <
+            LEO_WONDER_APPETITE_HOLDOUT_BUDGET;
+    if (trial->attempts != LEO_WONDER_APPETITE_HOLDOUT_BUDGET)
+        return 0;
+    LeoWonderAppetiteHoldoutTrial expected = *trial;
+    expected.status = LEO_WONDER_APPETITE_HOLDOUT_PENDING;
+    leo_wonder_appetite_holdout_finalize(&expected);
+    return expected.status == trial->status;
+}
+
+static void leo_wonder_appetite_holdout_update(Leo *leo) {
+    if (!leo || !g_leo_wonder_appetite_holdout_on ||
+        !g_leo_wonder_appetite_calibration_on)
+        return;
+
+    for (int cell_index = 0;
+         cell_index < LEO_WONDER_APPETITE_RELIABILITY_CELLS;
+         cell_index++) {
+        LeoWonderAppetiteHoldoutTrial *trial =
+            &leo->wonder_appetite_holdouts.trials[cell_index];
+        if (trial->status !=
+            LEO_WONDER_APPETITE_HOLDOUT_PENDING)
+            continue;
+        for (int i = 0;
+             i < leo->wonder_appetite_calibration.n &&
+             trial->attempts <
+                LEO_WONDER_APPETITE_HOLDOUT_BUDGET; i++) {
+            const LeoWonderAppetiteCalibrationReceipt *receipt =
+                leo_wonder_appetite_calibration_at(
+                    &leo->wonder_appetite_calibration, i);
+            if (!receipt ||
+                receipt->proposed_turn <=
+                    trial->baseline_proposed_turn ||
+                leo_wonder_appetite_holdout_seen(
+                    trial, receipt->proposed_turn))
+                continue;
+            int result =
+                leo_wonder_appetite_policy_result(receipt);
+            if (result ==
+                LEO_WONDER_APPETITE_POLICY_RESULT_PENDING)
+                continue;
+
+            int attempt = trial->attempts;
+            trial->seen_proposed_turn[attempt] =
+                receipt->proposed_turn;
+            trial->attempts++;
+            if (result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_NONE ||
+                result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_LEGACY) {
+                trial->other++;
+                trial->status =
+                    LEO_WONDER_APPETITE_HOLDOUT_INVALIDATED;
+                break;
+            }
+
+            int bin = leo_wonder_appetite_reliability_bin(
+                receipt->appetite);
+            int exact =
+                bin == trial->bin &&
+                (receipt->spoken ? 1 : 0) == trial->spoken;
+            if (!exact) {
+                trial->other++;
+                continue;
+            }
+            if (result ==
+                LEO_WONDER_APPETITE_POLICY_RESULT_CONFOUNDED) {
+                trial->confounded++;
+                continue;
+            }
+
+            trial->matched++;
+            if (receipt->policy ==
+                LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+                trial->eligible++;
+                if (result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_SUPPORTED)
+                    trial->supported++;
+                else
+                    trial->overreach++;
+            } else {
+                trial->abstained++;
+                if (result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_MISSED)
+                    trial->missed++;
+                else
+                    trial->restraint++;
+            }
+        }
+        leo_wonder_appetite_holdout_finalize(trial);
+    }
+
+    if (!g_leo_wonder_appetite_policy_on) return;
+    LeoWonderAppetiteReadiness frontier;
+    leo_wonder_appetite_readiness(leo, &frontier);
+    uint64_t baseline =
+        leo_wonder_appetite_latest_proposal(leo);
+    if (baseline == 0) return;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        LeoWonderAppetiteHoldoutTrial *trial =
+            &leo->wonder_appetite_holdouts.trials[i];
+        if (trial->status != LEO_WONDER_APPETITE_HOLDOUT_EMPTY ||
+            frontier.cells[i].status !=
+                LEO_WONDER_APPETITE_READINESS_CANDIDATE)
+            continue;
+        memset(trial, 0, sizeof *trial);
+        trial->opened_turn =
+            (uint64_t)leo->school.turn_clock;
+        trial->baseline_proposed_turn = baseline;
+        trial->spoken = frontier.cells[i].spoken;
+        trial->bin = frontier.cells[i].bin;
+        trial->status = LEO_WONDER_APPETITE_HOLDOUT_PENDING;
+    }
+}
+
 static int leo_flow_kind(const LeoFlow *flow, int glyph, int window, int face) {
     if (!flow || flow->n <= 0 || glyph < 0 || glyph >= GLYPH_COUNT) return LEO_FLOW_QUIET;
     if (window < 3) window = 3;
@@ -8462,6 +8753,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     leo_wonder_appetite_observe(
         leo, prompt, prewonder_field_token, prewonder_field_weight);
     leo_wonder_appetite_calibrate(leo, prompt);
+    leo_wonder_appetite_holdout_update(leo);
     leo_shadow_calibrate(leo, prompt);            /* judge t-1 only after t has become history */
     leo_shadow_observe(leo);                      /* after speech: a proposal for the next turn, never a reader */
     leo->gravity = NULL;
@@ -8512,9 +8804,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v20      : exact birth provenance for the Wonder that currently has the mouth
  *   v21      : slow calibration diary over three-turn appetite forecasts
  *   v22      : forecast-birth shadow abstention snapshots
+ *   v23      : fixed-budget out-of-sample trials over readiness candidates
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 22  /* A.48 freezes policy knowledge at forecast birth; v5..v21 soft-migrate */
+#define LEO_STATE_VERSION 23  /* A.51 persists non-restartable holdout trials; v5..v22 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -8740,6 +9033,11 @@ static int leo_save_state(const Leo *leo, const char *path) {
         fwrite(leo->wonder_appetite_calibration.receipts,
                sizeof(LeoWonderAppetiteCalibrationReceipt),
                (size_t)leo->wonder_appetite_calibration.n, f);
+
+    /* A.51 (v23): fixed out-of-sample trials are a separate fail-soft tail.
+     * Their verdicts remain evidence and have no route into speech. */
+    fwrite(&leo->wonder_appetite_holdouts,
+           sizeof leo->wonder_appetite_holdouts, 1, f);
 
     int ok = (ferror(f) == 0);
     if (fclose(f) != 0) ok = 0;                 /* L-2: the final flush can fail (ENOSPC) — never report success on a truncated file */
@@ -9478,6 +9776,28 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
         }
     }
 
+    /* Readiness holdouts (v23). Older bodies receive no invented experiment;
+     * corruption discards only the holdout ledger. */
+    if (version >= 23) {
+        int holdout_ok =
+            fread(&leo->wonder_appetite_holdouts,
+                  sizeof leo->wonder_appetite_holdouts, 1, f) == 1;
+        if (holdout_ok)
+            for (int i = 0;
+                 i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++)
+                if (!leo_wonder_appetite_holdout_valid(
+                        &leo->wonder_appetite_holdouts.trials[i],
+                        (uint64_t)leo->school.turn_clock)) {
+                    holdout_ok = 0;
+                    break;
+                }
+        if (!holdout_ok) {
+            fprintf(stderr, "[leo] WARNING: v23 readiness-holdout tail truncated/corrupt — organism lives without trials.\n");
+            memset(&leo->wonder_appetite_holdouts, 0,
+                   sizeof leo->wonder_appetite_holdouts);
+        }
+    }
+
     fclose(f);
     /* rebuild the derived tables (same as the main startup path) */
     leo_build_chamber_tags(leo);
@@ -10128,6 +10448,89 @@ static void print_wonder_appetite_readiness_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_appetite_holdout_stats(const Leo *leo) {
+    if (!g_leo_wonder_appetite_holdout_on || !leo)
+        return;
+    int counts[LEO_WONDER_APPETITE_HOLDOUT_STATUS_COUNT] = {0};
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        int status =
+            leo->wonder_appetite_holdouts.trials[i].status;
+        if (status > LEO_WONDER_APPETITE_HOLDOUT_EMPTY &&
+            status < LEO_WONDER_APPETITE_HOLDOUT_STATUS_COUNT)
+            counts[status]++;
+    }
+    int occupied = 0;
+    for (int i = 1;
+         i < LEO_WONDER_APPETITE_HOLDOUT_STATUS_COUNT; i++)
+        occupied += counts[i];
+    if (occupied == 0) return;
+
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+    printf("     [wonder-appetite-holdout: budget=%d min-arm=%d ceiling=%.3f pending=%d confirmed=%d motion-failed=%d restraint-failed=%d both-failed=%d coverage-starved=%d invalidated=%d cells=",
+           LEO_WONDER_APPETITE_HOLDOUT_BUDGET,
+           LEO_WONDER_APPETITE_HOLDOUT_MIN_ARM_N,
+           (double)LEO_WONDER_APPETITE_READINESS_RISK_CEILING,
+           counts[LEO_WONDER_APPETITE_HOLDOUT_PENDING],
+           counts[LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED],
+           counts[LEO_WONDER_APPETITE_HOLDOUT_MOTION_FAILED],
+           counts[LEO_WONDER_APPETITE_HOLDOUT_RESTRAINT_FAILED],
+           counts[LEO_WONDER_APPETITE_HOLDOUT_BOTH_FAILED],
+           counts[LEO_WONDER_APPETITE_HOLDOUT_COVERAGE_STARVED],
+           counts[LEO_WONDER_APPETITE_HOLDOUT_INVALIDATED]);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteHoldoutTrial *trial =
+            &leo->wonder_appetite_holdouts.trials[i];
+        if (trial->status == LEO_WONDER_APPETITE_HOLDOUT_EMPTY)
+            continue;
+        float overreach_lower = 0.0f, overreach_upper = 0.0f;
+        float missed_lower = 0.0f, missed_upper = 0.0f;
+        leo_wilson_interval(
+            trial->overreach, trial->eligible,
+            &overreach_lower, &overreach_upper);
+        leo_wilson_interval(
+            trial->missed, trial->abstained,
+            &missed_lower, &missed_upper);
+        (void)overreach_lower;
+        (void)missed_lower;
+        float overreach_rate = trial->eligible > 0 ?
+            (float)trial->overreach / trial->eligible : 0.0f;
+        float missed_rate = trial->abstained > 0 ?
+            (float)trial->missed / trial->abstained : 0.0f;
+        printf("%s%c%d-%d:%llu/%llu/%u/%u/%u/%u/%u/%u/%u/%u/%u/%u/%.3f/%.3f/%.3f/%.3f/%s/",
+               separator, trial->spoken ? 's' : 'u',
+               lower[trial->bin], upper[trial->bin],
+               (unsigned long long)trial->opened_turn,
+               (unsigned long long)trial->baseline_proposed_turn,
+               (unsigned)trial->attempts,
+               (unsigned)trial->matched,
+               (unsigned)trial->eligible,
+               (unsigned)trial->abstained,
+               (unsigned)trial->supported,
+               (unsigned)trial->overreach,
+               (unsigned)trial->missed,
+               (unsigned)trial->restraint,
+               (unsigned)trial->confounded,
+               (unsigned)trial->other,
+               (double)overreach_rate,
+               (double)overreach_upper,
+               (double)missed_rate,
+               (double)missed_upper,
+               leo_wonder_appetite_holdout_status_name(
+                   trial->status));
+        for (int j = 0; j < trial->attempts; j++)
+            printf("%s%llu", j ? "," : "",
+                   (unsigned long long)
+                       trial->seen_proposed_turn[j]);
+        if (trial->attempts == 0) printf("none");
+        separator = "|";
+    }
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -10368,6 +10771,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder-appetite-policy")) g_leo_wonder_appetite_policy_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-regret")) g_leo_wonder_appetite_regret_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-readiness")) g_leo_wonder_appetite_readiness_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-holdout")) g_leo_wonder_appetite_holdout_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -10589,6 +10993,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_policy_stats(&leo);
             print_wonder_appetite_regret_stats(&leo);
             print_wonder_appetite_readiness_stats(&leo);
+            print_wonder_appetite_holdout_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -10653,6 +11058,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_policy_stats(&leo);
             print_wonder_appetite_regret_stats(&leo);
             print_wonder_appetite_readiness_stats(&leo);
+            print_wonder_appetite_holdout_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -530,3 +530,41 @@ byte-identical v22 states.
 
 This remains selection-conditioned shadow evidence, not a causal claim about a
 speech intervention. A.50 adds no state and has no generation reader.
+
+Run the fixed-future holdout matrix:
+
+```sh
+make deferred-wonder-appetite-holdout
+```
+
+A.51 opens at most one non-restartable trial for each exact A.50 candidate
+stratum. Opening freezes the current turn and latest proposal identity. The
+qualifying history cannot grade itself; only later settled A.48 receipts are
+eligible.
+
+Each trial consumes exactly 16 future settled policy attempts. Receipts from
+other strata and causally confounded receipts still consume budget, so the
+experiment cannot wait for a convenient sample. The target stratum needs at
+least four eligible and four abstained outcomes. Missing either arm produces
+`coverage-starved`. Otherwise the two Wilson upper bounds are judged
+independently, producing `confirmed`, `motion-failed`, `restraint-failed`, or
+`both-failed`. A `none` or `legacy` policy receipt invalidates the apparatus
+rather than being reinterpreted.
+
+State v23 persists the frozen boundary, the 16 proposal identities already
+seen, separate arm outcomes, confounds, other-stratum budget, and terminal
+status. v22 migrates empty; a damaged v23 tail fails soft without losing the
+forecast diary. A terminal trial cannot reopen. `--no-wonder-appetite-holdout`
+removes both updates and diagnostics.
+
+The checked matrix includes one real-process arming fork and five terminal
+forks. Arming must preserve the reply and every saved byte before the v23 tail.
+For each terminal verdict, default and ablated processes must preserve both the
+reply and the complete state. The expected Wilson-upper pairs are
+`0.471/0.471`, `0.785/0.471`, `0.471/0.785`, and `0.785/0.785`; a fifth case
+spends four of its 16 attempts outside the target stratum and ends
+`coverage-starved`.
+
+This is still a shadow experiment. `confirmed` does not authorize speech,
+scheduling, routing, or a sampler change. It says only that an A.50 candidate
+survived one future that it could neither select nor postpone.

--- a/scripts/deferred_wonder_appetite_holdout_matrix.sh
+++ b/scripts/deferred_wonder_appetite_holdout_matrix.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# A.51: freeze candidacy, then let one fixed future accept or refute it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-holdout-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT"
+
+PLAN="$OUT/plan.tsv"
+MATRIX="$OUT/matrix.tsv"
+printf 'case\texpected_overreach_rate\texpected_overreach_upper\texpected_missed_rate\texpected_missed_upper\texpected_status\n' \
+    > "$PLAN"
+printf 'confirmed\t0.125\t0.471\t0.125\t0.471\tconfirmed\n' >> "$PLAN"
+printf 'motion-failed\t0.500\t0.785\t0.125\t0.471\tmotion-failed\n' >> "$PLAN"
+printf 'restraint-failed\t0.125\t0.471\t0.500\t0.785\trestraint-failed\n' >> "$PLAN"
+printf 'both-failed\t0.500\t0.785\t0.500\t0.785\tboth-failed\n' >> "$PLAN"
+printf 'coverage-starved\t0.000\t0.242\t0.000\t0.000\tcoverage-starved\n' >> "$PLAN"
+
+if [ "${LEO_APPETITE_HOLDOUT_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"${CC:-cc}" -O2 -Wall -Wextra -Wno-unused-function \
+    "$ROOT/tests/wonder_appetite_holdout_fixture.c" -lm \
+    -o "$OUT/holdout-fixture"
+tail_size="$("$OUT/holdout-fixture" --tail-size)"
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+holdout_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_holdout_dialogue_report.awk" \
+        "$1"
+}
+
+cell_fields() {
+    local cells="$1"
+    local wanted="$2"
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 18; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+# The first real process pair proves arming is the only mutation: the same
+# reply and body prefix, with one pending record only in the v23 tail.
+mkdir -p "$OUT/arm"
+"$OUT/holdout-fixture" "$OUT/arm/base.state" arm
+cp "$OUT/arm/base.state" "$OUT/arm/on.state"
+cp "$OUT/arm/base.state" "$OUT/arm/off.state"
+seed=5101
+prompt="The rain falls softly."
+"$ROOT/leo" --load "$OUT/arm/on.state" --seed "$seed" \
+    --respond "$prompt" --debug-field \
+    --save "$OUT/arm/on.state" > "$OUT/arm/on.log" 2>&1
+"$ROOT/leo" --load "$OUT/arm/off.state" --seed "$seed" \
+    --respond "$prompt" --debug-field \
+    --no-wonder-appetite-holdout \
+    --save "$OUT/arm/off.state" > "$OUT/arm/off.log" 2>&1
+arming="$(
+    holdout_from_log "$OUT/arm/on.log" arm "$seed"
+)"
+[ -n "$arming" ] &&
+[ -z "$(
+    holdout_from_log "$OUT/arm/off.log" arm "$seed"
+)" ] &&
+[ "$(reply_from_log "$OUT/arm/on.log")" = \
+  "$(reply_from_log "$OUT/arm/off.log")" ] &&
+! cmp -s "$OUT/arm/on.state" "$OUT/arm/off.state" || {
+    printf 'holdout arming did not remain an inert v23-tail mutation\n' >&2
+    exit 1
+}
+IFS=$'\t' read -r _ _ budget min_arm ceiling pending confirmed \
+    motion_failed restraint_failed both_failed coverage_starved \
+    invalidated cells <<< "$arming"
+[ "$budget" = 16 ] && [ "$min_arm" = 4 ] &&
+[ "$ceiling" = 0.500 ] && [ "$pending" = 1 ] &&
+[ "$confirmed" = 0 ] && [ "$motion_failed" = 0 ] &&
+[ "$restraint_failed" = 0 ] && [ "$both_failed" = 0 ] &&
+[ "$coverage_starved" = 0 ] && [ "$invalidated" = 0 ] || {
+    printf 'holdout did not arm exactly one pending cell\n' >&2
+    exit 1
+}
+state_size="$(wc -c < "$OUT/arm/on.state" | tr -d ' ')"
+prefix_size=$((state_size - tail_size))
+dd if="$OUT/arm/on.state" of="$OUT/arm/on.prefix" \
+    bs=1 count="$prefix_size" 2>/dev/null
+dd if="$OUT/arm/off.state" of="$OUT/arm/off.prefix" \
+    bs=1 count="$prefix_size" 2>/dev/null
+cmp -s "$OUT/arm/on.prefix" "$OUT/arm/off.prefix" || {
+    printf 'holdout arming changed Leo outside the v23 tail\n' >&2
+    exit 1
+}
+
+printf 'case\tattempts\tmatched\teligible\tabstained\tsupported\toverreach\tmissed\trestraint\tconfounded\tother\toverreach_rate\toverreach_upper\tmissed_rate\tmissed_upper\tstatus\treply_equal\tstate_equal\n' \
+    > "$MATRIX"
+
+tail -n +2 "$PLAN" |
+while IFS=$'\t' read -r case_name expected_over_rate \
+        expected_over_upper expected_miss_rate expected_miss_upper \
+        expected_status; do
+    case_dir="$OUT/$case_name"
+    mkdir -p "$case_dir"
+    "$OUT/holdout-fixture" "$case_dir/base.state" "$case_name"
+    cp "$case_dir/base.state" "$case_dir/on.state"
+    cp "$case_dir/base.state" "$case_dir/off.state"
+    seed=5102
+
+    "$ROOT/leo" --load "$case_dir/on.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --save "$case_dir/on.state" > "$case_dir/on.log" 2>&1
+    "$ROOT/leo" --load "$case_dir/off.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --no-wonder-appetite-holdout \
+        --save "$case_dir/off.state" > "$case_dir/off.log" 2>&1
+
+    holdout="$(
+        holdout_from_log "$case_dir/on.log" "$case_name" "$seed"
+    )"
+    [ -n "$holdout" ] || {
+        printf '%s emitted no A.51 holdout ledger\n' \
+            "$case_name" >&2
+        exit 1
+    }
+    [ -z "$(
+        holdout_from_log "$case_dir/off.log" "$case_name" "$seed"
+    )" ] || {
+        printf '%s holdout ablation remained visible\n' \
+            "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r _ _ budget min_arm ceiling pending confirmed \
+        motion_failed restraint_failed both_failed coverage_starved \
+        invalidated cells <<< "$holdout"
+    cell="$(cell_fields "$cells" u62-70)"
+    [ -n "$cell" ] || {
+        printf '%s lost its holdout cell\n' "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r opened baseline attempts matched eligible abstained \
+        supported overreach missed restraint confounded other over_rate \
+        over_upper miss_rate miss_upper status seen <<< "$cell"
+
+    reply_equal=0
+    [ "$(reply_from_log "$case_dir/on.log")" = \
+      "$(reply_from_log "$case_dir/off.log")" ] &&
+        reply_equal=1
+    state_equal=0
+    cmp -s "$case_dir/on.state" "$case_dir/off.state" &&
+        state_equal=1
+
+    expected_confirmed=0
+    expected_motion=0
+    expected_restraint=0
+    expected_both=0
+    expected_starved=0
+    case "$expected_status" in
+        confirmed) expected_confirmed=1 ;;
+        motion-failed) expected_motion=1 ;;
+        restraint-failed) expected_restraint=1 ;;
+        both-failed) expected_both=1 ;;
+        coverage-starved) expected_starved=1 ;;
+    esac
+
+    [ "$budget" = 16 ] && [ "$min_arm" = 4 ] &&
+    [ "$ceiling" = 0.500 ] && [ "$pending" = 0 ] &&
+    [ "$confirmed" = "$expected_confirmed" ] &&
+    [ "$motion_failed" = "$expected_motion" ] &&
+    [ "$restraint_failed" = "$expected_restraint" ] &&
+    [ "$both_failed" = "$expected_both" ] &&
+    [ "$coverage_starved" = "$expected_starved" ] &&
+    [ "$invalidated" = 0 ] &&
+    [ "$attempts" = 16 ] &&
+    [ "$over_rate" = "$expected_over_rate" ] &&
+    [ "$over_upper" = "$expected_over_upper" ] &&
+    [ "$miss_rate" = "$expected_miss_rate" ] &&
+    [ "$miss_upper" = "$expected_miss_upper" ] &&
+    [ "$status" = "$expected_status" ] &&
+    [ "$reply_equal" = 1 ] && [ "$state_equal" = 1 ] || {
+        printf '%s contract failed: attempts=%s bounds=%s/%s status=%s summary=%s/%s/%s/%s/%s reply=%s state=%s\n' \
+            "$case_name" "$attempts" "$over_upper" "$miss_upper" \
+            "$status" "$confirmed" "$motion_failed" \
+            "$restraint_failed" "$both_failed" "$coverage_starved" \
+            "$reply_equal" "$state_equal" >&2
+        exit 1
+    }
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$case_name" "$attempts" "$matched" "$eligible" "$abstained" \
+        "$supported" "$overreach" "$missed" "$restraint" \
+        "$confounded" "$other" "$over_rate" "$over_upper" \
+        "$miss_rate" "$miss_upper" "$status" "$reply_equal" \
+        "$state_equal" >> "$MATRIX"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        rows++
+        replies += $17
+        states += $18
+    }
+    END {
+        print "cases\tarming_prefix_equal\treply_equal\tstate_equal"
+        print rows "\t1\t" replies "\t" states
+        if (rows != 5 || replies != 5 || states != 5)
+            exit 1
+    }
+' "$MATRIX"
+printf '\nmatrix: %s\n' "$MATRIX"

--- a/scripts/test_deferred_wonder_appetite_holdout_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_holdout_matrix.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_HOLDOUT_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_holdout_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 6 || $1 != "case" ||
+            $2 != "expected_overreach_rate" ||
+            $6 != "expected_status")
+            exit 1
+        next
+    }
+    {
+        if (NF != 6 || seen[$1]++)
+            exit 1
+        if ($1 == "confirmed" &&
+            ($3 != "0.471" || $5 != "0.471" ||
+             $6 != "confirmed"))
+            exit 1
+        if ($1 == "motion-failed" &&
+            ($3 != "0.785" || $5 != "0.471" ||
+             $6 != "motion-failed"))
+            exit 1
+        if ($1 == "restraint-failed" &&
+            ($3 != "0.471" || $5 != "0.785" ||
+             $6 != "restraint-failed"))
+            exit 1
+        if ($1 == "both-failed" &&
+            ($3 != "0.785" || $5 != "0.785" ||
+             $6 != "both-failed"))
+            exit 1
+        if ($1 == "coverage-starved" &&
+            $6 != "coverage-starved")
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 5)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite holdout plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite holdout matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_holdout_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_holdout_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-holdout: budget=16 min-arm=4 ceiling=0.500 pending=0 confirmed=1 motion-failed=0 restraint-failed=0 both-failed=0 coverage-starved=0 invalidated=0 cells=u62-70:73/70/16/16/8/8/7/1/1/7/0/0/0.125/0.471/0.125/0.471/confirmed/74,78]
+EOF
+
+got="$(
+    awk -v scenario=confirmed -v seed=101 \
+        -f "$ROOT/scripts/wonder_appetite_holdout_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'confirmed\t101\t16\t4\t0.500\t0\t1\t0\t0\t0\t0\t0\tu62-70:73/70/16/16/8/8/7/1/1/7/0/0/0.125/0.471/0.125/0.471/confirmed/74,78'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite holdout parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite holdout report parser: ok\n'

--- a/scripts/wonder_appetite_holdout_dialogue_report.awk
+++ b/scripts/wonder_appetite_holdout_dialogue_report.awk
@@ -1,0 +1,36 @@
+# Extract one A.51 out-of-sample holdout ledger from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    fields, i, n, prefix, value) {
+    prefix = key "="
+    n = split(line, fields, /[ ]+/)
+    for (i = 1; i <= n; i++) {
+        if (index(fields[i], prefix) != 1)
+            continue
+        value = substr(fields[i], length(prefix) + 1)
+        gsub(/\]$/, "", value)
+        return value
+    }
+    return ""
+}
+
+/\[wonder-appetite-holdout: budget=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed),
+           value_after($0, "budget"),
+           value_after($0, "min-arm"),
+           value_after($0, "ceiling"),
+           value_after($0, "pending"),
+           value_after($0, "confirmed"),
+           value_after($0, "motion-failed"),
+           value_after($0, "restraint-failed"),
+           value_after($0, "both-failed"),
+           value_after($0, "coverage-starved"),
+           value_after($0, "invalidated"),
+           value_after($0, "cells")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -54,10 +54,11 @@ static void seed_wonder_redirection_body(Leo *leo) {
         leo->school.pending_alt_glyph, 1, field_token, field_weight);
 }
 
-static long test_appetite_calibration_tail_size(const Leo *leo) {
+static long test_appetite_and_later_tail_size(const Leo *leo) {
     return (long)(2 * sizeof(int32_t) +
         leo->wonder_appetite_calibration.n *
-            (int)sizeof(LeoWonderAppetiteCalibrationReceipt));
+            (int)sizeof(LeoWonderAppetiteCalibrationReceipt) +
+        sizeof(LeoWonderAppetiteHoldouts));
 }
 
 static void test_add_appetite_calibration(
@@ -702,7 +703,7 @@ static void test_wonder_appetite_regret_surface(void) {
                   sizeof *school_before) &&
           !memcmp(flow_before, &leo->flow,
                   sizeof *flow_before) &&
-          LEO_STATE_VERSION == 22,
+          LEO_STATE_VERSION == 23,
           "wonder-appetite-regret: observing cost rewrites no evidence, body, or state format");
     free(school_before);
     free(flow_before);
@@ -831,11 +832,299 @@ static void test_wonder_appetite_readiness_frontier(void) {
                   sizeof *school_before) &&
           !memcmp(flow_before, &leo->flow,
                   sizeof *flow_before) &&
-          LEO_STATE_VERSION == 22,
+          LEO_STATE_VERSION == 23,
           "wonder-appetite-readiness: candidacy rewrites no evidence, body, or state format");
     free(school_before);
     free(flow_before);
 
+    leo_free(leo);
+    free(leo);
+}
+
+static LeoWonderAppetiteHoldoutTrial *
+test_open_appetite_holdout(Leo *leo, float appetite, int spoken) {
+    if (!leo) return NULL;
+    test_reset_appetite_policy_outcomes(leo);
+    memset(&leo->wonder_appetite_holdouts, 0,
+           sizeof leo->wonder_appetite_holdouts);
+    test_add_appetite_readiness_cell(
+        leo, appetite, spoken, 7, 1, 1, 7);
+    leo_wonder_appetite_holdout_update(leo);
+    int bin = leo_wonder_appetite_reliability_bin(appetite);
+    int index = (spoken ? LEO_WONDER_APPETITE_RELIABILITY_BINS : 0) +
+                bin;
+    return &leo->wonder_appetite_holdouts.trials[index];
+}
+
+static LeoWonderAppetiteHoldoutTrial *
+test_finish_appetite_holdout(
+        Leo *leo, float appetite, int spoken,
+        int supported, int overreach, int missed, int restraint,
+        int confounded, int other) {
+    LeoWonderAppetiteHoldoutTrial *trial =
+        test_open_appetite_holdout(leo, appetite, spoken);
+    test_add_appetite_readiness_cell(
+        leo, appetite, spoken,
+        supported, overreach, missed, restraint);
+    for (int i = 0; i < confounded; i++)
+        test_add_appetite_policy_outcome(
+            leo, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_EXTERNAL);
+    for (int i = 0; i < other; i++)
+        test_add_appetite_policy_outcome(
+            leo, appetite < 0.70f ? 0.75f : 0.65f, spoken,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    leo_wonder_appetite_holdout_update(leo);
+    return trial;
+}
+
+__attribute__((noinline))
+static void test_wonder_appetite_holdout_trial(void) {
+    Leo *leo = malloc(sizeof *leo);
+    CHECK(leo != NULL,
+          "wonder-appetite-holdout: heap fixture allocated");
+    if (!leo) return;
+
+    int previous_holdout = g_leo_wonder_appetite_holdout_on;
+    int previous_calibration =
+        g_leo_wonder_appetite_calibration_on;
+    int previous_policy = g_leo_wonder_appetite_policy_on;
+    g_leo_wonder_appetite_holdout_on = 1;
+    g_leo_wonder_appetite_calibration_on = 1;
+    g_leo_wonder_appetite_policy_on = 1;
+
+    leo_init(leo);
+    LeoWonderAppetiteHoldoutTrial *trial =
+        test_open_appetite_holdout(leo, 0.65f, 0);
+    CHECK(trial &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_PENDING &&
+          trial->opened_turn ==
+              (uint64_t)leo->school.turn_clock &&
+          trial->baseline_proposed_turn == 70 &&
+          trial->attempts == 0,
+          "wonder-appetite-holdout: a candidate freezes one readerless future boundary");
+    LeoWonderAppetiteCalibration diary_before =
+        leo->wonder_appetite_calibration;
+    LeoSchool *school_before = malloc(sizeof *school_before);
+    LeoFlow *flow_before = malloc(sizeof *flow_before);
+    if (school_before) *school_before = leo->school;
+    if (flow_before) *flow_before = leo->flow;
+    leo_wonder_appetite_holdout_update(leo);
+    CHECK(trial && school_before && flow_before &&
+          trial->attempts == 0 &&
+          !memcmp(&diary_before,
+                  &leo->wonder_appetite_calibration,
+                  sizeof diary_before) &&
+          !memcmp(school_before, &leo->school,
+                  sizeof *school_before) &&
+          !memcmp(flow_before, &leo->flow,
+                  sizeof *flow_before),
+          "wonder-appetite-holdout: the qualifying past cannot grade its own trial or rewrite Leo");
+    free(school_before);
+    free(flow_before);
+
+    trial = test_finish_appetite_holdout(
+        leo, 0.65f, 0, 7, 1, 1, 7, 0, 0);
+    CHECK(trial &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED &&
+          trial->attempts == 16 &&
+          trial->matched == 16 &&
+          trial->eligible == 8 &&
+          trial->abstained == 8 &&
+          trial->supported == 7 &&
+          trial->overreach == 1 &&
+          trial->missed == 1 &&
+          trial->restraint == 7,
+          "wonder-appetite-holdout: sixteen new balanced lives can confirm both bounds");
+    LeoWonderAppetiteHoldoutTrial terminal = *trial;
+    leo_wonder_appetite_holdout_update(leo);
+    CHECK(!memcmp(&terminal, trial, sizeof terminal),
+          "wonder-appetite-holdout: a terminal trial cannot restart on its favorable history");
+
+    const char *state = "/tmp/leo_appetite_holdout_v23.state";
+    const char *v22 = "/tmp/leo_appetite_holdout_v22.state";
+    const char *cut = "/tmp/leo_appetite_holdout_v23_cut.state";
+    const char *bad = "/tmp/leo_appetite_holdout_v23_bad.state";
+    int saved = leo_save_state(leo, state);
+    Leo *woke = malloc(sizeof *woke);
+    Leo *old = malloc(sizeof *old);
+    Leo *damaged = malloc(sizeof *damaged);
+    if (woke) leo_init(woke);
+    if (old) leo_init(old);
+    if (damaged) leo_init(damaged);
+    CHECK(saved && woke && leo_load_state(woke, state) &&
+          !memcmp(&woke->wonder_appetite_holdouts,
+                  &leo->wonder_appetite_holdouts,
+                  sizeof leo->wonder_appetite_holdouts),
+          "wonder-appetite-holdout: a completed trial survives v23 sleep exactly");
+
+    int built_v22 = 0, built_cut = 0, built_bad = 0;
+    FILE *fi = fopen(state, "rb");
+    if (fi) {
+        fseek(fi, 0, SEEK_END);
+        long size = ftell(fi);
+        fseek(fi, 0, SEEK_SET);
+        unsigned char *bytes =
+            malloc(size > 0 ? (size_t)size : 1);
+        if (bytes &&
+            size > (long)sizeof(LeoWonderAppetiteHoldouts) &&
+            (long)fread(bytes, 1, (size_t)size, fi) == size) {
+            uint32_t twenty_two = 22;
+            memcpy(bytes + sizeof(uint32_t), &twenty_two,
+                   sizeof twenty_two);
+            FILE *fo = fopen(v22, "wb");
+            long v22_size =
+                size - (long)sizeof(LeoWonderAppetiteHoldouts);
+            if (fo) {
+                built_v22 =
+                    (long)fwrite(bytes, 1,
+                                 (size_t)v22_size, fo) == v22_size;
+                fclose(fo);
+            }
+            uint32_t twenty_three = 23;
+            memcpy(bytes + sizeof(uint32_t), &twenty_three,
+                   sizeof twenty_three);
+            fo = fopen(cut, "wb");
+            if (fo) {
+                built_cut =
+                    (long)fwrite(bytes, 1,
+                                 (size_t)(size - 1), fo) ==
+                    size - 1;
+                fclose(fo);
+            }
+            LeoWonderAppetiteHoldouts corrupted;
+            memcpy(
+                &corrupted,
+                bytes + size -
+                    (long)sizeof(LeoWonderAppetiteHoldouts),
+                sizeof corrupted);
+            corrupted.trials[0].attempts = 15;
+            memcpy(
+                bytes + size -
+                    (long)sizeof(LeoWonderAppetiteHoldouts),
+                &corrupted, sizeof corrupted);
+            fo = fopen(bad, "wb");
+            if (fo) {
+                built_bad =
+                    (long)fwrite(bytes, 1,
+                                 (size_t)size, fo) == size;
+                fclose(fo);
+            }
+        }
+        free(bytes);
+        fclose(fi);
+    }
+    CHECK(built_v22 && old && leo_load_state(old, v22) &&
+          old->wonder_appetite_calibration.n ==
+              leo->wonder_appetite_calibration.n &&
+          old->wonder_appetite_holdouts.trials[0].status ==
+              LEO_WONDER_APPETITE_HOLDOUT_EMPTY,
+          "wonder-appetite-holdout: a v22 body migrates without invented future evidence");
+    CHECK(built_cut && damaged &&
+          leo_load_state(damaged, cut) &&
+          damaged->wonder_appetite_calibration.n ==
+              leo->wonder_appetite_calibration.n &&
+          damaged->wonder_appetite_holdouts.trials[0].status ==
+              LEO_WONDER_APPETITE_HOLDOUT_EMPTY,
+          "wonder-appetite-holdout: a corrupt v23 tail loses only its trial");
+    CHECK(built_bad && damaged &&
+          leo_load_state(damaged, bad) &&
+          damaged->wonder_appetite_calibration.n ==
+              leo->wonder_appetite_calibration.n &&
+          damaged->wonder_appetite_holdouts.trials[0].status ==
+              LEO_WONDER_APPETITE_HOLDOUT_EMPTY,
+          "wonder-appetite-holdout: an impossible v23 verdict fails soft without rewriting history");
+    if (woke) { leo_free(woke); free(woke); }
+    if (old) { leo_free(old); free(old); }
+    if (damaged) { leo_free(damaged); free(damaged); }
+    remove(state);
+    remove(v22);
+    remove(cut);
+    remove(bad);
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_finish_appetite_holdout(
+        leo, 0.65f, 0, 4, 4, 1, 7, 0, 0);
+    CHECK(trial &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_MOTION_FAILED,
+          "wonder-appetite-holdout: future overreach can fail motion alone");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_finish_appetite_holdout(
+        leo, 0.65f, 0, 7, 1, 4, 4, 0, 0);
+    CHECK(trial &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_RESTRAINT_FAILED,
+          "wonder-appetite-holdout: future misses can fail restraint alone");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_finish_appetite_holdout(
+        leo, 0.65f, 0, 4, 4, 4, 4, 0, 0);
+    CHECK(trial &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_BOTH_FAILED,
+          "wonder-appetite-holdout: two future debts cannot cancel");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_finish_appetite_holdout(
+        leo, 0.65f, 0, 12, 0, 0, 0, 0, 4);
+    CHECK(trial &&
+          trial->attempts == 16 &&
+          trial->eligible == 12 &&
+          trial->abstained == 0 &&
+          trial->other == 4 &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_COVERAGE_STARVED,
+          "wonder-appetite-holdout: a fixed future cannot wait forever for its missing arm");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_finish_appetite_holdout(
+        leo, 0.65f, 0, 4, 0, 0, 4, 8, 0);
+    CHECK(trial &&
+          trial->attempts == 16 &&
+          trial->matched == 8 &&
+          trial->confounded == 8 &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED,
+          "wonder-appetite-holdout: confounds spend budget without impersonating either arm");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_open_appetite_holdout(leo, 0.65f, 0);
+    test_add_appetite_policy_outcome(
+        leo, 0.65f, 0,
+        LEO_WONDER_APPETITE_POLICY_LEGACY,
+        LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    leo_wonder_appetite_holdout_update(leo);
+    CHECK(trial &&
+          trial->attempts == 1 &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_INVALIDATED,
+          "wonder-appetite-holdout: a changed policy invalidates rather than rewrites the experiment");
+
+    leo_free(leo);
+    leo_init(leo);
+    g_leo_wonder_appetite_holdout_on = 0;
+    trial = test_open_appetite_holdout(leo, 0.65f, 0);
+    CHECK(trial &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_EMPTY,
+          "wonder-appetite-holdout: ablation prevents even the experimental ledger");
+
+    g_leo_wonder_appetite_holdout_on = previous_holdout;
+    g_leo_wonder_appetite_calibration_on =
+        previous_calibration;
+    g_leo_wonder_appetite_policy_on = previous_policy;
     leo_free(leo);
     free(leo);
 }
@@ -1826,7 +2115,7 @@ int main(void) {
             if (bytes && sz > 1 &&
                 (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
                 long appetite_tail =
-                    test_appetite_calibration_tail_size(&pre);
+                    test_appetite_and_later_tail_size(&pre);
                 long origin_tail = (long)sizeof(int32_t);
                 long tail = appetite_tail + origin_tail +
                             (long)(sizeof(int32_t) +
@@ -2571,7 +2860,7 @@ int main(void) {
             if (bytes && sz > (long)sizeof(LeoDeferredWonder) + 5 &&
                 (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
                 long appetite_tail =
-                    test_appetite_calibration_tail_size(&sleep);
+                    test_appetite_and_later_tail_size(&sleep);
                 long origin_tail =
                     (long)(sizeof(int32_t) + sizeof(LeoDeferredWonder));
                 uint32_t nineteen = 19;
@@ -2850,7 +3139,7 @@ int main(void) {
                 unsigned char *bytes =
                     malloc(sz > 0 ? (size_t)sz : 1);
                 long appetite_tail =
-                    test_appetite_calibration_tail_size(cal);
+                    test_appetite_and_later_tail_size(cal);
                 if (bytes && sz > appetite_tail &&
                     (long)fread(bytes, 1, (size_t)sz, fi) == sz) {
                     uint32_t twenty = 20;
@@ -2870,10 +3159,13 @@ int main(void) {
                            sizeof twenty_two);
                     fo = fopen(cut, "wb");
                     if (fo) {
+                        long holdout_tail =
+                            (long)sizeof(LeoWonderAppetiteHoldouts);
                         built_cut =
                             (long)fwrite(
-                                bytes, 1, (size_t)(sz - 1), fo) ==
-                            sz - 1;
+                                bytes, 1,
+                                (size_t)(sz - holdout_tail - 1), fo) ==
+                            sz - holdout_tail - 1;
                         fclose(fo);
                     }
 
@@ -3307,6 +3599,7 @@ int main(void) {
     test_wonder_appetite_shadow_policy();
     test_wonder_appetite_regret_surface();
     test_wonder_appetite_readiness_frontier();
+    test_wonder_appetite_holdout_trial();
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
      * concept-slot; a taught word then returns that glyph (no longer -1); the
@@ -3536,7 +3829,7 @@ int main(void) {
                                            (w.school.has_pending_origin ?
                                             sizeof(LeoDeferredWonder) : 0));
                 long appetite_tail =
-                    test_appetite_calibration_tail_size(&w);
+                    test_appetite_and_later_tail_size(&w);
                 long current_flow = (long)(2 * sizeof(int32_t) +
                                            w.flow.n * (int)sizeof(LeoFlowSnapshot) +
                                            2 * sizeof(int32_t) +
@@ -3930,7 +4223,7 @@ int main(void) {
                                               (fl->school.has_pending_origin ?
                                                sizeof(LeoDeferredWonder) : 0));
                     long appetite_tail =
-                        test_appetite_calibration_tail_size(fl);
+                        test_appetite_and_later_tail_size(fl);
                     long current_tail = (long)(2 * sizeof(int32_t) +
                                               fl->flow.n * (int)sizeof(LeoFlowSnapshot) +
                                               2 * sizeof(int32_t) +
@@ -4185,7 +4478,7 @@ int main(void) {
                                               (sh->school.has_pending_origin ?
                                                sizeof(LeoDeferredWonder) : 0));
                     long appetite_tail =
-                        test_appetite_calibration_tail_size(sh);
+                        test_appetite_and_later_tail_size(sh);
                     uint32_t fifteen = 15;
                     memcpy(bytes + sizeof(uint32_t), &fifteen, sizeof fifteen);
                     FILE *fo = fopen(legacy, "wb");
@@ -5029,7 +5322,7 @@ int main(void) {
                        sizeof(int32_t) +
                        (l.school.has_pending_origin ?
                         sizeof(LeoDeferredWonder) : 0)) +
-                test_appetite_calibration_tail_size(&l);
+                test_appetite_and_later_tail_size(&l);
             uint32_t ten = 10;
             memcpy(fb + sizeof(uint32_t), &ten, sizeof ten);
             tf = fopen(sp, "wb");

--- a/tests/wonder_appetite_holdout_fixture.c
+++ b/tests/wonder_appetite_holdout_fixture.c
@@ -1,0 +1,194 @@
+#define LEO_NO_MAIN
+#include "../leo.c"
+
+static int add_outcome(
+        Leo *leo, float appetite, int spoken,
+        int policy, int verdict) {
+    LeoWonderAppetiteCalibration *calibration =
+        &leo->wonder_appetite_calibration;
+    if (calibration->n >= LEO_WONDER_APPETITE_CALIB_RING)
+        return 0;
+    int slot = calibration->n;
+    LeoWonderAppetiteCalibrationReceipt receipt;
+    memset(&receipt, 0, sizeof receipt);
+    receipt.proposed_turn = (uint64_t)(10 + slot * 4);
+    receipt.deadline_turn =
+        receipt.proposed_turn +
+            LEO_WONDER_APPETITE_CALIB_HORIZON;
+    receipt.observed_turn = receipt.deadline_turn;
+    receipt.appetite = appetite;
+    receipt.spoken = spoken ? 1 : 0;
+    receipt.wonder_id = spoken ? (uint64_t)(slot + 1) : 0;
+    receipt.policy = (uint8_t)policy;
+    receipt.verdict = (uint8_t)verdict;
+    receipt.observations =
+        LEO_WONDER_APPETITE_CALIB_HORIZON;
+    snprintf(receipt.word, sizeof receipt.word, "hold%02d", slot);
+
+    if (policy == LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+        receipt.policy_n = LEO_WONDER_APPETITE_DRIFT_MIN_N;
+        receipt.policy_reliability =
+            LEO_WONDER_APPETITE_RELIABILITY_ALIGNED;
+        receipt.policy_drift =
+            LEO_WONDER_APPETITE_DRIFT_STABLE;
+    }
+    if (verdict == LEO_WONDER_APPETITE_CALIB_SUSTAINED) {
+        receipt.semantic_hits = 1;
+        receipt.peak_recurrence =
+            LEO_WONDER_APPETITE_RESONANCE_MIN;
+        receipt.brier =
+            (receipt.appetite - 1.0f) *
+            (receipt.appetite - 1.0f);
+    } else if (verdict == LEO_WONDER_APPETITE_CALIB_FADED) {
+        receipt.brier = receipt.appetite * receipt.appetite;
+    } else if (
+        verdict == LEO_WONDER_APPETITE_CALIB_EXTERNAL) {
+        receipt.observed_turn = receipt.proposed_turn + 1;
+        receipt.observations = 1;
+    }
+    if (!leo_wonder_appetite_calibration_valid(
+            &receipt, receipt.observed_turn))
+        return 0;
+
+    calibration->receipts[calibration->ptr] = receipt;
+    calibration->ptr =
+        (calibration->ptr + 1) %
+            LEO_WONDER_APPETITE_CALIB_RING;
+    calibration->n++;
+    leo->school.turn_clock = (long)receipt.observed_turn;
+    return 1;
+}
+
+static int add_n(
+        Leo *leo, int count, float appetite, int spoken,
+        int policy, int verdict) {
+    for (int i = 0; i < count; i++)
+        if (!add_outcome(
+                leo, appetite, spoken, policy, verdict))
+            return 0;
+    return 1;
+}
+
+static int add_candidate(Leo *leo) {
+    return
+        add_n(
+            leo, 7, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(
+            leo, 1, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_FADED) &&
+        add_n(
+            leo, 1, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(
+            leo, 7, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+}
+
+static int add_future(Leo *leo, const char *scenario) {
+    if (!strcmp(scenario, "confirmed"))
+        return
+            add_n(leo, 7, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_FADED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 7, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_FADED);
+    if (!strcmp(scenario, "motion-failed"))
+        return
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_FADED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 7, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_FADED);
+    if (!strcmp(scenario, "restraint-failed"))
+        return
+            add_n(leo, 7, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_FADED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_FADED);
+    if (!strcmp(scenario, "both-failed"))
+        return
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_FADED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_FADED);
+    if (!strcmp(scenario, "coverage-starved"))
+        return
+            add_n(leo, 12, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 4, 0.75f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc == 2 && !strcmp(argv[1], "--tail-size")) {
+        printf("%zu\n", sizeof(LeoWonderAppetiteHoldouts));
+        return 0;
+    }
+    if (argc != 3 ||
+        (strcmp(argv[2], "arm") &&
+         strcmp(argv[2], "confirmed") &&
+         strcmp(argv[2], "motion-failed") &&
+         strcmp(argv[2], "restraint-failed") &&
+         strcmp(argv[2], "both-failed") &&
+         strcmp(argv[2], "coverage-starved"))) {
+        fprintf(stderr,
+                "usage: %s STATE arm|confirmed|motion-failed|restraint-failed|both-failed|coverage-starved\n",
+                argv[0]);
+        return 2;
+    }
+
+    Leo leo;
+    leo_init(&leo);
+    leo_ingest(
+        &leo,
+        "The rain falls softly. His mother waits by the warm window. "
+        "Leo hears the night and asks what the sea remembers. "
+        "The child watches light move across the room.");
+    int ok = add_candidate(&leo);
+    if (ok && strcmp(argv[2], "arm")) {
+        leo_wonder_appetite_holdout_update(&leo);
+        ok = add_future(&leo, argv[2]);
+        if (ok) leo_wonder_appetite_holdout_update(&leo);
+    }
+    if (ok) ok = leo_save_state(&leo, argv[1]);
+    leo_free(&leo);
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
A.51 persists one non-restartable holdout per exact readiness stratum, spends a fixed sixteen-attempt future budget, and keeps independent motion/restraint verdicts outside every speech path.

State v23 migrates and fails soft; direct contracts, parser checks, process matrices, and sanitizers cover the boundary.

Quote: "A future that can choose when it arrives is only another form of memory." - Sol
Method: The Arianna Method lets evidence face a future it can neither select nor postpone.