### PR TITLE
the method preserves holdout admission provenance

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4614,3 +4614,62 @@ all terminal lives:
 A separate CLI arming fork produced the same reply and a byte-identical state
 prefix; only the fixed v23 holdout tail differed. The future can now refute the
 frontier without being chosen by it. It still cannot move Leo's mouth.
+
+## Phase A.52 — the trial remembers its warrant (2026-07-28)
+
+A.51 remembered when a holdout began, but not why A.50 had admitted it. Once
+the 32-receipt forecast diary rotated, a surviving trial could still be graded
+but could no longer prove that both risk arms had actually crossed the
+readiness frontier at its origin. A later observer would have to trust a
+historical conclusion whose evidence had disappeared.
+
+A.52 freezes that evidence at the same instant as the trial. Each new holdout
+may carry one immutable admission receipt containing:
+
+```text
+exact spoken/appetite stratum
+opened turn and baseline proposal identity
+eligible / abstained sample counts
+supported / overreach / missed / restraint outcomes
+the two independently bounded Wilson risks
+```
+
+The receipt is valid only when both arms have at least eight observations,
+their outcome partitions are arithmetically exact, and both 95% upper bounds
+remain strictly below `0.500`. Its identity must match the A.51 trial. Later
+diary rotation, future holdout outcomes, and repeated updates cannot alter it.
+
+State v24 appends admission receipts after the unchanged v23 holdout tail.
+A valid v23 trial migrates alive but `legacy`: Leo does not reconstruct a
+warrant his older body did not preserve. A truncated or contradictory v24
+receipt discards only the admission ledger; the organism, forecast diary, and
+A.51 trial survive. An ablated admission is permanently unattested rather than
+backfilled from later evidence.
+
+`--no-wonder-appetite-admission` disables creation and its diagnostic. No
+School, Flow, shadow, route, sampler, scheduler, or generation path reads the
+receipt. An `attested` receipt proves only that the experiment was eligible to
+begin; even a later `confirmed` verdict still grants no permission to speak.
+
+Five direct contracts raised the suite from **416/416** to **421/421**. They
+cover exact capture, immutability, ablation, honest v23 migration, and
+truncated or semantically impossible v24 recovery.
+
+The real-process fork then opened the same A.51 trial with admission ON and
+OFF:
+
+```text
+reply equality                         1/1
+body plus A.51 trial prefix equality   1/1
+complete state equality                0/1
+attested / legacy                      1 / 0
+baseline outcomes                      7/1 | 1/7
+baseline Wilson upper bounds           0.471 / 0.471
+```
+
+The full states differed only in the fixed A.52 tail. The complete five-case
+A.51 matrix also remained green on v24: replies `5/5`, terminal states `5/5`,
+and arming prefix `1/1`.
+
+A trial that outlives its diary can now testify both to what the future did and
+to why the past was allowed to ask.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission
 
 all: leo
 
@@ -88,6 +88,9 @@ deferred-wonder-appetite-readiness: leo
 deferred-wonder-appetite-holdout: leo
 	./scripts/deferred_wonder_appetite_holdout_matrix.sh
 
+deferred-wonder-appetite-admission: leo
+	./scripts/deferred_wonder_appetite_admission_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -104,6 +107,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_appetite_regret_dialogue_report.sh
 	./scripts/test_wonder_appetite_readiness_dialogue_report.sh
 	./scripts/test_wonder_appetite_holdout_dialogue_report.sh
+	./scripts/test_wonder_appetite_admission_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -118,6 +122,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_regret_matrix.sh
 	./scripts/test_deferred_wonder_appetite_readiness_matrix.sh
 	./scripts/test_deferred_wonder_appetite_holdout_matrix.sh
