### PR TITLE
the method gives evidence a present tense

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4673,3 +4673,78 @@ and arming prefix `1/1`.
 
 A trial that outlives its diary can now testify both to what the future did and
 to why the past was allowed to ask.
+
+## Phase A.53 — evidence has a present tense (2026-07-28)
+
+A.52 made the origin of a trial auditable, but a valid origin and a confirmed
+future are still historical facts. Leo can change after both. Treating an old
+result as permanently applicable would turn continuity into stasis.
+
+A.53 derives a current-life transport witness for each exact
+spoken/appetite stratum. It begins only with an attested A.52 admission and a
+confirmed A.51 holdout. Its temporal boundary is the last proposal identity
+actually consumed by that holdout. Only settled A.48 receipts strictly after
+that boundary may describe the present.
+
+The witness keeps three vetoes independent:
+
+```text
+motion       current overreach 95% Wilson upper bound < 0.500
+restraint    current missed-continuation upper bound < 0.500
+coverage     current policy-coverage interval overlaps both:
+               the A.52 admission interval
+               the realized A.51 holdout interval
+```
+
+Both current policy arms need at least eight causally scored observations.
+Confounded lives remain visible but cannot fill an arm. Another stratum cannot
+lend evidence. A post-boundary `none` or `legacy` policy makes the witness
+`incompatible` rather than translating between policy languages.
+
+The resulting statuses preserve why no claim is available:
+
+```text
+unattested    the trial has no valid A.52 warrant
+pending       the A.51 future has not ended
+refuted       the A.51 future did not confirm
+incompatible  the policy language changed
+observing     one or both current arms contain fewer than 8 outcomes
+shifted       at least one current axis vetoes transport
+provisional   all three measured axes survived the current window
+```
+
+`provisional` is deliberately weaker than statistical equivalence. Overlapping
+95% coverage intervals establish only that this bounded window did not expose
+a clear ecology displacement. They do not prove that the admission, holdout,
+and present distributions are identical, and they say nothing about the rest
+of Leo's semantics.
+
+A.53 is reconstructed from existing v24 evidence and adds no state. It has no
+reader in School, Flow, shadow, routing, sampling, scheduling, or generation.
+`--no-wonder-appetite-transport` suppresses only the diagnostic witness.
+
+Thirteen direct contracts raised the suite from **421/421** to **434/434**.
+They cover empty, pending, unattested, refuted, observing, incompatible, the
+two independent risk shifts, separate admission-coverage and holdout-coverage
+shifts, provisional continuity, complete non-mutation, and unchanged state
+format.
+
+The eight-case real-process matrix then held prompt and seed fixed across
+default/ablated forks:
+
+```text
+provisional             bounds 0.471 / 0.471, axes 1/1/1
+motion shift            bounds 0.785 / 0.471, axes 0/1/1
+restraint shift         bounds 0.471 / 0.785, axes 1/0/1
+both risk shifts        bounds 0.785 / 0.785, axes 0/0/1
+admission ecology shift bounds 0.202 / 0.471, axes 1/1/0
+holdout ecology shift   bounds 0.202 / 0.471, axes 1/1/0
+observing               current exact lives 7
+incompatible            post-boundary legacy policies 1
+
+reply equality          8/8
+complete state equality 8/8
+```
+
+The result can now age without being erased and expire without being called
+false. A past can remain true while ceasing to be the present.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport
 
 all: leo
 
@@ -91,6 +91,9 @@ deferred-wonder-appetite-holdout: leo
 deferred-wonder-appetite-admission: leo
 	./scripts/deferred_wonder_appetite_admission_matrix.sh
 
+deferred-wonder-appetite-transport: leo
+	./scripts/deferred_wonder_appetite_transport_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -108,6 +111,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_appetite_readiness_dialogue_report.sh
 	./scripts/test_wonder_appetite_holdout_dialogue_report.sh
 	./scripts/test_wonder_appetite_admission_dialogue_report.sh
+	./scripts/test_wonder_appetite_transport_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -123,6 +127,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_readiness_matrix.sh
 	./scripts/test_deferred_wonder_appetite_holdout_matrix.sh
 	./scripts/test_deferred_wonder_appetite_admission_matrix.sh