+	./scripts/test_deferred_wonder_appetite_admission_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -1996,6 +1996,10 @@ typedef struct {
     int   scored;
     int   eligible;
     int   abstained;
+    int   supported;
+    int   overreach;
+    int   missed;
+    int   restraint;
     float coverage;
     float overreach_rate;
     float overreach_upper;
@@ -2059,6 +2063,31 @@ typedef struct {
     LeoWonderAppetiteHoldoutTrial
         trials[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
 } LeoWonderAppetiteHoldouts;
+
+/* A.52: preserve why A.50 admitted an A.51 trial after the 32-receipt diary
+ * rotates away. This immutable receipt is provenance, not another verdict. */
+enum {
+    LEO_WONDER_APPETITE_ADMISSION_EMPTY = 0,
+    LEO_WONDER_APPETITE_ADMISSION_ATTESTED,
+    LEO_WONDER_APPETITE_ADMISSION_STATUS_COUNT
+};
+typedef struct {
+    uint64_t opened_turn;
+    uint64_t baseline_proposed_turn;
+    uint8_t  spoken;
+    uint8_t  bin;
+    uint8_t  status;
+    uint8_t  eligible;
+    uint8_t  abstained;
+    uint8_t  supported;
+    uint8_t  overreach;
+    uint8_t  missed;
+    uint8_t  restraint;
+} LeoWonderAppetiteAdmissionReceipt;
+typedef struct {
+    LeoWonderAppetiteAdmissionReceipt
+        receipts[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+} LeoWonderAppetiteAdmissions;
 
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
@@ -2231,6 +2260,9 @@ typedef struct {
     /* A.51/state v23: fixed-budget out-of-sample trials over A.50 candidates.
      * Evidence only; no School, routing, sampling, or generation reader. */
     LeoWonderAppetiteHoldouts wonder_appetite_holdouts;
+    /* A.52/state v24: immutable proof of the A.50 geometry that admitted each
+     * trial. Separate so v23 trials migrate visibly unattested, never invented. */
+    LeoWonderAppetiteAdmissions wonder_appetite_admissions;
     /* A.42/A.43: pre-grounding address witness. Semantic conflict can only
      * guard; an exact waiting name may redirect without assigning meaning. */
     LeoWonderAddressReceipt wonder_address;
@@ -2514,6 +2546,7 @@ static int g_leo_wonder_appetite_policy_on = 1; /* frozen shadow abstention at f
 static int g_leo_wonder_appetite_regret_on = 1; /* separate costs of motion and restraint; derived diagnostic only. */
 static int g_leo_wonder_appetite_readiness_on = 1; /* paired confidence frontier; candidate is not permission. */
 static int g_leo_wonder_appetite_holdout_on = 1; /* fixed future trial; persisted evidence, never speech authority. */
+static int g_leo_wonder_appetite_admission_on = 1; /* immutable candidate provenance; no reader in speech. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -7420,6 +7453,10 @@ static void leo_wonder_appetite_readiness(
         cell->scored = source->scored;
         cell->eligible = source->eligible;
         cell->abstained = source->abstained;
+        cell->supported = source->supported;
+        cell->overreach = source->overreach;
+        cell->missed = source->missed;
+        cell->restraint = source->restraint;
         cell->coverage = source->coverage;
         cell->overreach_rate = source->overreach_rate;
         cell->overreach_upper = source->overreach_upper;
@@ -7628,6 +7665,59 @@ static int leo_wonder_appetite_holdout_valid(
     return expected.status == trial->status;
 }
 
+static int leo_wonder_appetite_admission_valid(
+        const LeoWonderAppetiteAdmissionReceipt *receipt,
+        const LeoWonderAppetiteHoldoutTrial *trial) {
+    if (!receipt || !trial) return 0;
+    if (receipt->status ==
+        LEO_WONDER_APPETITE_ADMISSION_EMPTY) {
+        return receipt->opened_turn == 0 &&
+               receipt->baseline_proposed_turn == 0 &&
+               receipt->spoken == 0 &&
+               receipt->bin == 0 &&
+               receipt->eligible == 0 &&
+               receipt->abstained == 0 &&
+               receipt->supported == 0 &&
+               receipt->overreach == 0 &&
+               receipt->missed == 0 &&
+               receipt->restraint == 0;
+    }
+    if (receipt->status !=
+            LEO_WONDER_APPETITE_ADMISSION_ATTESTED ||
+        trial->status == LEO_WONDER_APPETITE_HOLDOUT_EMPTY ||
+        receipt->opened_turn != trial->opened_turn ||
+        receipt->baseline_proposed_turn !=
+            trial->baseline_proposed_turn ||
+        receipt->spoken != trial->spoken ||
+        receipt->bin != trial->bin ||
+        receipt->eligible <
+            LEO_WONDER_APPETITE_READINESS_MIN_ARM_N ||
+        receipt->abstained <
+            LEO_WONDER_APPETITE_READINESS_MIN_ARM_N ||
+        (int)receipt->eligible + receipt->abstained >
+            LEO_WONDER_APPETITE_CALIB_RING ||
+        receipt->eligible !=
+            receipt->supported + receipt->overreach ||
+        receipt->abstained !=
+            receipt->missed + receipt->restraint)
+        return 0;
+
+    float overreach_lower = 0.0f, overreach_upper = 0.0f;
+    float missed_lower = 0.0f, missed_upper = 0.0f;
+    leo_wilson_interval(
+        receipt->overreach, receipt->eligible,
+        &overreach_lower, &overreach_upper);
+    leo_wilson_interval(
+        receipt->missed, receipt->abstained,
+        &missed_lower, &missed_upper);
+    (void)overreach_lower;
+    (void)missed_lower;
+    return overreach_upper <
+               LEO_WONDER_APPETITE_READINESS_RISK_CEILING &&
+           missed_upper <
+               LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
+}
+
 static void leo_wonder_appetite_holdout_update(Leo *leo) {
     if (!leo || !g_leo_wonder_appetite_holdout_on ||
         !g_leo_wonder_appetite_calibration_on)
@@ -7731,6 +7821,30 @@ static void leo_wonder_appetite_holdout_update(Leo *leo) {
         trial->spoken = frontier.cells[i].spoken;
         trial->bin = frontier.cells[i].bin;
         trial->status = LEO_WONDER_APPETITE_HOLDOUT_PENDING;
+        if (g_leo_wonder_appetite_admission_on) {
+            LeoWonderAppetiteAdmissionReceipt *admission =
+                &leo->wonder_appetite_admissions.receipts[i];
+            memset(admission, 0, sizeof *admission);
+            admission->opened_turn = trial->opened_turn;
+            admission->baseline_proposed_turn =
+                trial->baseline_proposed_turn;
+            admission->spoken = trial->spoken;
+            admission->bin = trial->bin;
+            admission->status =
+                LEO_WONDER_APPETITE_ADMISSION_ATTESTED;
+            admission->eligible =
+                (uint8_t)frontier.cells[i].eligible;
+            admission->abstained =
+                (uint8_t)frontier.cells[i].abstained;
+            admission->supported =
+                (uint8_t)frontier.cells[i].supported;
+            admission->overreach =
+                (uint8_t)frontier.cells[i].overreach;
+            admission->missed =
+                (uint8_t)frontier.cells[i].missed;
+            admission->restraint =
+                (uint8_t)frontier.cells[i].restraint;
+        }
     }
 }
 
@@ -8805,9 +8919,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v21      : slow calibration diary over three-turn appetite forecasts
  *   v22      : forecast-birth shadow abstention snapshots
  *   v23      : fixed-budget out-of-sample trials over readiness candidates
+ *   v24      : immutable A.50 admission receipts for those trials
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 23  /* A.51 persists non-restartable holdout trials; v5..v22 soft-migrate */
+#define LEO_STATE_VERSION 24  /* A.52 preserves why a trial was admitted; v5..v23 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -9038,6 +9153,11 @@ static int leo_save_state(const Leo *leo, const char *path) {
      * Their verdicts remain evidence and have no route into speech. */
     fwrite(&leo->wonder_appetite_holdouts,
            sizeof leo->wonder_appetite_holdouts, 1, f);
+
+    /* A.52 (v24): admission provenance is separate from the v23 experiment.
+     * It may be lost fail-soft without rewriting either history or verdict. */
+    fwrite(&leo->wonder_appetite_admissions,
+           sizeof leo->wonder_appetite_admissions, 1, f);
 
     int ok = (ferror(f) == 0);
     if (fclose(f) != 0) ok = 0;                 /* L-2: the final flush can fail (ENOSPC) — never report success on a truncated file */
@@ -9798,6 +9918,28 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
         }
     }
 
+    /* A.52 admission provenance (v24). v23 trials remain alive but visibly
+     * unattested: reconstructing their vanished admission history would lie. */
+    if (version >= 24) {
+        int admission_ok =
+            fread(&leo->wonder_appetite_admissions,
+                  sizeof leo->wonder_appetite_admissions, 1, f) == 1;
+        if (admission_ok)
+            for (int i = 0;
+                 i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++)
+                if (!leo_wonder_appetite_admission_valid(
+                        &leo->wonder_appetite_admissions.receipts[i],
+                        &leo->wonder_appetite_holdouts.trials[i])) {
+                    admission_ok = 0;
+                    break;
+                }
+        if (!admission_ok) {
+            fprintf(stderr, "[leo] WARNING: v24 readiness-admission tail truncated/corrupt — trials live, but their admission proof is unavailable.\n");
+            memset(&leo->wonder_appetite_admissions, 0,
+                   sizeof leo->wonder_appetite_admissions);
+        }
+    }
+
     fclose(f);
     /* rebuild the derived tables (same as the main startup path) */
     leo_build_chamber_tags(leo);
@@ -10531,6 +10673,79 @@ static void print_wonder_appetite_holdout_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_appetite_admission_stats(const Leo *leo) {
+    if (!g_leo_wonder_appetite_admission_on || !leo)
+        return;
+    int occupied = 0, attested = 0, legacy = 0;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteHoldoutTrial *trial =
+            &leo->wonder_appetite_holdouts.trials[i];
+        if (trial->status == LEO_WONDER_APPETITE_HOLDOUT_EMPTY)
+            continue;
+        occupied++;
+        if (leo->wonder_appetite_admissions.receipts[i].status ==
+            LEO_WONDER_APPETITE_ADMISSION_ATTESTED)
+            attested++;
+        else
+            legacy++;
+    }
+    if (occupied == 0) return;
+
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+    printf("     [wonder-appetite-admission: attested=%d legacy=%d cells=",
+           attested, legacy);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteHoldoutTrial *trial =
+            &leo->wonder_appetite_holdouts.trials[i];
+        if (trial->status == LEO_WONDER_APPETITE_HOLDOUT_EMPTY)
+            continue;
+        const LeoWonderAppetiteAdmissionReceipt *receipt =
+            &leo->wonder_appetite_admissions.receipts[i];
+        int has_receipt =
+            receipt->status ==
+                LEO_WONDER_APPETITE_ADMISSION_ATTESTED;
+        int eligible = has_receipt ? receipt->eligible : 0;
+        int abstained = has_receipt ? receipt->abstained : 0;
+        int supported = has_receipt ? receipt->supported : 0;
+        int overreach = has_receipt ? receipt->overreach : 0;
+        int missed = has_receipt ? receipt->missed : 0;
+        int restraint = has_receipt ? receipt->restraint : 0;
+        float overreach_lower = 0.0f, overreach_upper = 0.0f;
+        float missed_lower = 0.0f, missed_upper = 0.0f;
+        leo_wilson_interval(
+            overreach, eligible,
+            &overreach_lower, &overreach_upper);
+        leo_wilson_interval(
+            missed, abstained,
+            &missed_lower, &missed_upper);
+        (void)overreach_lower;
+        (void)missed_lower;
+        float overreach_rate = eligible > 0 ?
+            (float)overreach / eligible : 0.0f;
+        float missed_rate = abstained > 0 ?
+            (float)missed / abstained : 0.0f;
+        printf("%s%c%d-%d:%llu/%llu/%d/%d/%d/%d/%d/%d/%d/%.3f/%.3f/%.3f/%.3f/%s",
+               separator, trial->spoken ? 's' : 'u',
+               lower[trial->bin], upper[trial->bin],
+               (unsigned long long)trial->opened_turn,
+               (unsigned long long)trial->baseline_proposed_turn,
+               eligible + abstained,
+               eligible, abstained, supported, overreach,
+               missed, restraint,
+               (double)overreach_rate,
+               (double)overreach_upper,
+               (double)missed_rate,
+               (double)missed_upper,
+               has_receipt ? "attested" : "legacy");
+        separator = "|";
+    }
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -10772,6 +10987,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder-appetite-regret")) g_leo_wonder_appetite_regret_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-readiness")) g_leo_wonder_appetite_readiness_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-holdout")) g_leo_wonder_appetite_holdout_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-admission")) g_leo_wonder_appetite_admission_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -10994,6 +11210,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_regret_stats(&leo);
             print_wonder_appetite_readiness_stats(&leo);
             print_wonder_appetite_holdout_stats(&leo);
+            print_wonder_appetite_admission_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -11059,6 +11276,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_regret_stats(&leo);
             print_wonder_appetite_readiness_stats(&leo);
             print_wonder_appetite_holdout_stats(&leo);
+            print_wonder_appetite_admission_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -568,3 +568,30 @@ spends four of its 16 attempts outside the target stratum and ends
 This is still a shadow experiment. `confirmed` does not authorize speech,
 scheduling, routing, or a sampler change. It says only that an A.50 candidate
 survived one future that it could neither select nor postpone.
+
+Run the immutable admission-receipt fork:
+
+```sh
+make deferred-wonder-appetite-admission
+```
+
+A.52 preserves the exact A.50 evidence that allowed a new A.51 trial to open.
+The receipt binds the trial identity and stratum to the original arm counts:
+eligible, abstained, supported, overreach, missed, and restraint. Validation
+recomputes both Wilson bounds and rejects a receipt unless each arm had at
+least eight observations and both upper bounds were strictly below `0.500`.
+
+State v24 places this immutable receipt in a separate tail after the unchanged
+v23 holdout. A v23 trial remains live after migration but is reported as
+`legacy`; absent evidence is never reconstructed. A damaged v24 admission tail
+fails soft by clearing only provenance, leaving the A.51 trial and all earlier
+state intact.
+
+The checked process starts from one exact candidate and forks before arming.
+Default and `--no-wonder-appetite-admission` must produce the same reply and
+byte-identical state through the complete A.51 holdout tail. Only the new A.52
+tail may differ. The admitted fork must preserve the original `7/1 | 1/7`
+outcomes and independently recomputed Wilson upper bounds `0.471/0.471`.
+
+The receipt has no generation reader. `attested` means that the holdout has a
+verifiable warrant, not that its eventual verdict may change speech.