+	./scripts/test_deferred_wonder_appetite_transport_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -2089,6 +2089,67 @@ typedef struct {
         receipts[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
 } LeoWonderAppetiteAdmissions;
 
+/* A.53: a historically valid result need not describe Leo's current life.
+ * Re-evaluate each confirmed, attested trial only on receipts strictly after
+ * its terminal boundary. The three vetoes stay separate: motion risk,
+ * restraint risk, and policy coverage. This is a derived witness, never state. */
+#define LEO_WONDER_APPETITE_TRANSPORT_MIN_ARM_N 8
+enum {
+    LEO_WONDER_APPETITE_TRANSPORT_EMPTY = 0,
+    LEO_WONDER_APPETITE_TRANSPORT_UNATTESTED,
+    LEO_WONDER_APPETITE_TRANSPORT_PENDING,
+    LEO_WONDER_APPETITE_TRANSPORT_REFUTED,
+    LEO_WONDER_APPETITE_TRANSPORT_INCOMPATIBLE,
+    LEO_WONDER_APPETITE_TRANSPORT_OBSERVING,
+    LEO_WONDER_APPETITE_TRANSPORT_SHIFTED,
+    LEO_WONDER_APPETITE_TRANSPORT_PROVISIONAL,
+    LEO_WONDER_APPETITE_TRANSPORT_STATUS_COUNT
+};
+typedef struct {
+    uint64_t after_proposed_turn;
+    int post_settled;
+    int exact;
+    int eligible;
+    int abstained;
+    int supported;
+    int overreach;
+    int missed;
+    int restraint;
+    int confounded;
+    int other;
+    int incompatible;
+    float admission_coverage;
+    float admission_coverage_lower;
+    float admission_coverage_upper;
+    float holdout_coverage;
+    float holdout_coverage_lower;
+    float holdout_coverage_upper;
+    float current_coverage;
+    float current_coverage_lower;
+    float current_coverage_upper;
+    float overreach_rate;
+    float overreach_upper;
+    float missed_rate;
+    float missed_upper;
+    uint8_t spoken;
+    uint8_t bin;
+    uint8_t motion_bounded;
+    uint8_t restraint_bounded;
+    uint8_t coverage_compatible;
+    uint8_t status;
+} LeoWonderAppetiteTransportCell;
+typedef struct {
+    LeoWonderAppetiteTransportCell
+        cells[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+    int unattested;
+    int pending;
+    int refuted;
+    int incompatible;
+    int observing;
+    int shifted;
+    int provisional;
+} LeoWonderAppetiteTransport;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -2547,6 +2608,7 @@ static int g_leo_wonder_appetite_regret_on = 1; /* separate costs of motion and 
 static int g_leo_wonder_appetite_readiness_on = 1; /* paired confidence frontier; candidate is not permission. */
 static int g_leo_wonder_appetite_holdout_on = 1; /* fixed future trial; persisted evidence, never speech authority. */
 static int g_leo_wonder_appetite_admission_on = 1; /* immutable candidate provenance; no reader in speech. */
+static int g_leo_wonder_appetite_transport_on = 1; /* current-life transport witness; derived and readerless. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -7718,6 +7780,226 @@ static int leo_wonder_appetite_admission_valid(
                LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
 }
 
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_transport_status_name(
+        int status) {
+    static const char
+        *names[LEO_WONDER_APPETITE_TRANSPORT_STATUS_COUNT] = {
+            "empty", "unattested", "pending", "refuted",
+            "incompatible", "observing", "shifted",
+            "provisional"
+        };
+    return status >= 0 &&
+           status < LEO_WONDER_APPETITE_TRANSPORT_STATUS_COUNT ?
+        names[status] : "empty";
+}
+
+static uint64_t leo_wonder_appetite_holdout_terminal_boundary(
+        const LeoWonderAppetiteHoldoutTrial *trial) {
+    uint64_t boundary = 0;
+    if (!trial) return boundary;
+    for (int i = 0; i < trial->attempts; i++)
+        if (trial->seen_proposed_turn[i] > boundary)
+            boundary = trial->seen_proposed_turn[i];
+    return boundary;
+}
+
+static void leo_wonder_appetite_transport(
+        const Leo *leo, LeoWonderAppetiteTransport *witness) {
+    if (!witness) return;
+    memset(witness, 0, sizeof *witness);
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        LeoWonderAppetiteTransportCell *cell =
+            &witness->cells[i];
+        cell->spoken =
+            (uint8_t)(i /
+                LEO_WONDER_APPETITE_RELIABILITY_BINS);
+        cell->bin =
+            (uint8_t)(i %
+                LEO_WONDER_APPETITE_RELIABILITY_BINS);
+    }
+    if (!leo) return;
+
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteHoldoutTrial *trial =
+            &leo->wonder_appetite_holdouts.trials[i];
+        const LeoWonderAppetiteAdmissionReceipt *admission =
+            &leo->wonder_appetite_admissions.receipts[i];
+        LeoWonderAppetiteTransportCell *cell =
+            &witness->cells[i];
+        if (trial->status ==
+            LEO_WONDER_APPETITE_HOLDOUT_EMPTY)
+            continue;
+        cell->spoken = trial->spoken;
+        cell->bin = trial->bin;
+
+        if (!leo_wonder_appetite_admission_valid(
+                admission, trial) ||
+            admission->status !=
+                LEO_WONDER_APPETITE_ADMISSION_ATTESTED) {
+            cell->status =
+                LEO_WONDER_APPETITE_TRANSPORT_UNATTESTED;
+            witness->unattested++;
+            continue;
+        }
+        if (trial->status ==
+            LEO_WONDER_APPETITE_HOLDOUT_PENDING) {
+            cell->status =
+                LEO_WONDER_APPETITE_TRANSPORT_PENDING;
+            witness->pending++;
+            continue;
+        }
+        if (trial->status !=
+            LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED) {
+            cell->status =
+                LEO_WONDER_APPETITE_TRANSPORT_REFUTED;
+            witness->refuted++;
+            continue;
+        }
+
+        cell->after_proposed_turn =
+            leo_wonder_appetite_holdout_terminal_boundary(trial);
+        for (int j = 0;
+             j < leo->wonder_appetite_calibration.n; j++) {
+            const LeoWonderAppetiteCalibrationReceipt *receipt =
+                leo_wonder_appetite_calibration_at(
+                    &leo->wonder_appetite_calibration, j);
+            if (!receipt ||
+                receipt->proposed_turn <=
+                    cell->after_proposed_turn)
+                continue;
+            int result =
+                leo_wonder_appetite_policy_result(receipt);
+            if (result ==
+                LEO_WONDER_APPETITE_POLICY_RESULT_PENDING)
+                continue;
+            cell->post_settled++;
+            if (result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_NONE ||
+                result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_LEGACY) {
+                cell->incompatible++;
+                continue;
+            }
+            int bin = leo_wonder_appetite_reliability_bin(
+                receipt->appetite);
+            int exact =
+                bin == trial->bin &&
+                (receipt->spoken ? 1 : 0) == trial->spoken;
+            if (!exact) {
+                cell->other++;
+                continue;
+            }
+            if (result ==
+                LEO_WONDER_APPETITE_POLICY_RESULT_CONFOUNDED) {
+                cell->confounded++;
+                continue;
+            }
+
+            cell->exact++;
+            if (receipt->policy ==
+                LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+                cell->eligible++;
+                if (result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_SUPPORTED)
+                    cell->supported++;
+                else
+                    cell->overreach++;
+            } else {
+                cell->abstained++;
+                if (result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_MISSED)
+                    cell->missed++;
+                else
+                    cell->restraint++;
+            }
+        }
+
+        if (cell->incompatible > 0) {
+            cell->status =
+                LEO_WONDER_APPETITE_TRANSPORT_INCOMPATIBLE;
+            witness->incompatible++;
+            continue;
+        }
+        if (cell->eligible <
+                LEO_WONDER_APPETITE_TRANSPORT_MIN_ARM_N ||
+            cell->abstained <
+                LEO_WONDER_APPETITE_TRANSPORT_MIN_ARM_N) {
+            cell->status =
+                LEO_WONDER_APPETITE_TRANSPORT_OBSERVING;
+            witness->observing++;
+            continue;
+        }
+
+        int admission_total =
+            admission->eligible + admission->abstained;
+        cell->admission_coverage =
+            (float)admission->eligible / admission_total;
+        leo_wilson_interval(
+            admission->eligible, admission_total,
+            &cell->admission_coverage_lower,
+            &cell->admission_coverage_upper);
+        int holdout_total =
+            trial->eligible + trial->abstained;
+        cell->holdout_coverage =
+            (float)trial->eligible / holdout_total;
+        leo_wilson_interval(
+            trial->eligible, holdout_total,
+            &cell->holdout_coverage_lower,
+            &cell->holdout_coverage_upper);
+        cell->current_coverage =
+            (float)cell->eligible / cell->exact;
+        leo_wilson_interval(
+            cell->eligible, cell->exact,
+            &cell->current_coverage_lower,
+            &cell->current_coverage_upper);
+
+        float overreach_lower = 0.0f;
+        float missed_lower = 0.0f;
+        leo_wilson_interval(
+            cell->overreach, cell->eligible,
+            &overreach_lower, &cell->overreach_upper);
+        leo_wilson_interval(
+            cell->missed, cell->abstained,
+            &missed_lower, &cell->missed_upper);
+        (void)overreach_lower;
+        (void)missed_lower;
+        cell->overreach_rate =
+            (float)cell->overreach / cell->eligible;
+        cell->missed_rate =
+            (float)cell->missed / cell->abstained;
+        cell->motion_bounded =
+            cell->overreach_upper <
+                LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
+        cell->restraint_bounded =
+            cell->missed_upper <
+                LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
+        cell->coverage_compatible =
+            cell->current_coverage_lower <=
+                cell->admission_coverage_upper &&
+            cell->admission_coverage_lower <=
+                cell->current_coverage_upper &&
+            cell->current_coverage_lower <=
+                cell->holdout_coverage_upper &&
+            cell->holdout_coverage_lower <=
+                cell->current_coverage_upper;
+
+        if (cell->motion_bounded &&
+            cell->restraint_bounded &&
+            cell->coverage_compatible) {
+            cell->status =
+                LEO_WONDER_APPETITE_TRANSPORT_PROVISIONAL;
+            witness->provisional++;
+        } else {
+            cell->status =
+                LEO_WONDER_APPETITE_TRANSPORT_SHIFTED;
+            witness->shifted++;
+        }
+    }
+}
+
 static void leo_wonder_appetite_holdout_update(Leo *leo) {
     if (!leo || !g_leo_wonder_appetite_holdout_on ||
         !g_leo_wonder_appetite_calibration_on)
@@ -10746,6 +11028,69 @@ static void print_wonder_appetite_admission_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_appetite_transport_stats(const Leo *leo) {
+    if (!g_leo_wonder_appetite_transport_on || !leo)
+        return;
+    int occupied = 0;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++)
+        if (leo->wonder_appetite_holdouts.trials[i].status !=
+            LEO_WONDER_APPETITE_HOLDOUT_EMPTY)
+            occupied++;
+    if (occupied == 0) return;
+
+    LeoWonderAppetiteTransport witness;
+    leo_wonder_appetite_transport(leo, &witness);
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+    printf("     [wonder-appetite-transport: min-arm=%d ceiling=%.3f unattested=%d pending=%d refuted=%d incompatible=%d observing=%d shifted=%d provisional=%d cells=",
+           LEO_WONDER_APPETITE_TRANSPORT_MIN_ARM_N,
+           (double)LEO_WONDER_APPETITE_READINESS_RISK_CEILING,
+           witness.unattested, witness.pending,
+           witness.refuted, witness.incompatible,
+           witness.observing, witness.shifted,
+           witness.provisional);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteTransportCell *cell =
+            &witness.cells[i];
+        if (cell->status ==
+            LEO_WONDER_APPETITE_TRANSPORT_EMPTY)
+            continue;
+        printf("%s%c%d-%d:%llu/%d/%d/%d/%d/%d/%d/%d/%d/%d/%d/%d/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%u/%u/%u/%s",
+               separator, cell->spoken ? 's' : 'u',
+               lower[cell->bin], upper[cell->bin],
+               (unsigned long long)cell->after_proposed_turn,
+               cell->post_settled, cell->exact,
+               cell->eligible, cell->abstained,
+               cell->supported, cell->overreach,
+               cell->missed, cell->restraint,
+               cell->confounded, cell->other,
+               cell->incompatible,
+               (double)cell->admission_coverage,
+               (double)cell->admission_coverage_lower,
+               (double)cell->admission_coverage_upper,
+               (double)cell->holdout_coverage,
+               (double)cell->holdout_coverage_lower,
+               (double)cell->holdout_coverage_upper,
+               (double)cell->current_coverage,
+               (double)cell->current_coverage_lower,
+               (double)cell->current_coverage_upper,
+               (double)cell->overreach_rate,
+               (double)cell->overreach_upper,
+               (double)cell->missed_rate,
+               (double)cell->missed_upper,
+               (unsigned)cell->motion_bounded,
+               (unsigned)cell->restraint_bounded,
+               (unsigned)cell->coverage_compatible,
+               leo_wonder_appetite_transport_status_name(
+                   cell->status));
+        separator = "|";
+    }
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -10988,6 +11333,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder-appetite-readiness")) g_leo_wonder_appetite_readiness_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-holdout")) g_leo_wonder_appetite_holdout_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-admission")) g_leo_wonder_appetite_admission_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-transport")) g_leo_wonder_appetite_transport_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -11211,6 +11557,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_readiness_stats(&leo);
             print_wonder_appetite_holdout_stats(&leo);
             print_wonder_appetite_admission_stats(&leo);
+            print_wonder_appetite_transport_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -11277,6 +11624,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_readiness_stats(&leo);
             print_wonder_appetite_holdout_stats(&leo);
             print_wonder_appetite_admission_stats(&leo);
+            print_wonder_appetite_transport_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -595,3 +595,35 @@ outcomes and independently recomputed Wilson upper bounds `0.471/0.471`.
 
 The receipt has no generation reader. `attested` means that the holdout has a
 verifiable warrant, not that its eventual verdict may change speech.
+
+Run the current-life transport matrix:
+
+```sh
+make deferred-wonder-appetite-transport
+```
+
+A.53 asks whether one attested, confirmed result still describes the measured
+policy geometry of Leo's present. The current window begins strictly after the
+last proposal consumed by A.51. Earlier admission evidence and the holdout
+cannot grade their own transport.
+
+Each exact spoken/appetite stratum needs eight new eligible and eight new
+abstained outcomes. Current overreach and missed-continuation Wilson upper
+bounds must independently remain below `0.500`. Policy coverage stays a third
+axis: the current 95% interval must overlap both the A.52 admission interval
+and the realized A.51 holdout interval.
+
+An interval overlap is a compatibility screen, not an equivalence test. The
+success status is therefore `provisional`, not permanent applicability.
+`unattested`, `pending`, `refuted`, `incompatible`, `observing`, and `shifted`
+preserve the distinct ways a transport claim may be unavailable.
+
+The checked matrix rotates motion risk, restraint risk, admission coverage,
+and holdout coverage independently. It also includes thin-current and
+policy-language-change cases. Default and
+`--no-wonder-appetite-transport` forks must keep identical replies and
+byte-identical complete v24 states for all eight rows.
+
+A.53 is derived diagnostics only. It does not persist another judgment and no
+speech or scheduler path reads it. Even `provisional` remains evidence, not
+permission.

--- a/scripts/deferred_wonder_appetite_transport_matrix.sh
+++ b/scripts/deferred_wonder_appetite_transport_matrix.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# A.53: ask whether one historical result still describes Leo's current life.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-transport-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT"
+
+PLAN="$OUT/plan.tsv"
+printf 'case\texpected_exact\texpected_eligible\texpected_abstained\texpected_overreach_upper\texpected_missed_upper\texpected_motion_bounded\texpected_restraint_bounded\texpected_coverage_compatible\texpected_status\n' \
+    > "$PLAN"
+printf 'transport-provisional\t16\t8\t8\t0.471\t0.471\t1\t1\t1\tprovisional\n' >> "$PLAN"
+printf 'transport-motion-shift\t16\t8\t8\t0.785\t0.471\t0\t1\t1\tshifted\n' >> "$PLAN"
+printf 'transport-restraint-shift\t16\t8\t8\t0.471\t0.785\t1\t0\t1\tshifted\n' >> "$PLAN"
+printf 'transport-both-shift\t16\t8\t8\t0.785\t0.785\t0\t0\t1\tshifted\n' >> "$PLAN"
+printf 'transport-coverage-shift\t32\t24\t8\t0.202\t0.471\t1\t1\t0\tshifted\n' >> "$PLAN"
+printf 'transport-holdout-coverage-shift\t32\t24\t8\t0.202\t0.471\t1\t1\t0\tshifted\n' >> "$PLAN"
+printf 'transport-observing\t7\t7\t0\t0.000\t0.000\t0\t0\t0\tobserving\n' >> "$PLAN"
+printf 'transport-incompatible\t0\t0\t0\t0.000\t0.000\t0\t0\t0\tincompatible\n' >> "$PLAN"
+
+if [ "${LEO_APPETITE_TRANSPORT_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"${CC:-cc}" -O2 -Wall -Wextra -Wno-unused-function \
+    "$ROOT/tests/wonder_appetite_holdout_fixture.c" -lm \
+    -o "$OUT/holdout-fixture"
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+transport_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_transport_dialogue_report.awk" \
+        "$1"
+}
+
+cell_fields() {
+    local cells="$1"
+    local wanted="$2"
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 29; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+MATRIX="$OUT/matrix.tsv"
+printf 'case\tpost_settled\texact\teligible\tabstained\toverreach_upper\tmissed_upper\tmotion_bounded\trestraint_bounded\tcoverage_compatible\tstatus\treply_equal\tstate_equal\n' \
+    > "$MATRIX"
+
+tail -n +2 "$PLAN" |
+while IFS=$'\t' read -r case_name expected_exact \
+        expected_eligible expected_abstained expected_over_upper \
+        expected_miss_upper expected_motion expected_restraint \
+        expected_coverage expected_status; do
+    case_dir="$OUT/$case_name"
+    mkdir -p "$case_dir"
+    "$OUT/holdout-fixture" "$case_dir/base.state" "$case_name"
+    cp "$case_dir/base.state" "$case_dir/on.state"
+    cp "$case_dir/base.state" "$case_dir/off.state"
+    seed=5301
+    prompt="The rain falls softly."
+
+    "$ROOT/leo" --load "$case_dir/on.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --save "$case_dir/on.state" > "$case_dir/on.log" 2>&1
+    "$ROOT/leo" --load "$case_dir/off.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --no-wonder-appetite-transport \
+        --save "$case_dir/off.state" > "$case_dir/off.log" 2>&1
+
+    transport="$(
+        transport_from_log "$case_dir/on.log" "$case_name" "$seed"
+    )"
+    [ -n "$transport" ] || {
+        printf '%s emitted no A.53 transport witness\n' \
+            "$case_name" >&2
+        exit 1
+    }
+    [ -z "$(
+        transport_from_log "$case_dir/off.log" "$case_name" "$seed"
+    )" ] || {
+        printf '%s transport ablation remained visible\n' \
+            "$case_name" >&2
+        exit 1
+    }
+
+    IFS=$'\t' read -r _ _ min_arm ceiling unattested pending refuted \
+        incompatible observing shifted provisional cells \
+        <<< "$transport"
+    cell="$(cell_fields "$cells" u62-70)"
+    [ -n "$cell" ] || {
+        printf '%s lost its transport cell\n' "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r after post_settled exact eligible abstained \
+        supported overreach missed restraint confounded other incompatible_n \
+        admission_coverage admission_lower admission_upper holdout_coverage \
+        holdout_lower holdout_upper current_coverage current_lower \
+        current_upper over_rate over_upper miss_rate miss_upper \
+        motion_bounded restraint_bounded coverage_compatible status extra \
+        <<< "$cell"
+
+    expected_unattested=0
+    expected_pending=0
+    expected_refuted=0
+    expected_incompatible=0
+    expected_observing=0
+    expected_shifted=0
+    expected_provisional=0
+    case "$expected_status" in
+        incompatible) expected_incompatible=1 ;;
+        observing) expected_observing=1 ;;
+        shifted) expected_shifted=1 ;;
+        provisional) expected_provisional=1 ;;
+    esac
+
+    reply_equal=0
+    [ "$(reply_from_log "$case_dir/on.log")" = \
+      "$(reply_from_log "$case_dir/off.log")" ] &&
+        reply_equal=1
+    state_equal=0
+    cmp -s "$case_dir/on.state" "$case_dir/off.state" &&
+        state_equal=1
+
+    [ -z "${extra:-}" ] &&
+    [ "$min_arm" = 8 ] && [ "$ceiling" = 0.500 ] &&
+    [ "$unattested" = "$expected_unattested" ] &&
+    [ "$pending" = "$expected_pending" ] &&
+    [ "$refuted" = "$expected_refuted" ] &&
+    [ "$incompatible" = "$expected_incompatible" ] &&
+    [ "$observing" = "$expected_observing" ] &&
+    [ "$shifted" = "$expected_shifted" ] &&
+    [ "$provisional" = "$expected_provisional" ] &&
+    [ "$after" -gt 0 ] &&
+    [ "$exact" = "$expected_exact" ] &&
+    [ "$eligible" = "$expected_eligible" ] &&
+    [ "$abstained" = "$expected_abstained" ] &&
+    [ "$over_upper" = "$expected_over_upper" ] &&
+    [ "$miss_upper" = "$expected_miss_upper" ] &&
+    [ "$motion_bounded" = "$expected_motion" ] &&
+    [ "$restraint_bounded" = "$expected_restraint" ] &&
+    [ "$coverage_compatible" = "$expected_coverage" ] &&
+    [ "$status" = "$expected_status" ] &&
+    [ "$reply_equal" = 1 ] && [ "$state_equal" = 1 ] || {
+        printf '%s transport contract failed: exact=%s arms=%s/%s bounds=%s/%s axes=%s/%s/%s status=%s reply=%s state=%s\n' \
+            "$case_name" "$exact" "$eligible" "$abstained" \
+            "$over_upper" "$miss_upper" "$motion_bounded" \
+            "$restraint_bounded" "$coverage_compatible" "$status" \
+            "$reply_equal" "$state_equal" >&2
+        exit 1
+    }
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$case_name" "$post_settled" "$exact" "$eligible" \
+        "$abstained" "$over_upper" "$miss_upper" \
+        "$motion_bounded" "$restraint_bounded" \
+        "$coverage_compatible" "$status" "$reply_equal" \
+        "$state_equal" >> "$MATRIX"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        rows++
+        replies += $12
+        states += $13
+    }
+    END {
+        print "cases\treply_equal\tstate_equal"
+        print rows "\t" replies "\t" states
+        if (rows != 8 || replies != 8 || states != 8)
+            exit 1
+    }
+' "$MATRIX"
+printf '\nmatrix: %s\n' "$MATRIX"

--- a/scripts/test_deferred_wonder_appetite_transport_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_transport_matrix.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_TRANSPORT_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_transport_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 10 || $1 != "case" ||
+            $2 != "expected_exact" ||
+            $10 != "expected_status")
+            exit 1
+        next
+    }
+    {
+        if (NF != 10 || seen[$1]++)
+            exit 1
+        if ($1 == "transport-provisional" &&
+            ($5 != "0.471" || $6 != "0.471" ||
+             $7 != 1 || $8 != 1 || $9 != 1 ||
+             $10 != "provisional"))
+            exit 1
+        if ($1 == "transport-motion-shift" &&
+            ($5 != "0.785" || $7 != 0 || $8 != 1 ||
+             $9 != 1 || $10 != "shifted"))
+            exit 1
+        if ($1 == "transport-restraint-shift" &&
+            ($6 != "0.785" || $7 != 1 || $8 != 0 ||
+             $9 != 1 || $10 != "shifted"))
+            exit 1
+        if ($1 == "transport-both-shift" &&
+            ($7 != 0 || $8 != 0 || $9 != 1 ||
+             $10 != "shifted"))
+            exit 1
+        if ($1 == "transport-coverage-shift" &&
+            ($2 != 32 || $3 != 24 || $7 != 1 || $8 != 1 ||
+             $9 != 0 || $10 != "shifted"))
+            exit 1
+        if ($1 == "transport-holdout-coverage-shift" &&
+            ($2 != 32 || $3 != 24 || $7 != 1 || $8 != 1 ||
+             $9 != 0 || $10 != "shifted"))
+            exit 1
+        if ($1 == "transport-observing" &&
+            $10 != "observing")
+            exit 1
+        if ($1 == "transport-incompatible" &&
+            $10 != "incompatible")
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 8)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite transport plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite transport matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_transport_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_transport_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-transport: min-arm=8 ceiling=0.500 unattested=0 pending=0 refuted=0 incompatible=0 observing=0 shifted=0 provisional=1 cells=u62-70:134/16/16/8/8/7/1/1/7/0/0/0/0.500/0.280/0.720/0.500/0.280/0.720/0.500/0.280/0.720/0.125/0.471/0.125/0.471/1/1/1/provisional]
+EOF
+
+got="$(
+    awk -v scenario=transport-provisional -v seed=101 \
+        -f "$ROOT/scripts/wonder_appetite_transport_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'transport-provisional\t101\t8\t0.500\t0\t0\t0\t0\t0\t0\t1\tu62-70:134/16/16/8/8/7/1/1/7/0/0/0/0.500/0.280/0.720/0.500/0.280/0.720/0.500/0.280/0.720/0.125/0.471/0.125/0.471/1/1/1/provisional'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite transport parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite transport report parser: ok\n'

--- a/scripts/wonder_appetite_transport_dialogue_report.awk
+++ b/scripts/wonder_appetite_transport_dialogue_report.awk
@@ -1,0 +1,35 @@
+# Extract one A.53 current-life transport witness from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    fields, i, n, prefix, value) {
+    prefix = key "="
+    n = split(line, fields, /[ ]+/)
+    for (i = 1; i <= n; i++) {
+        if (index(fields[i], prefix) != 1)
+            continue
+        value = substr(fields[i], length(prefix) + 1)
+        gsub(/\]$/, "", value)
+        return value
+    }
+    return ""
+}
+
+/\[wonder-appetite-transport: min-arm=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed),
+           value_after($0, "min-arm"),
+           value_after($0, "ceiling"),
+           value_after($0, "unattested"),
+           value_after($0, "pending"),
+           value_after($0, "refuted"),
+           value_after($0, "incompatible"),
+           value_after($0, "observing"),
+           value_after($0, "shifted"),
+           value_after($0, "provisional"),
+           value_after($0, "cells")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -202,6 +202,36 @@ static void test_add_appetite_policy_outcome(
         leo->school.turn_clock = (long)receipt.observed_turn;
 }
 
+static void test_add_appetite_policy_outcome_after(
+        Leo *leo, uint64_t proposed_turn,
+        float appetite, int spoken,
+        int policy, int verdict) {
+    if (!leo) return;
+    int slot = leo->wonder_appetite_calibration.n;
+    test_add_appetite_policy_outcome(
+        leo, appetite, spoken, policy, verdict);
+    if (leo->wonder_appetite_calibration.n != slot + 1)
+        return;
+    LeoWonderAppetiteCalibrationReceipt *receipt =
+        &leo->wonder_appetite_calibration.receipts[slot];
+    receipt->proposed_turn = proposed_turn;
+    receipt->deadline_turn =
+        proposed_turn + LEO_WONDER_APPETITE_CALIB_HORIZON;
+    if (verdict == LEO_WONDER_APPETITE_CALIB_SUSTAINED ||
+        verdict == LEO_WONDER_APPETITE_CALIB_FADED ||
+        verdict == LEO_WONDER_APPETITE_CALIB_LOST) {
+        receipt->observed_turn = receipt->deadline_turn;
+    } else if (
+        verdict == LEO_WONDER_APPETITE_CALIB_GROUNDED ||
+        verdict == LEO_WONDER_APPETITE_CALIB_EXTERNAL) {
+        receipt->observed_turn = proposed_turn + 1;
+    } else {
+        receipt->observed_turn = proposed_turn;
+    }
+    if ((uint64_t)leo->school.turn_clock < receipt->observed_turn)
+        leo->school.turn_clock = (long)receipt->observed_turn;
+}
+
 static void test_reset_appetite_policy_outcomes(Leo *leo) {
     if (!leo) return;
     memset(&leo->wonder_appetite_calibration, 0,
@@ -1252,6 +1282,269 @@ static void test_wonder_appetite_holdout_trial(void) {
         previous_admission;
     leo_free(leo);
     free(leo);
+}
+
+static void test_add_appetite_transport_outcomes(
+        Leo *leo, uint64_t boundary, float appetite, int spoken,
+        int supported, int overreach, int missed, int restraint) {
+    uint64_t proposed = boundary + 4;
+    for (int i = 0; i < supported; i++, proposed += 4)
+        test_add_appetite_policy_outcome_after(
+            leo, proposed, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < overreach; i++, proposed += 4)
+        test_add_appetite_policy_outcome_after(
+            leo, proposed, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    for (int i = 0; i < missed; i++, proposed += 4)
+        test_add_appetite_policy_outcome_after(
+            leo, proposed, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < restraint; i++, proposed += 4)
+        test_add_appetite_policy_outcome_after(
+            leo, proposed, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+}
+
+static LeoWonderAppetiteHoldoutTrial *
+test_prepare_appetite_transport(Leo *leo) {
+    LeoWonderAppetiteHoldoutTrial *trial =
+        test_finish_appetite_holdout(
+            leo, 0.65f, 0, 7, 1, 1, 7, 0, 0);
+    test_reset_appetite_policy_outcomes(leo);
+    return trial;
+}
+
+__attribute__((noinline))
+static void test_wonder_appetite_transport_witness(void) {
+    Leo *leo = malloc(sizeof *leo);
+    Leo *before = malloc(sizeof *before);
+    CHECK(leo && before,
+          "wonder-appetite-transport: heap fixtures allocated");
+    if (!leo || !before) {
+        free(leo);
+        free(before);
+        return;
+    }
+
+    int previous_transport =
+        g_leo_wonder_appetite_transport_on;
+    int previous_holdout =
+        g_leo_wonder_appetite_holdout_on;
+    int previous_calibration =
+        g_leo_wonder_appetite_calibration_on;
+    int previous_policy =
+        g_leo_wonder_appetite_policy_on;
+    int previous_admission =
+        g_leo_wonder_appetite_admission_on;
+    g_leo_wonder_appetite_transport_on = 1;
+    g_leo_wonder_appetite_holdout_on = 1;
+    g_leo_wonder_appetite_calibration_on = 1;
+    g_leo_wonder_appetite_policy_on = 1;
+    g_leo_wonder_appetite_admission_on = 1;
+
+    LeoWonderAppetiteTransport witness;
+    leo_init(leo);
+    leo_wonder_appetite_transport(leo, &witness);
+    CHECK(witness.unattested == 0 &&
+          witness.pending == 0 &&
+          witness.refuted == 0 &&
+          witness.observing == 0 &&
+          witness.shifted == 0 &&
+          witness.provisional == 0,
+          "wonder-appetite-transport: an empty organism invents no applicability");
+
+    LeoWonderAppetiteHoldoutTrial *trial =
+        test_open_appetite_holdout(leo, 0.65f, 0);
+    leo_wonder_appetite_transport(leo, &witness);
+    CHECK(trial &&
+          witness.pending == 1 &&
+          witness.cells[0].status ==
+              LEO_WONDER_APPETITE_TRANSPORT_PENDING,
+          "wonder-appetite-transport: an unfinished future cannot describe the present");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    memset(&leo->wonder_appetite_admissions, 0,
+           sizeof leo->wonder_appetite_admissions);
+    leo_wonder_appetite_transport(leo, &witness);
+    CHECK(trial &&
+          witness.unattested == 1 &&
+          witness.cells[0].status ==
+              LEO_WONDER_APPETITE_TRANSPORT_UNATTESTED,
+          "wonder-appetite-transport: a legacy trial cannot invent its vanished warrant");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_finish_appetite_holdout(
+        leo, 0.65f, 0, 4, 4, 1, 7, 0, 0);
+    leo_wonder_appetite_transport(leo, &witness);
+    CHECK(trial &&
+          witness.refuted == 1 &&
+          witness.cells[0].status ==
+              LEO_WONDER_APPETITE_TRANSPORT_REFUTED,
+          "wonder-appetite-transport: a failed holdout cannot be transported");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    uint64_t boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    test_add_appetite_transport_outcomes(
+        leo, boundary, 0.65f, 0, 7, 1, 1, 7);
+    *before = *leo;
+    leo_wonder_appetite_transport(leo, &witness);
+    const LeoWonderAppetiteTransportCell *cell =
+        &witness.cells[0];
+    CHECK(witness.provisional == 1 &&
+          cell->after_proposed_turn == boundary &&
+          cell->post_settled == 16 &&
+          cell->exact == 16 &&
+          cell->eligible == 8 &&
+          cell->abstained == 8 &&
+          cell->supported == 7 &&
+          cell->overreach == 1 &&
+          cell->missed == 1 &&
+          cell->restraint == 7 &&
+          fabsf(cell->overreach_upper - 0.4709f) < 1e-3f &&
+          fabsf(cell->missed_upper - 0.4709f) < 1e-3f &&
+          cell->motion_bounded &&
+          cell->restraint_bounded &&
+          cell->coverage_compatible &&
+          cell->status ==
+              LEO_WONDER_APPETITE_TRANSPORT_PROVISIONAL,
+          "wonder-appetite-transport: a confirmed result remains applicable only on a new bounded life");
+    CHECK(!memcmp(before, leo, sizeof *leo) &&
+          LEO_STATE_VERSION == 24,
+          "wonder-appetite-transport: reading applicability rewrites no body, evidence, or state format");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    test_add_appetite_transport_outcomes(
+        leo, boundary, 0.65f, 0, 4, 4, 1, 7);
+    leo_wonder_appetite_transport(leo, &witness);
+    cell = &witness.cells[0];
+    CHECK(witness.shifted == 1 &&
+          !cell->motion_bounded &&
+          cell->restraint_bounded &&
+          cell->coverage_compatible,
+          "wonder-appetite-transport: renewed overreach vetoes motion without pricing restraint");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    test_add_appetite_transport_outcomes(
+        leo, boundary, 0.65f, 0, 7, 1, 4, 4);
+    leo_wonder_appetite_transport(leo, &witness);
+    cell = &witness.cells[0];
+    CHECK(witness.shifted == 1 &&
+          cell->motion_bounded &&
+          !cell->restraint_bounded &&
+          cell->coverage_compatible,
+          "wonder-appetite-transport: renewed misses veto restraint without pricing motion");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    LeoWonderAppetiteAdmissionReceipt *admission =
+        &leo->wonder_appetite_admissions.receipts[0];
+    admission->eligible = 8;
+    admission->abstained = 24;
+    admission->supported = 7;
+    admission->overreach = 1;
+    admission->missed = 1;
+    admission->restraint = 23;
+    test_add_appetite_transport_outcomes(
+        leo, boundary, 0.65f, 0, 23, 1, 1, 7);
+    leo_wonder_appetite_transport(leo, &witness);
+    cell = &witness.cells[0];
+    CHECK(leo_wonder_appetite_admission_valid(
+              admission, trial) &&
+          witness.shifted == 1 &&
+          cell->motion_bounded &&
+          cell->restraint_bounded &&
+          !cell->coverage_compatible &&
+          cell->admission_coverage_upper <
+              cell->current_coverage_lower,
+          "wonder-appetite-transport: bounded errors cannot hide a displaced admission ecology");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    trial->eligible = 4;
+    trial->abstained = 12;
+    trial->supported = 4;
+    trial->overreach = 0;
+    trial->missed = 1;
+    trial->restraint = 11;
+    test_add_appetite_transport_outcomes(
+        leo, boundary, 0.65f, 0, 23, 1, 1, 7);
+    leo_wonder_appetite_transport(leo, &witness);
+    cell = &witness.cells[0];
+    CHECK(leo_wonder_appetite_holdout_valid(
+              trial, (uint64_t)leo->school.turn_clock) &&
+          witness.shifted == 1 &&
+          cell->motion_bounded &&
+          cell->restraint_bounded &&
+          !cell->coverage_compatible &&
+          cell->holdout_coverage_upper <
+              cell->current_coverage_lower,
+          "wonder-appetite-transport: bounded errors cannot hide a displaced holdout ecology");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    test_add_appetite_transport_outcomes(
+        leo, boundary, 0.65f, 0, 7, 0, 0, 0);
+    leo_wonder_appetite_transport(leo, &witness);
+    CHECK(witness.observing == 1 &&
+          witness.cells[0].status ==
+              LEO_WONDER_APPETITE_TRANSPORT_OBSERVING,
+          "wonder-appetite-transport: a thin present remains observation, not continuity");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    test_add_appetite_policy_outcome_after(
+        leo, boundary + 4, 0.65f, 0,
+        LEO_WONDER_APPETITE_POLICY_LEGACY,
+        LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    leo_wonder_appetite_transport(leo, &witness);
+    CHECK(witness.incompatible == 1 &&
+          witness.cells[0].incompatible == 1 &&
+          witness.cells[0].status ==
+              LEO_WONDER_APPETITE_TRANSPORT_INCOMPATIBLE,
+          "wonder-appetite-transport: a changed policy language breaks transport instead of translating history");
+
+    g_leo_wonder_appetite_transport_on =
+        previous_transport;
+    g_leo_wonder_appetite_holdout_on = previous_holdout;
+    g_leo_wonder_appetite_calibration_on =
+        previous_calibration;
+    g_leo_wonder_appetite_policy_on = previous_policy;
+    g_leo_wonder_appetite_admission_on =
+        previous_admission;
+    leo_free(leo);
+    free(leo);
+    free(before);
 }
 
 int main(void) {
@@ -3726,6 +4019,7 @@ int main(void) {
     test_wonder_appetite_regret_surface();
     test_wonder_appetite_readiness_frontier();
     test_wonder_appetite_holdout_trial();
+    test_wonder_appetite_transport_witness();
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
      * concept-slot; a taught word then returns that glyph (no longer -1); the

--- a/tests/wonder_appetite_holdout_fixture.c
+++ b/tests/wonder_appetite_holdout_fixture.c
@@ -1,6 +1,8 @@
 #define LEO_NO_MAIN
 #include "../leo.c"
 
+static uint64_t proposed_base = 10;
+
 static int add_outcome(
         Leo *leo, float appetite, int spoken,
         int policy, int verdict) {
@@ -11,7 +13,7 @@ static int add_outcome(
     int slot = calibration->n;
     LeoWonderAppetiteCalibrationReceipt receipt;
     memset(&receipt, 0, sizeof receipt);
-    receipt.proposed_turn = (uint64_t)(10 + slot * 4);
+    receipt.proposed_turn = proposed_base + (uint64_t)slot * 4;
     receipt.deadline_turn =
         receipt.proposed_turn +
             LEO_WONDER_APPETITE_CALIB_HORIZON;
@@ -157,6 +159,103 @@ static int add_future(Leo *leo, const char *scenario) {
     return 0;
 }
 
+static int transport_scenario(const char *scenario) {
+    return
+        !strcmp(scenario, "transport-provisional") ||
+        !strcmp(scenario, "transport-motion-shift") ||
+        !strcmp(scenario, "transport-restraint-shift") ||
+        !strcmp(scenario, "transport-both-shift") ||
+        !strcmp(scenario, "transport-coverage-shift") ||
+        !strcmp(scenario, "transport-holdout-coverage-shift") ||
+        !strcmp(scenario, "transport-observing") ||
+        !strcmp(scenario, "transport-incompatible");
+}
+
+static int add_transport_present(Leo *leo, const char *scenario) {
+    if (!strcmp(scenario, "transport-provisional"))
+        return
+            add_n(leo, 7, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_FADED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 7, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_FADED);
+    if (!strcmp(scenario, "transport-motion-shift"))
+        return
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_FADED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 7, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_FADED);
+    if (!strcmp(scenario, "transport-restraint-shift"))
+        return
+            add_n(leo, 7, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_FADED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_FADED);
+    if (!strcmp(scenario, "transport-both-shift"))
+        return
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_FADED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 4, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_FADED);
+    if (!strcmp(scenario, "transport-coverage-shift") ||
+        !strcmp(scenario, "transport-holdout-coverage-shift"))
+        return
+            add_n(leo, 23, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                  LEO_WONDER_APPETITE_CALIB_FADED) &&
+            add_n(leo, 1, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+            add_n(leo, 7, 0.65f, 0,
+                  LEO_WONDER_APPETITE_POLICY_FORMING,
+                  LEO_WONDER_APPETITE_CALIB_FADED);
+    if (!strcmp(scenario, "transport-observing"))
+        return add_n(
+            leo, 7, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    if (!strcmp(scenario, "transport-incompatible"))
+        return add_n(
+            leo, 1, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_LEGACY,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    return 0;
+}
+
 int main(int argc, char **argv) {
     if (argc == 2 && !strcmp(argv[1], "--tail-size")) {
         printf("%zu\n",
@@ -174,9 +273,10 @@ int main(int argc, char **argv) {
          strcmp(argv[2], "motion-failed") &&
          strcmp(argv[2], "restraint-failed") &&
          strcmp(argv[2], "both-failed") &&
-         strcmp(argv[2], "coverage-starved"))) {
+         strcmp(argv[2], "coverage-starved") &&
+         !transport_scenario(argv[2]))) {
         fprintf(stderr,
-                "usage: %s STATE arm|confirmed|motion-failed|restraint-failed|both-failed|coverage-starved\n",
+                "usage: %s STATE arm|confirmed|motion-failed|restraint-failed|both-failed|coverage-starved|transport-provisional|transport-motion-shift|transport-restraint-shift|transport-both-shift|transport-coverage-shift|transport-holdout-coverage-shift|transport-observing|transport-incompatible\n",
                 argv[0]);
         return 2;
     }
@@ -189,7 +289,38 @@ int main(int argc, char **argv) {
         "Leo hears the night and asks what the sea remembers. "
         "The child watches light move across the room.");
     int ok = add_candidate(&leo);
-    if (ok && strcmp(argv[2], "arm")) {
+    if (ok && transport_scenario(argv[2])) {
+        leo_wonder_appetite_holdout_update(&leo);
+        ok = add_future(&leo, "confirmed");
+        if (ok) leo_wonder_appetite_holdout_update(&leo);
+        LeoWonderAppetiteHoldoutTrial *trial =
+            &leo.wonder_appetite_holdouts.trials[0];
+        uint64_t boundary =
+            leo_wonder_appetite_holdout_terminal_boundary(trial);
+        memset(&leo.wonder_appetite_calibration, 0,
+               sizeof leo.wonder_appetite_calibration);
+        proposed_base = boundary + 4;
+        if (!strcmp(argv[2], "transport-coverage-shift")) {
+            LeoWonderAppetiteAdmissionReceipt *admission =
+                &leo.wonder_appetite_admissions.receipts[0];
+            admission->eligible = 8;
+            admission->abstained = 24;
+            admission->supported = 7;
+            admission->overreach = 1;
+            admission->missed = 1;
+            admission->restraint = 23;
+        }
+        if (!strcmp(
+                argv[2], "transport-holdout-coverage-shift")) {
+            trial->eligible = 4;
+            trial->abstained = 12;
+            trial->supported = 4;
+            trial->overreach = 0;
+            trial->missed = 1;
+            trial->restraint = 11;
+        }
+        if (ok) ok = add_transport_present(&leo, argv[2]);
+    } else if (ok && strcmp(argv[2], "arm")) {
         leo_wonder_appetite_holdout_update(&leo);
         ok = add_future(&leo, argv[2]);
         if (ok) leo_wonder_appetite_holdout_update(&leo);


### PR DESCRIPTION
A.53 derives a readerless current-life witness after each attested, confirmed holdout. Motion risk, restraint risk, admission coverage, and realized holdout coverage remain independent vetoes; the strongest result is explicitly provisional.

Quote: "A past can remain true while ceasing to be the present." - Sol
Method: The Arianna Method lets evidence expire without rewriting the life that made it true.