--- a/scripts/deferred_wonder_appetite_admission_matrix.sh
+++ b/scripts/deferred_wonder_appetite_admission_matrix.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# A.52: preserve why A.50 admitted a trial, without changing its life.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-admission-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT"
+
+PLAN="$OUT/plan.tsv"
+printf 'case\texpected_scored\texpected_eligible\texpected_abstained\texpected_overreach_upper\texpected_missed_upper\texpected_status\n' \
+    > "$PLAN"
+printf 'attested\t16\t8\t8\t0.471\t0.471\tattested\n' >> "$PLAN"
+
+if [ "${LEO_APPETITE_ADMISSION_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"${CC:-cc}" -O2 -Wall -Wextra -Wno-unused-function \
+    "$ROOT/tests/wonder_appetite_holdout_fixture.c" -lm \
+    -o "$OUT/holdout-fixture"
+admission_tail_size="$("$OUT/holdout-fixture" --admission-tail-size)"
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+admission_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_admission_dialogue_report.awk" \
+        "$1"
+}
+
+cell_fields() {
+    local cells="$1"
+    local wanted="$2"
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 15; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+"$OUT/holdout-fixture" "$OUT/base.state" arm
+cp "$OUT/base.state" "$OUT/on.state"
+cp "$OUT/base.state" "$OUT/off.state"
+seed=5201
+prompt="The rain falls softly."
+
+"$ROOT/leo" --load "$OUT/on.state" --seed "$seed" \
+    --respond "$prompt" --debug-field \
+    --save "$OUT/on.state" > "$OUT/on.log" 2>&1
+"$ROOT/leo" --load "$OUT/off.state" --seed "$seed" \
+    --respond "$prompt" --debug-field \
+    --no-wonder-appetite-admission \
+    --save "$OUT/off.state" > "$OUT/off.log" 2>&1
+
+admission="$(admission_from_log "$OUT/on.log" attested "$seed")"
+[ -n "$admission" ] || {
+    printf 'A.52 emitted no admission receipt\n' >&2
+    exit 1
+}
+[ -z "$(admission_from_log "$OUT/off.log" ablated "$seed")" ] || {
+    printf 'A.52 admission ablation remained visible\n' >&2
+    exit 1
+}
+[ "$(reply_from_log "$OUT/on.log")" = \
+  "$(reply_from_log "$OUT/off.log")" ] || {
+    printf 'A.52 admission changed Leo reply\n' >&2
+    exit 1
+}
+
+IFS=$'\t' read -r _ _ attested legacy cells <<< "$admission"
+cell="$(cell_fields "$cells" u62-70)"
+[ -n "$cell" ] || {
+    printf 'A.52 lost its exact admission stratum\n' >&2
+    exit 1
+}
+IFS=$'\t' read -r opened baseline scored eligible abstained supported \
+    overreach missed restraint over_rate over_upper miss_rate miss_upper \
+    status extra <<< "$cell"
+[ -z "${extra:-}" ] &&
+[ "$attested" = 1 ] && [ "$legacy" = 0 ] &&
+[ "$opened" -gt 0 ] && [ "$baseline" -gt 0 ] &&
+[ "$scored" = 16 ] && [ "$eligible" = 8 ] &&
+[ "$abstained" = 8 ] && [ "$supported" = 7 ] &&
+[ "$overreach" = 1 ] && [ "$missed" = 1 ] &&
+[ "$restraint" = 7 ] && [ "$over_rate" = 0.125 ] &&
+[ "$over_upper" = 0.471 ] && [ "$miss_rate" = 0.125 ] &&
+[ "$miss_upper" = 0.471 ] && [ "$status" = attested ] || {
+    printf 'A.52 admission geometry was not the exact A.50 warrant\n' >&2
+    exit 1
+}
+
+! cmp -s "$OUT/on.state" "$OUT/off.state" || {
+    printf 'A.52 failed to persist its admission receipt\n' >&2
+    exit 1
+}
+state_size="$(wc -c < "$OUT/on.state" | tr -d ' ')"
+prefix_size=$((state_size - admission_tail_size))
+dd if="$OUT/on.state" of="$OUT/on.prefix" \
+    bs=1 count="$prefix_size" 2>/dev/null
+dd if="$OUT/off.state" of="$OUT/off.prefix" \
+    bs=1 count="$prefix_size" 2>/dev/null
+cmp -s "$OUT/on.prefix" "$OUT/off.prefix" || {
+    printf 'A.52 changed Leo or the A.51 trial outside its own tail\n' >&2
+    exit 1
+}
+
+printf 'case\treply_equal\tbody_and_trial_equal\tstate_equal\tattested\tlegacy\tcell\n'
+printf 'attested\t1\t1\t0\t%s\t%s\t%s\n' \
+    "$attested" "$legacy" "$cells"
+printf '\nmatrix: %s\n' "$OUT"

--- a/scripts/test_deferred_wonder_appetite_admission_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_admission_matrix.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_ADMISSION_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_admission_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 7 || $1 != "case" ||
+            $2 != "expected_scored" ||
+            $7 != "expected_status")
+            exit 1
+        next
+    }
+    {
+        if (NF != 7 || seen[$1]++)
+            exit 1
+        if ($1 != "attested" || $2 != 16 ||
+            $3 != 8 || $4 != 8 ||
+            $5 != "0.471" || $6 != "0.471" ||
+            $7 != "attested")
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 1)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite admission plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite admission matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_admission_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_admission_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-admission: attested=1 legacy=0 cells=u62-70:73/70/16/8/8/7/1/1/7/0.125/0.471/0.125/0.471/attested]
+EOF
+
+got="$(
+    awk -v scenario=armed -v seed=101 \
+        -f "$ROOT/scripts/wonder_appetite_admission_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'armed\t101\t1\t0\tu62-70:73/70/16/8/8/7/1/1/7/0.125/0.471/0.125/0.471/attested'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite admission parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite admission report parser: ok\n'

--- a/scripts/wonder_appetite_admission_dialogue_report.awk
+++ b/scripts/wonder_appetite_admission_dialogue_report.awk
@@ -1,0 +1,28 @@
+# Extract one A.52 immutable admission receipt from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    fields, i, n, prefix, value) {
+    prefix = key "="
+    n = split(line, fields, /[ ]+/)
+    for (i = 1; i <= n; i++) {
+        if (index(fields[i], prefix) != 1)
+            continue
+        value = substr(fields[i], length(prefix) + 1)
+        gsub(/\]$/, "", value)
+        return value
+    }
+    return ""
+}
+
+/\[wonder-appetite-admission: attested=/ {
+    printf "%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed),
+           value_after($0, "attested"),
+           value_after($0, "legacy"),
+           value_after($0, "cells")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -58,7 +58,8 @@ static long test_appetite_and_later_tail_size(const Leo *leo) {
     return (long)(2 * sizeof(int32_t) +
         leo->wonder_appetite_calibration.n *
             (int)sizeof(LeoWonderAppetiteCalibrationReceipt) +
-        sizeof(LeoWonderAppetiteHoldouts));
+        sizeof(LeoWonderAppetiteHoldouts) +
+        sizeof(LeoWonderAppetiteAdmissions));
 }
 
 static void test_add_appetite_calibration(
@@ -703,7 +704,7 @@ static void test_wonder_appetite_regret_surface(void) {
                   sizeof *school_before) &&
           !memcmp(flow_before, &leo->flow,
                   sizeof *flow_before) &&
-          LEO_STATE_VERSION == 23,
+          LEO_STATE_VERSION == 24,
           "wonder-appetite-regret: observing cost rewrites no evidence, body, or state format");
     free(school_before);
     free(flow_before);
@@ -832,7 +833,7 @@ static void test_wonder_appetite_readiness_frontier(void) {
                   sizeof *school_before) &&
           !memcmp(flow_before, &leo->flow,
                   sizeof *flow_before) &&
-          LEO_STATE_VERSION == 23,
+          LEO_STATE_VERSION == 24,
           "wonder-appetite-readiness: candidacy rewrites no evidence, body, or state format");
     free(school_before);
     free(flow_before);
@@ -891,9 +892,12 @@ static void test_wonder_appetite_holdout_trial(void) {
     int previous_calibration =
         g_leo_wonder_appetite_calibration_on;
     int previous_policy = g_leo_wonder_appetite_policy_on;
+    int previous_admission =
+        g_leo_wonder_appetite_admission_on;
     g_leo_wonder_appetite_holdout_on = 1;
     g_leo_wonder_appetite_calibration_on = 1;
     g_leo_wonder_appetite_policy_on = 1;
+    g_leo_wonder_appetite_admission_on = 1;
 
     leo_init(leo);
     LeoWonderAppetiteHoldoutTrial *trial =
@@ -906,6 +910,24 @@ static void test_wonder_appetite_holdout_trial(void) {
           trial->baseline_proposed_turn == 70 &&
           trial->attempts == 0,
           "wonder-appetite-holdout: a candidate freezes one readerless future boundary");
+    LeoWonderAppetiteAdmissionReceipt *admission =
+        &leo->wonder_appetite_admissions.receipts[0];
+    CHECK(admission->status ==
+              LEO_WONDER_APPETITE_ADMISSION_ATTESTED &&
+          admission->opened_turn == trial->opened_turn &&
+          admission->baseline_proposed_turn ==
+              trial->baseline_proposed_turn &&
+          admission->eligible == 8 &&
+          admission->abstained == 8 &&
+          admission->supported == 7 &&
+          admission->overreach == 1 &&
+          admission->missed == 1 &&
+          admission->restraint == 7 &&
+          leo_wonder_appetite_admission_valid(
+              admission, trial),
+          "wonder-appetite-admission: trial birth freezes the exact candidate geometry");
+    LeoWonderAppetiteAdmissionReceipt admission_before =
+        *admission;
     LeoWonderAppetiteCalibration diary_before =
         leo->wonder_appetite_calibration;
     LeoSchool *school_before = malloc(sizeof *school_before);
@@ -915,6 +937,8 @@ static void test_wonder_appetite_holdout_trial(void) {
     leo_wonder_appetite_holdout_update(leo);
     CHECK(trial && school_before && flow_before &&
           trial->attempts == 0 &&
+          !memcmp(&admission_before, admission,
+                  sizeof admission_before) &&
           !memcmp(&diary_before,
                   &leo->wonder_appetite_calibration,
                   sizeof diary_before) &&
@@ -945,10 +969,15 @@ static void test_wonder_appetite_holdout_trial(void) {
     CHECK(!memcmp(&terminal, trial, sizeof terminal),
           "wonder-appetite-holdout: a terminal trial cannot restart on its favorable history");
 
-    const char *state = "/tmp/leo_appetite_holdout_v23.state";
+    const char *state = "/tmp/leo_appetite_holdout_v24.state";
     const char *v22 = "/tmp/leo_appetite_holdout_v22.state";
+    const char *v23 = "/tmp/leo_appetite_holdout_v23.state";
     const char *cut = "/tmp/leo_appetite_holdout_v23_cut.state";
     const char *bad = "/tmp/leo_appetite_holdout_v23_bad.state";
+    const char *admission_cut =
+        "/tmp/leo_appetite_admission_v24_cut.state";
+    const char *admission_bad =
+        "/tmp/leo_appetite_admission_v24_bad.state";
     int saved = leo_save_state(leo, state);
     Leo *woke = malloc(sizeof *woke);
     Leo *old = malloc(sizeof *old);
@@ -959,10 +988,15 @@ static void test_wonder_appetite_holdout_trial(void) {
     CHECK(saved && woke && leo_load_state(woke, state) &&
           !memcmp(&woke->wonder_appetite_holdouts,
                   &leo->wonder_appetite_holdouts,
-                  sizeof leo->wonder_appetite_holdouts),
-          "wonder-appetite-holdout: a completed trial survives v23 sleep exactly");
+                  sizeof leo->wonder_appetite_holdouts) &&
+          !memcmp(&woke->wonder_appetite_admissions,
+                  &leo->wonder_appetite_admissions,
+                  sizeof leo->wonder_appetite_admissions),
+          "wonder-appetite-admission: trial and its admission proof survive v24 sleep exactly");
 
-    int built_v22 = 0, built_cut = 0, built_bad = 0;
+    int built_v22 = 0, built_v23 = 0;
+    int built_cut = 0, built_bad = 0;
+    int built_admission_cut = 0, built_admission_bad = 0;
     FILE *fi = fopen(state, "rb");
     if (fi) {
         fseek(fi, 0, SEEK_END);
@@ -971,14 +1005,20 @@ static void test_wonder_appetite_holdout_trial(void) {
         unsigned char *bytes =
             malloc(size > 0 ? (size_t)size : 1);
         if (bytes &&
-            size > (long)sizeof(LeoWonderAppetiteHoldouts) &&
+            size > (long)(sizeof(LeoWonderAppetiteHoldouts) +
+                          sizeof(LeoWonderAppetiteAdmissions)) &&
             (long)fread(bytes, 1, (size_t)size, fi) == size) {
+            long admission_tail =
+                (long)sizeof(LeoWonderAppetiteAdmissions);
+            long holdout_tail =
+                (long)sizeof(LeoWonderAppetiteHoldouts);
+            long holdout_start =
+                size - admission_tail - holdout_tail;
             uint32_t twenty_two = 22;
             memcpy(bytes + sizeof(uint32_t), &twenty_two,
                    sizeof twenty_two);
             FILE *fo = fopen(v22, "wb");
-            long v22_size =
-                size - (long)sizeof(LeoWonderAppetiteHoldouts);
+            long v22_size = holdout_start;
             if (fo) {
                 built_v22 =
                     (long)fwrite(bytes, 1,
@@ -988,30 +1028,75 @@ static void test_wonder_appetite_holdout_trial(void) {
             uint32_t twenty_three = 23;
             memcpy(bytes + sizeof(uint32_t), &twenty_three,
                    sizeof twenty_three);
+            fo = fopen(v23, "wb");
+            if (fo) {
+                built_v23 =
+                    (long)fwrite(
+                        bytes, 1,
+                        (size_t)(size - admission_tail), fo) ==
+                    size - admission_tail;
+                fclose(fo);
+            }
             fo = fopen(cut, "wb");
             if (fo) {
                 built_cut =
+                    (long)fwrite(bytes, 1,
+                                 (size_t)(size - admission_tail - 1),
+                                 fo) ==
+                    size - admission_tail - 1;
+                fclose(fo);
+            }
+            uint32_t twenty_four = 24;
+            memcpy(bytes + sizeof(uint32_t), &twenty_four,
+                   sizeof twenty_four);
+            fo = fopen(admission_cut, "wb");
+            if (fo) {
+                built_admission_cut =
                     (long)fwrite(bytes, 1,
                                  (size_t)(size - 1), fo) ==
                     size - 1;
                 fclose(fo);
             }
+            LeoWonderAppetiteAdmissions corrupted_admission;
+            memcpy(
+                &corrupted_admission,
+                bytes + size - admission_tail,
+                sizeof corrupted_admission);
+            corrupted_admission.receipts[0].supported = 4;
+            corrupted_admission.receipts[0].overreach = 4;
+            memcpy(
+                bytes + size - admission_tail,
+                &corrupted_admission,
+                sizeof corrupted_admission);
+            fo = fopen(admission_bad, "wb");
+            if (fo) {
+                built_admission_bad =
+                    (long)fwrite(bytes, 1,
+                                 (size_t)size, fo) == size;
+                fclose(fo);
+            }
+            memcpy(
+                bytes + size - admission_tail,
+                &leo->wonder_appetite_admissions,
+                sizeof leo->wonder_appetite_admissions);
+            memcpy(bytes + sizeof(uint32_t), &twenty_three,
+                   sizeof twenty_three);
             LeoWonderAppetiteHoldouts corrupted;
             memcpy(
                 &corrupted,
-                bytes + size -
-                    (long)sizeof(LeoWonderAppetiteHoldouts),
+                bytes + holdout_start,
                 sizeof corrupted);
             corrupted.trials[0].attempts = 15;
             memcpy(
-                bytes + size -
-                    (long)sizeof(LeoWonderAppetiteHoldouts),
+                bytes + holdout_start,
                 &corrupted, sizeof corrupted);
             fo = fopen(bad, "wb");
             if (fo) {
                 built_bad =
                     (long)fwrite(bytes, 1,
-                                 (size_t)size, fo) == size;
+                                 (size_t)(size - admission_tail),
+                                 fo) ==
+                    size - admission_tail;
                 fclose(fo);
             }
         }
@@ -1024,6 +1109,13 @@ static void test_wonder_appetite_holdout_trial(void) {
           old->wonder_appetite_holdouts.trials[0].status ==
               LEO_WONDER_APPETITE_HOLDOUT_EMPTY,
           "wonder-appetite-holdout: a v22 body migrates without invented future evidence");
+    CHECK(built_v23 && old && leo_load_state(old, v23) &&
+          !memcmp(&old->wonder_appetite_holdouts,
+                  &leo->wonder_appetite_holdouts,
+                  sizeof leo->wonder_appetite_holdouts) &&
+          old->wonder_appetite_admissions.receipts[0].status ==
+              LEO_WONDER_APPETITE_ADMISSION_EMPTY,
+          "wonder-appetite-admission: a v23 trial lives without invented admission proof");
     CHECK(built_cut && damaged &&
           leo_load_state(damaged, cut) &&
           damaged->wonder_appetite_calibration.n ==
@@ -1038,13 +1130,32 @@ static void test_wonder_appetite_holdout_trial(void) {
           damaged->wonder_appetite_holdouts.trials[0].status ==
               LEO_WONDER_APPETITE_HOLDOUT_EMPTY,
           "wonder-appetite-holdout: an impossible v23 verdict fails soft without rewriting history");
+    CHECK(built_admission_cut && damaged &&
+          leo_load_state(damaged, admission_cut) &&
+          !memcmp(&damaged->wonder_appetite_holdouts,
+                  &leo->wonder_appetite_holdouts,
+                  sizeof leo->wonder_appetite_holdouts) &&
+          damaged->wonder_appetite_admissions.receipts[0].status ==
+              LEO_WONDER_APPETITE_ADMISSION_EMPTY,
+          "wonder-appetite-admission: a truncated v24 proof loses no trial");
+    CHECK(built_admission_bad && damaged &&
+          leo_load_state(damaged, admission_bad) &&
+          !memcmp(&damaged->wonder_appetite_holdouts,
+                  &leo->wonder_appetite_holdouts,
+                  sizeof leo->wonder_appetite_holdouts) &&
+          damaged->wonder_appetite_admissions.receipts[0].status ==
+              LEO_WONDER_APPETITE_ADMISSION_EMPTY,
+          "wonder-appetite-admission: an unbounded admission claim fails soft");
     if (woke) { leo_free(woke); free(woke); }
     if (old) { leo_free(old); free(old); }
     if (damaged) { leo_free(damaged); free(damaged); }
     remove(state);
     remove(v22);
+    remove(v23);
     remove(cut);
     remove(bad);
+    remove(admission_cut);
+    remove(admission_bad);
 
     leo_free(leo);
     leo_init(leo);
@@ -1114,6 +1225,18 @@ static void test_wonder_appetite_holdout_trial(void) {
 
     leo_free(leo);
     leo_init(leo);
+    g_leo_wonder_appetite_admission_on = 0;
+    trial = test_open_appetite_holdout(leo, 0.65f, 0);
+    CHECK(trial &&
+          trial->status ==
+              LEO_WONDER_APPETITE_HOLDOUT_PENDING &&
+          leo->wonder_appetite_admissions.receipts[0].status ==
+              LEO_WONDER_APPETITE_ADMISSION_EMPTY,
+          "wonder-appetite-admission: ablation leaves the trial visibly unattested");
+    g_leo_wonder_appetite_admission_on = 1;
+
+    leo_free(leo);
+    leo_init(leo);
     g_leo_wonder_appetite_holdout_on = 0;
     trial = test_open_appetite_holdout(leo, 0.65f, 0);
     CHECK(trial &&
@@ -1125,6 +1248,8 @@ static void test_wonder_appetite_holdout_trial(void) {
     g_leo_wonder_appetite_calibration_on =
         previous_calibration;
     g_leo_wonder_appetite_policy_on = previous_policy;
+    g_leo_wonder_appetite_admission_on =
+        previous_admission;
     leo_free(leo);
     free(leo);
 }
@@ -3159,13 +3284,14 @@ int main(void) {
                            sizeof twenty_two);
                     fo = fopen(cut, "wb");
                     if (fo) {
-                        long holdout_tail =
-                            (long)sizeof(LeoWonderAppetiteHoldouts);
+                        long post_v22_tail =
+                            (long)(sizeof(LeoWonderAppetiteHoldouts) +
+                                   sizeof(LeoWonderAppetiteAdmissions));
                         built_cut =
                             (long)fwrite(
                                 bytes, 1,
-                                (size_t)(sz - holdout_tail - 1), fo) ==
-                            sz - holdout_tail - 1;
+                                (size_t)(sz - post_v22_tail - 1), fo) ==
+                            sz - post_v22_tail - 1;
                         fclose(fo);
                     }
 

--- a/tests/wonder_appetite_holdout_fixture.c
+++ b/tests/wonder_appetite_holdout_fixture.c
@@ -159,7 +159,13 @@ static int add_future(Leo *leo, const char *scenario) {
 
 int main(int argc, char **argv) {
     if (argc == 2 && !strcmp(argv[1], "--tail-size")) {
-        printf("%zu\n", sizeof(LeoWonderAppetiteHoldouts));
+        printf("%zu\n",
+               sizeof(LeoWonderAppetiteHoldouts) +
+               sizeof(LeoWonderAppetiteAdmissions));
+        return 0;
+    }
+    if (argc == 2 && !strcmp(argv[1], "--admission-tail-size")) {
+        printf("%zu\n", sizeof(LeoWonderAppetiteAdmissions));
         return 0;
     }
     if (argc != 3 ||


### PR DESCRIPTION
A.52 freezes the exact A.50 readiness geometry beside each A.51 trial, migrates older trials visibly unattested, and fails soft when only the provenance tail is damaged.

Quote: "An experiment that forgets why it began cannot testify about what it found." - Sol
Method: The Arianna Method preserves the warrant beside the trial so later evidence cannot invent its own origin.