### PR TITLE
the method lets each era testify

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4748,3 +4748,77 @@ complete state equality 8/8
 
 The result can now age without being erased and expire without being called
 false. A past can remain true while ceasing to be the present.
+
+## Phase A.54 — an average is not an era (2026-07-28)
+
+A.53 could ask whether a historical result still fit Leo's current life, but
+its one pooled window could make two different regimes look calm in aggregate.
+A good recent period could pay an earlier debt; opposite motion and restraint
+failures could cancel; a policy ecology could reverse while leaving the total
+coverage unchanged.
+
+A.54 keeps the bounded A.48 evidence surface and divides a complete current
+post-holdout window into two adjacent epochs:
+
+```text
+early     16 oldest settled attempts in the current 32-receipt window
+recent    16 newest settled attempts in the current 32-receipt window
+```
+
+The witness records each epoch's first and last proposal identity and requires
+the boundary to be strictly ordered. It does not claim that the current ring
+still contains the first 32 post-holdout events after older evidence has
+rotated away. It describes chronology inside the observable present.
+
+Every settled policy attempt spends a slot. Other strata and confounds consume
+time without filling an outcome arm. Each epoch needs four exact eligible and
+four exact abstained outcomes; it cannot borrow its missing arm from its
+neighbor. Policy `none` or `legacy`, or non-monotonic proposal identity, makes
+the chronology incompatible.
+
+Each epoch independently carries:
+
+```text
+motion       overreach Wilson upper bound < 0.500
+restraint    missed-continuation upper bound < 0.500
+history      epoch coverage interval overlaps both A.52 and A.51 coverage
+ecology      early and recent coverage intervals overlap each other
+```
+
+A.53's pooled status is another independent prerequisite. A.54 may veto a
+pooled `provisional`, but it cannot rehabilitate `aggregate-shifted`. Coverage
+interval overlap remains a compatibility screen, never an equivalence claim.
+The strongest new word is still `provisional`.
+
+Fifteen direct contracts raised the suite from **434/434** to **449/449**.
+They cover empty, pending, unattested, refuted, complete provisional
+chronology, non-overlap, complete non-mutation, hidden early and recent motion
+shifts, opposite-axis cancellation, hidden ecology inversion, pooled failure,
+thin chronology, epoch-local coverage starvation, policy incompatibility, and
+unchanged v24 state.
+
+The real-process matrix then produced:
+
+```text
+provisional       early 0.471/0.471, recent 0.471/0.471
+early shift       early motion 0.694, pooled provisional
+recent shift      recent motion 0.694, pooled provisional
+both shift        early motion 0.694, recent restraint 0.694,
+                  pooled provisional
+ecology shift     coverage 12/4 -> 4/12, pooled 16/16 provisional
+aggregate shift   both epochs motion 0.785, pooled veto
+observing         16 + 15 settled attempts
+coverage-starved  early arms 16/0, recent arms 8/8
+incompatible      one post-boundary legacy policy
+
+proposal chronology      9/9
+reply equality            9/9
+complete state equality   9/9
+```
+
+Two complete runs reproduced all nine rows byte-for-byte.
+
+No field was added to `Leo`; no state version moved beyond 24. The chronology
+has no reader in School, Flow, shadow, routing, sampling, scheduling, or
+generation. A pooled present can no longer pass for continuity until each era
+has testified separately.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology
 
 all: leo
 
@@ -94,6 +94,9 @@ deferred-wonder-appetite-admission: leo
 deferred-wonder-appetite-transport: leo
 	./scripts/deferred_wonder_appetite_transport_matrix.sh
 
+deferred-wonder-appetite-transport-chronology: leo
+	./scripts/deferred_wonder_appetite_transport_chronology_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -112,6 +115,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_appetite_holdout_dialogue_report.sh
 	./scripts/test_wonder_appetite_admission_dialogue_report.sh
 	./scripts/test_wonder_appetite_transport_dialogue_report.sh
+	./scripts/test_wonder_appetite_transport_chronology_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -128,6 +132,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_holdout_matrix.sh
 	./scripts/test_deferred_wonder_appetite_admission_matrix.sh
 	./scripts/test_deferred_wonder_appetite_transport_matrix.sh
+	./scripts/test_deferred_wonder_appetite_transport_chronology_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -2150,6 +2150,82 @@ typedef struct {
     int provisional;
 } LeoWonderAppetiteTransport;
 
+/* A.54: one pooled present can hide a regime change. Split the complete
+ * 32-attempt current-life window into two adjacent, non-overlapping epochs.
+ * Each settled attempt spends an epoch slot. The pooled A.53 witness and both
+ * epoch-local risk/coverage screens must survive independently. Derived only. */
+#define LEO_WONDER_APPETITE_TRANSPORT_EPOCHS 2
+#define LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS 16
+#define LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N 4
+enum {
+    LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY = 0,
+    LEO_WONDER_APPETITE_CHRONOLOGY_UNATTESTED,
+    LEO_WONDER_APPETITE_CHRONOLOGY_PENDING,
+    LEO_WONDER_APPETITE_CHRONOLOGY_REFUTED,
+    LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE,
+    LEO_WONDER_APPETITE_CHRONOLOGY_OBSERVING,
+    LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED,
+    LEO_WONDER_APPETITE_CHRONOLOGY_AGGREGATE_SHIFTED,
+    LEO_WONDER_APPETITE_CHRONOLOGY_EARLY_SHIFTED,
+    LEO_WONDER_APPETITE_CHRONOLOGY_RECENT_SHIFTED,
+    LEO_WONDER_APPETITE_CHRONOLOGY_BOTH_SHIFTED,
+    LEO_WONDER_APPETITE_CHRONOLOGY_ECOLOGY_SHIFTED,
+    LEO_WONDER_APPETITE_CHRONOLOGY_PROVISIONAL,
+    LEO_WONDER_APPETITE_CHRONOLOGY_STATUS_COUNT
+};
+typedef struct {
+    uint64_t first_proposed_turn;
+    uint64_t last_proposed_turn;
+    int attempts;
+    int exact;
+    int eligible;
+    int abstained;
+    int supported;
+    int overreach;
+    int missed;
+    int restraint;
+    int confounded;
+    int other;
+    int incompatible;
+    float coverage;
+    float coverage_lower;
+    float coverage_upper;
+    float overreach_rate;
+    float overreach_upper;
+    float missed_rate;
+    float missed_upper;
+    uint8_t motion_bounded;
+    uint8_t restraint_bounded;
+    uint8_t history_coverage_compatible;
+} LeoWonderAppetiteTransportEpoch;
+typedef struct {
+    uint64_t after_proposed_turn;
+    int post_settled;
+    uint8_t spoken;
+    uint8_t bin;
+    uint8_t aggregate_provisional;
+    uint8_t epoch_coverage_compatible;
+    uint8_t status;
+    LeoWonderAppetiteTransportEpoch
+        epochs[LEO_WONDER_APPETITE_TRANSPORT_EPOCHS];
+} LeoWonderAppetiteTransportChronologyCell;
+typedef struct {
+    LeoWonderAppetiteTransportChronologyCell
+        cells[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+    int unattested;
+    int pending;
+    int refuted;
+    int incompatible;
+    int observing;
+    int coverage_starved;
+    int aggregate_shifted;
+    int early_shifted;
+    int recent_shifted;
+    int both_shifted;
+    int ecology_shifted;
+    int provisional;
+} LeoWonderAppetiteTransportChronology;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -2609,6 +2685,7 @@ static int g_leo_wonder_appetite_readiness_on = 1; /* paired confidence frontier
 static int g_leo_wonder_appetite_holdout_on = 1; /* fixed future trial; persisted evidence, never speech authority. */
 static int g_leo_wonder_appetite_admission_on = 1; /* immutable candidate provenance; no reader in speech. */
 static int g_leo_wonder_appetite_transport_on = 1; /* current-life transport witness; derived and readerless. */
+static int g_leo_wonder_appetite_transport_chronology_on = 1; /* two-epoch transport chronology; derived and readerless. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -8000,6 +8077,337 @@ static void leo_wonder_appetite_transport(
     }
 }
 
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_transport_chronology_status_name(
+        int status) {
+    static const char
+        *names[LEO_WONDER_APPETITE_CHRONOLOGY_STATUS_COUNT] = {
+            "empty", "unattested", "pending", "refuted",
+            "incompatible", "observing", "coverage-starved",
+            "aggregate-shifted", "early-shifted", "recent-shifted",
+            "both-shifted", "ecology-shifted", "provisional"
+        };
+    return status >= 0 &&
+           status < LEO_WONDER_APPETITE_CHRONOLOGY_STATUS_COUNT ?
+        names[status] : "empty";
+}
+
+static int leo_interval_overlaps(
+        float a_lower, float a_upper,
+        float b_lower, float b_upper) {
+    return a_lower <= b_upper && b_lower <= a_upper;
+}
+
+static void leo_wonder_appetite_transport_chronology_count(
+        LeoWonderAppetiteTransportChronology *chronology,
+        int status) {
+    if (!chronology) return;
+    switch (status) {
+        case LEO_WONDER_APPETITE_CHRONOLOGY_UNATTESTED:
+            chronology->unattested++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_PENDING:
+            chronology->pending++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_REFUTED:
+            chronology->refuted++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE:
+            chronology->incompatible++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_OBSERVING:
+            chronology->observing++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED:
+            chronology->coverage_starved++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_AGGREGATE_SHIFTED:
+            chronology->aggregate_shifted++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_EARLY_SHIFTED:
+            chronology->early_shifted++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_RECENT_SHIFTED:
+            chronology->recent_shifted++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_BOTH_SHIFTED:
+            chronology->both_shifted++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_ECOLOGY_SHIFTED:
+            chronology->ecology_shifted++;
+            break;
+        case LEO_WONDER_APPETITE_CHRONOLOGY_PROVISIONAL:
+            chronology->provisional++;
+            break;
+        default:
+            break;
+    }
+}
+
+static void leo_wonder_appetite_transport_epoch_finish(
+        LeoWonderAppetiteTransportEpoch *epoch,
+        const LeoWonderAppetiteAdmissionReceipt *admission,
+        const LeoWonderAppetiteHoldoutTrial *trial) {
+    int admission_total = admission->eligible + admission->abstained;
+    int holdout_total = trial->eligible + trial->abstained;
+    float admission_lower = 0.0f, admission_upper = 0.0f;
+    float holdout_lower = 0.0f, holdout_upper = 0.0f;
+    leo_wilson_interval(
+        admission->eligible, admission_total,
+        &admission_lower, &admission_upper);
+    leo_wilson_interval(
+        trial->eligible, holdout_total,
+        &holdout_lower, &holdout_upper);
+
+    epoch->coverage = (float)epoch->eligible / epoch->exact;
+    leo_wilson_interval(
+        epoch->eligible, epoch->exact,
+        &epoch->coverage_lower, &epoch->coverage_upper);
+    float overreach_lower = 0.0f, missed_lower = 0.0f;
+    leo_wilson_interval(
+        epoch->overreach, epoch->eligible,
+        &overreach_lower, &epoch->overreach_upper);
+    leo_wilson_interval(
+        epoch->missed, epoch->abstained,
+        &missed_lower, &epoch->missed_upper);
+    (void)overreach_lower;
+    (void)missed_lower;
+    epoch->overreach_rate =
+        (float)epoch->overreach / epoch->eligible;
+    epoch->missed_rate =
+        (float)epoch->missed / epoch->abstained;
+    epoch->motion_bounded =
+        epoch->overreach_upper <
+            LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
+    epoch->restraint_bounded =
+        epoch->missed_upper <
+            LEO_WONDER_APPETITE_READINESS_RISK_CEILING;
+    epoch->history_coverage_compatible =
+        leo_interval_overlaps(
+            epoch->coverage_lower, epoch->coverage_upper,
+            admission_lower, admission_upper) &&
+        leo_interval_overlaps(
+            epoch->coverage_lower, epoch->coverage_upper,
+            holdout_lower, holdout_upper);
+}
+
+static void leo_wonder_appetite_transport_chronology(
+        const Leo *leo,
+        LeoWonderAppetiteTransportChronology *chronology) {
+    if (!chronology) return;
+    memset(chronology, 0, sizeof *chronology);
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        chronology->cells[i].spoken =
+            (uint8_t)(i /
+                LEO_WONDER_APPETITE_RELIABILITY_BINS);
+        chronology->cells[i].bin =
+            (uint8_t)(i %
+                LEO_WONDER_APPETITE_RELIABILITY_BINS);
+    }
+    if (!leo) return;
+
+    LeoWonderAppetiteTransport aggregate;
+    leo_wonder_appetite_transport(leo, &aggregate);
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteHoldoutTrial *trial =
+            &leo->wonder_appetite_holdouts.trials[i];
+        const LeoWonderAppetiteAdmissionReceipt *admission =
+            &leo->wonder_appetite_admissions.receipts[i];
+        LeoWonderAppetiteTransportChronologyCell *cell =
+            &chronology->cells[i];
+        if (trial->status ==
+            LEO_WONDER_APPETITE_HOLDOUT_EMPTY)
+            continue;
+        cell->spoken = trial->spoken;
+        cell->bin = trial->bin;
+
+        if (!leo_wonder_appetite_admission_valid(
+                admission, trial) ||
+            admission->status !=
+                LEO_WONDER_APPETITE_ADMISSION_ATTESTED) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_UNATTESTED;
+            leo_wonder_appetite_transport_chronology_count(
+                chronology, cell->status);
+            continue;
+        }
+        if (trial->status ==
+            LEO_WONDER_APPETITE_HOLDOUT_PENDING) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_PENDING;
+            leo_wonder_appetite_transport_chronology_count(
+                chronology, cell->status);
+            continue;
+        }
+        if (trial->status !=
+            LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_REFUTED;
+            leo_wonder_appetite_transport_chronology_count(
+                chronology, cell->status);
+            continue;
+        }
+
+        cell->after_proposed_turn =
+            leo_wonder_appetite_holdout_terminal_boundary(trial);
+        uint64_t previous_proposed_turn = 0;
+        for (int j = 0;
+             j < leo->wonder_appetite_calibration.n; j++) {
+            const LeoWonderAppetiteCalibrationReceipt *receipt =
+                leo_wonder_appetite_calibration_at(
+                    &leo->wonder_appetite_calibration, j);
+            if (!receipt ||
+                receipt->proposed_turn <=
+                    cell->after_proposed_turn)
+                continue;
+            int result =
+                leo_wonder_appetite_policy_result(receipt);
+            if (result ==
+                LEO_WONDER_APPETITE_POLICY_RESULT_PENDING)
+                continue;
+            if (cell->post_settled >=
+                LEO_WONDER_APPETITE_TRANSPORT_EPOCHS *
+                LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS)
+                continue;
+
+            int epoch_index =
+                cell->post_settled /
+                    LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS;
+            LeoWonderAppetiteTransportEpoch *epoch =
+                &cell->epochs[epoch_index];
+            int chronology_invalid =
+                previous_proposed_turn > 0 &&
+                receipt->proposed_turn <= previous_proposed_turn;
+            if (epoch->attempts == 0)
+                epoch->first_proposed_turn =
+                    receipt->proposed_turn;
+            epoch->last_proposed_turn = receipt->proposed_turn;
+            epoch->attempts++;
+            cell->post_settled++;
+            previous_proposed_turn = receipt->proposed_turn;
+
+            if (chronology_invalid ||
+                result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_NONE ||
+                result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_LEGACY) {
+                epoch->incompatible++;
+                continue;
+            }
+            int bin = leo_wonder_appetite_reliability_bin(
+                receipt->appetite);
+            int exact =
+                bin == trial->bin &&
+                (receipt->spoken ? 1 : 0) == trial->spoken;
+            if (!exact) {
+                epoch->other++;
+                continue;
+            }
+            if (result ==
+                LEO_WONDER_APPETITE_POLICY_RESULT_CONFOUNDED) {
+                epoch->confounded++;
+                continue;
+            }
+
+            epoch->exact++;
+            if (receipt->policy ==
+                LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+                epoch->eligible++;
+                if (result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_SUPPORTED)
+                    epoch->supported++;
+                else
+                    epoch->overreach++;
+            } else {
+                epoch->abstained++;
+                if (result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_MISSED)
+                    epoch->missed++;
+                else
+                    epoch->restraint++;
+            }
+        }
+
+        LeoWonderAppetiteTransportEpoch *early = &cell->epochs[0];
+        LeoWonderAppetiteTransportEpoch *recent = &cell->epochs[1];
+        if (early->incompatible > 0 ||
+            recent->incompatible > 0) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE;
+            leo_wonder_appetite_transport_chronology_count(
+                chronology, cell->status);
+            continue;
+        }
+        if (cell->post_settled <
+            LEO_WONDER_APPETITE_TRANSPORT_EPOCHS *
+            LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_OBSERVING;
+            leo_wonder_appetite_transport_chronology_count(
+                chronology, cell->status);
+            continue;
+        }
+        if (early->eligible <
+                LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N ||
+            early->abstained <
+                LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N ||
+            recent->eligible <
+                LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N ||
+            recent->abstained <
+                LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED;
+            leo_wonder_appetite_transport_chronology_count(
+                chronology, cell->status);
+            continue;
+        }
+
+        leo_wonder_appetite_transport_epoch_finish(
+            early, admission, trial);
+        leo_wonder_appetite_transport_epoch_finish(
+            recent, admission, trial);
+        cell->aggregate_provisional =
+            aggregate.cells[i].status ==
+                LEO_WONDER_APPETITE_TRANSPORT_PROVISIONAL;
+        cell->epoch_coverage_compatible =
+            leo_interval_overlaps(
+                early->coverage_lower, early->coverage_upper,
+                recent->coverage_lower, recent->coverage_upper);
+
+        int early_ok =
+            early->motion_bounded &&
+            early->restraint_bounded &&
+            early->history_coverage_compatible;
+        int recent_ok =
+            recent->motion_bounded &&
+            recent->restraint_bounded &&
+            recent->history_coverage_compatible;
+        if (!cell->aggregate_provisional) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_AGGREGATE_SHIFTED;
+        } else if (!early_ok && !recent_ok) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_BOTH_SHIFTED;
+        } else if (!early_ok) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_EARLY_SHIFTED;
+        } else if (!recent_ok) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_RECENT_SHIFTED;
+        } else if (!cell->epoch_coverage_compatible) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_ECOLOGY_SHIFTED;
+        } else {
+            cell->status =
+                LEO_WONDER_APPETITE_CHRONOLOGY_PROVISIONAL;
+        }
+        leo_wonder_appetite_transport_chronology_count(
+            chronology, cell->status);
+    }
+}
+
 static void leo_wonder_appetite_holdout_update(Leo *leo) {
     if (!leo || !g_leo_wonder_appetite_holdout_on ||
         !g_leo_wonder_appetite_calibration_on)
@@ -11091,6 +11499,80 @@ static void print_wonder_appetite_transport_stats(const Leo *leo) {
     printf("]\n");
 }
 
+static void print_wonder_appetite_transport_chronology_stats(
+        const Leo *leo) {
+    if (!g_leo_wonder_appetite_transport_chronology_on || !leo)
+        return;
+    int occupied = 0;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++)
+        if (leo->wonder_appetite_holdouts.trials[i].status !=
+            LEO_WONDER_APPETITE_HOLDOUT_EMPTY)
+            occupied++;
+    if (occupied == 0) return;
+
+    LeoWonderAppetiteTransportChronology chronology;
+    leo_wonder_appetite_transport_chronology(leo, &chronology);
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+    printf("     [wonder-appetite-transport-chronology: epochs=%d attempts=%d min-arm=%d ceiling=%.3f unattested=%d pending=%d refuted=%d incompatible=%d observing=%d coverage-starved=%d aggregate-shifted=%d early-shifted=%d recent-shifted=%d both-shifted=%d ecology-shifted=%d provisional=%d cells=",
+           LEO_WONDER_APPETITE_TRANSPORT_EPOCHS,
+           LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS,
+           LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N,
+           (double)LEO_WONDER_APPETITE_READINESS_RISK_CEILING,
+           chronology.unattested, chronology.pending,
+           chronology.refuted, chronology.incompatible,
+           chronology.observing, chronology.coverage_starved,
+           chronology.aggregate_shifted, chronology.early_shifted,
+           chronology.recent_shifted, chronology.both_shifted,
+           chronology.ecology_shifted, chronology.provisional);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteTransportChronologyCell *cell =
+            &chronology.cells[i];
+        if (cell->status ==
+            LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY)
+            continue;
+        printf("%s%c%d-%d:%llu/%d/%u/%u",
+               separator, cell->spoken ? 's' : 'u',
+               lower[cell->bin], upper[cell->bin],
+               (unsigned long long)cell->after_proposed_turn,
+               cell->post_settled,
+               (unsigned)cell->aggregate_provisional,
+               (unsigned)cell->epoch_coverage_compatible);
+        for (int j = 0;
+             j < LEO_WONDER_APPETITE_TRANSPORT_EPOCHS; j++) {
+            const LeoWonderAppetiteTransportEpoch *epoch =
+                &cell->epochs[j];
+            printf("/%llu/%llu/%d/%d/%d/%d/%d/%d/%d/%d/%d/%d/%d/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%u/%u/%u",
+                   (unsigned long long)epoch->first_proposed_turn,
+                   (unsigned long long)epoch->last_proposed_turn,
+                   epoch->attempts, epoch->exact,
+                   epoch->eligible, epoch->abstained,
+                   epoch->supported, epoch->overreach,
+                   epoch->missed, epoch->restraint,
+                   epoch->confounded, epoch->other,
+                   epoch->incompatible,
+                   (double)epoch->coverage,
+                   (double)epoch->coverage_lower,
+                   (double)epoch->coverage_upper,
+                   (double)epoch->overreach_rate,
+                   (double)epoch->overreach_upper,
+                   (double)epoch->missed_rate,
+                   (double)epoch->missed_upper,
+                   (unsigned)epoch->motion_bounded,
+                   (unsigned)epoch->restraint_bounded,
+                   (unsigned)epoch->history_coverage_compatible);
+        }
+        printf("/%s",
+               leo_wonder_appetite_transport_chronology_status_name(
+                   cell->status));
+        separator = "|";
+    }
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -11334,6 +11816,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder-appetite-holdout")) g_leo_wonder_appetite_holdout_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-admission")) g_leo_wonder_appetite_admission_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-transport")) g_leo_wonder_appetite_transport_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-transport-chronology")) g_leo_wonder_appetite_transport_chronology_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -11558,6 +12041,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_holdout_stats(&leo);
             print_wonder_appetite_admission_stats(&leo);
             print_wonder_appetite_transport_stats(&leo);
+            print_wonder_appetite_transport_chronology_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -11625,6 +12109,7 @@ int main(int argc, char **argv) {
             print_wonder_appetite_holdout_stats(&leo);
             print_wonder_appetite_admission_stats(&leo);
             print_wonder_appetite_transport_stats(&leo);
+            print_wonder_appetite_transport_chronology_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -627,3 +627,55 @@ byte-identical complete v24 states for all eight rows.
 A.53 is derived diagnostics only. It does not persist another judgment and no
 speech or scheduler path reads it. Even `provisional` remains evidence, not
 permission.
+
+Run the two-epoch current-life chronology:
+
+```sh
+make deferred-wonder-appetite-transport-chronology
+```
+
+A.54 asks whether A.53's pooled present is hiding a regime change. It uses the
+complete current 32-settled-attempt post-holdout window already bounded by the
+A.48 diary. The older 16 attempts form the `early` epoch and the newer 16 form
+the `recent` epoch. Their proposal boundaries must be ordered and
+non-overlapping. If earlier post-holdout evidence has rotated away, A.54 makes
+no claim to have recovered it; this is chronology inside the observable
+present, not a reconstruction of the first historical era.
+
+Every settled attempt spends one epoch slot, including another stratum or a
+causally confounded outcome. Pending receipts do not become outcomes and leave
+the window `observing`. A `none` or `legacy` policy, or non-monotonic proposal
+identity, makes it `incompatible`.
+Each complete epoch independently needs at least four exact eligible and four
+exact abstained outcomes. An absent arm produces `coverage-starved` rather than
+borrowing observations from the neighboring era.
+
+For each epoch, motion and restraint retain separate 95% Wilson upper-bound
+vetoes below `0.500`. Its policy-coverage interval must also overlap both the
+A.52 admission interval and the realized A.51 holdout interval. Finally, the
+early and recent coverage intervals must overlap each other. As in A.53,
+interval overlap is only a compatibility screen, not evidence of equivalent
+distributions.
+
+The pooled A.53 cell must remain `provisional` before A.54 can be
+`provisional`. Chronology can only add vetoes:
+
+```text
+aggregate-shifted  pooled A.53 transport already failed
+early-shifted      only the older observed epoch fails
+recent-shifted     only the newer observed epoch fails
+both-shifted       both epochs fail, possibly on different risk axes
+ecology-shifted    both epochs pass history screens but their coverages diverge
+provisional        pooled and both local screens expose no measured shift
+```
+
+The nine-case matrix includes three temporal arrangements with identical
+pooled arm totals, an opposite-axis cancellation, a `12/4 -> 4/12` policy
+ecology inversion whose pooled coverage remains `16/16`, a pooled failure,
+thin chronology, epoch-local coverage starvation, and policy incompatibility.
+Default and `--no-wonder-appetite-transport-chronology` forks must preserve
+strict proposal order, identical replies, and byte-identical complete v24
+states in every row.
+
+A.54 adds no state and no speech, scheduler, routing, sampling, or generation
+reader. It is a readerless chronology of evidence, not permission to intervene.

--- a/scripts/deferred_wonder_appetite_transport_chronology_matrix.sh
+++ b/scripts/deferred_wonder_appetite_transport_chronology_matrix.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# A.54: split a pooled present into adjacent early and recent regimes.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-transport-chronology-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT"
+
+PLAN="$OUT/plan.tsv"
+printf 'case\texpected_post_settled\texpected_early_attempts\texpected_recent_attempts\texpected_early_eligible\texpected_early_abstained\texpected_recent_eligible\texpected_recent_abstained\texpected_early_overreach_upper\texpected_early_missed_upper\texpected_recent_overreach_upper\texpected_recent_missed_upper\texpected_aggregate_provisional\texpected_epoch_coverage_compatible\texpected_status\n' > "$PLAN"
+printf 'chronology-provisional\t32\t16\t16\t8\t8\t8\t8\t0.471\t0.471\t0.471\t0.471\t1\t1\tprovisional\n' >> "$PLAN"
+printf 'chronology-early-shift\t32\t16\t16\t8\t8\t8\t8\t0.694\t0.324\t0.324\t0.324\t1\t1\tearly-shifted\n' >> "$PLAN"
+printf 'chronology-recent-shift\t32\t16\t16\t8\t8\t8\t8\t0.324\t0.324\t0.694\t0.324\t1\t1\trecent-shifted\n' >> "$PLAN"
+printf 'chronology-both-shift\t32\t16\t16\t8\t8\t8\t8\t0.694\t0.324\t0.324\t0.694\t1\t1\tboth-shifted\n' >> "$PLAN"
+printf 'chronology-ecology-shift\t32\t16\t16\t12\t4\t4\t12\t0.354\t0.490\t0.490\t0.354\t1\t0\tecology-shifted\n' >> "$PLAN"
+printf 'chronology-aggregate-shift\t32\t16\t16\t8\t8\t8\t8\t0.785\t0.324\t0.785\t0.324\t0\t1\taggregate-shifted\n' >> "$PLAN"
+printf 'chronology-observing\t31\t16\t15\t8\t8\t8\t7\t0.000\t0.000\t0.000\t0.000\t0\t0\tobserving\n' >> "$PLAN"
+printf 'chronology-coverage-starved\t32\t16\t16\t16\t0\t8\t8\t0.000\t0.000\t0.000\t0.000\t0\t0\tcoverage-starved\n' >> "$PLAN"
+printf 'chronology-incompatible\t1\t1\t0\t0\t0\t0\t0\t0.000\t0.000\t0.000\t0.000\t0\t0\tincompatible\n' >> "$PLAN"
+
+if [ "${LEO_APPETITE_TRANSPORT_CHRONOLOGY_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"${CC:-cc}" -O2 -Wall -Wextra -Wno-unused-function \
+    "$ROOT/tests/wonder_appetite_holdout_fixture.c" -lm \
+    -o "$OUT/holdout-fixture"
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+chronology_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_transport_chronology_dialogue_report.awk" \
+        "$1"
+}
+
+cell_fields() {
+    local cells="$1"
+    local wanted="$2"
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 51; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+MATRIX="$OUT/matrix.tsv"
+printf 'case\tpost_settled\tearly_attempts\trecent_attempts\tearly_eligible\tearly_abstained\trecent_eligible\trecent_abstained\tearly_overreach_upper\tearly_missed_upper\trecent_overreach_upper\trecent_missed_upper\taggregate_provisional\tepoch_coverage_compatible\tstatus\tchronological\treply_equal\tstate_equal\n' > "$MATRIX"
+
+tail -n +2 "$PLAN" |
+while IFS=$'\t' read -r case_name expected_post \
+        expected_early_attempts expected_recent_attempts \
+        expected_early_eligible expected_early_abstained \
+        expected_recent_eligible expected_recent_abstained \
+        expected_early_over expected_early_miss \
+        expected_recent_over expected_recent_miss \
+        expected_aggregate expected_epoch_coverage expected_status; do
+    case_dir="$OUT/$case_name"
+    mkdir -p "$case_dir"
+    "$OUT/holdout-fixture" "$case_dir/base.state" "$case_name"
+    cp "$case_dir/base.state" "$case_dir/on.state"
+    cp "$case_dir/base.state" "$case_dir/off.state"
+    seed=5401
+    prompt="The rain falls softly."
+
+    "$ROOT/leo" --load "$case_dir/on.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --save "$case_dir/on.state" > "$case_dir/on.log" 2>&1
+    "$ROOT/leo" --load "$case_dir/off.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --no-wonder-appetite-transport-chronology \
+        --save "$case_dir/off.state" > "$case_dir/off.log" 2>&1
+
+    chronology="$(
+        chronology_from_log "$case_dir/on.log" "$case_name" "$seed"
+    )"
+    [ -n "$chronology" ] || {
+        printf '%s emitted no A.54 chronology witness\n' \
+            "$case_name" >&2
+        exit 1
+    }
+    [ -z "$(
+        chronology_from_log "$case_dir/off.log" "$case_name" "$seed"
+    )" ] || {
+        printf '%s chronology ablation remained visible\n' \
+            "$case_name" >&2
+        exit 1
+    }
+
+    IFS=$'\t' read -r _ _ epochs attempts min_arm ceiling \
+        unattested pending refuted incompatible observing coverage_starved \
+        aggregate_shifted early_shifted recent_shifted both_shifted \
+        ecology_shifted provisional cells <<< "$chronology"
+    cell="$(cell_fields "$cells" u62-70)"
+    [ -n "$cell" ] || {
+        printf '%s lost its chronology cell\n' "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r after post_settled aggregate epoch_coverage \
+        early_first early_last early_attempts early_exact \
+        early_eligible early_abstained early_supported early_overreach \
+        early_missed early_restraint early_confounded early_other \
+        early_incompatible early_coverage early_lower early_upper \
+        early_over_rate early_over_upper early_miss_rate early_miss_upper \
+        early_motion early_restraint_bounded early_history \
+        recent_first recent_last recent_attempts recent_exact \
+        recent_eligible recent_abstained recent_supported recent_overreach \
+        recent_missed recent_restraint recent_confounded recent_other \
+        recent_incompatible recent_coverage recent_lower recent_upper \
+        recent_over_rate recent_over_upper recent_miss_rate recent_miss_upper \
+        recent_motion recent_restraint_bounded recent_history status extra \
+        <<< "$cell"
+
+    expected_unattested=0
+    expected_pending=0
+    expected_refuted=0
+    expected_incompatible=0
+    expected_observing=0
+    expected_coverage_starved=0
+    expected_aggregate_shifted=0
+    expected_early_shifted=0
+    expected_recent_shifted=0
+    expected_both_shifted=0
+    expected_ecology_shifted=0
+    expected_provisional=0
+    case "$expected_status" in
+        incompatible) expected_incompatible=1 ;;
+        observing) expected_observing=1 ;;
+        coverage-starved) expected_coverage_starved=1 ;;
+        aggregate-shifted) expected_aggregate_shifted=1 ;;
+        early-shifted) expected_early_shifted=1 ;;
+        recent-shifted) expected_recent_shifted=1 ;;
+        both-shifted) expected_both_shifted=1 ;;
+        ecology-shifted) expected_ecology_shifted=1 ;;
+        provisional) expected_provisional=1 ;;
+    esac
+
+    chronological=0
+    if [ "$recent_attempts" = 0 ]; then
+        chronological=1
+    elif [ "$early_last" -lt "$recent_first" ]; then
+        chronological=1
+    fi
+    reply_equal=0
+    [ "$(reply_from_log "$case_dir/on.log")" = \
+      "$(reply_from_log "$case_dir/off.log")" ] &&
+        reply_equal=1
+    state_equal=0
+    cmp -s "$case_dir/on.state" "$case_dir/off.state" &&
+        state_equal=1
+
+    [ -z "${extra:-}" ] &&
+    [ "$epochs" = 2 ] && [ "$attempts" = 16 ] &&
+    [ "$min_arm" = 4 ] && [ "$ceiling" = 0.500 ] &&
+    [ "$unattested" = "$expected_unattested" ] &&
+    [ "$pending" = "$expected_pending" ] &&
+    [ "$refuted" = "$expected_refuted" ] &&
+    [ "$incompatible" = "$expected_incompatible" ] &&
+    [ "$observing" = "$expected_observing" ] &&
+    [ "$coverage_starved" = "$expected_coverage_starved" ] &&
+    [ "$aggregate_shifted" = "$expected_aggregate_shifted" ] &&
+    [ "$early_shifted" = "$expected_early_shifted" ] &&
+    [ "$recent_shifted" = "$expected_recent_shifted" ] &&
+    [ "$both_shifted" = "$expected_both_shifted" ] &&
+    [ "$ecology_shifted" = "$expected_ecology_shifted" ] &&
+    [ "$provisional" = "$expected_provisional" ] &&
+    [ "$after" -gt 0 ] &&
+    [ "$post_settled" = "$expected_post" ] &&
+    [ "$early_attempts" = "$expected_early_attempts" ] &&
+    [ "$recent_attempts" = "$expected_recent_attempts" ] &&
+    [ "$early_eligible" = "$expected_early_eligible" ] &&
+    [ "$early_abstained" = "$expected_early_abstained" ] &&
+    [ "$recent_eligible" = "$expected_recent_eligible" ] &&
+    [ "$recent_abstained" = "$expected_recent_abstained" ] &&
+    [ "$early_over_upper" = "$expected_early_over" ] &&
+    [ "$early_miss_upper" = "$expected_early_miss" ] &&
+    [ "$recent_over_upper" = "$expected_recent_over" ] &&
+    [ "$recent_miss_upper" = "$expected_recent_miss" ] &&
+    [ "$aggregate" = "$expected_aggregate" ] &&
+    [ "$epoch_coverage" = "$expected_epoch_coverage" ] &&
+    [ "$status" = "$expected_status" ] &&
+    [ "$chronological" = 1 ] &&
+    [ "$reply_equal" = 1 ] && [ "$state_equal" = 1 ] || {
+        printf '%s chronology contract failed: post=%s attempts=%s/%s arms=%s/%s|%s/%s bounds=%s/%s|%s/%s aggregate=%s ecology=%s status=%s order=%s reply=%s state=%s\n' \
+            "$case_name" "$post_settled" "$early_attempts" \
+            "$recent_attempts" "$early_eligible" "$early_abstained" \
+            "$recent_eligible" "$recent_abstained" \
+            "$early_over_upper" "$early_miss_upper" \
+            "$recent_over_upper" "$recent_miss_upper" \
+            "$aggregate" "$epoch_coverage" "$status" \
+            "$chronological" "$reply_equal" "$state_equal" >&2
+        exit 1
+    }
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$case_name" "$post_settled" "$early_attempts" \
+        "$recent_attempts" "$early_eligible" "$early_abstained" \
+        "$recent_eligible" "$recent_abstained" \
+        "$early_over_upper" "$early_miss_upper" \
+        "$recent_over_upper" "$recent_miss_upper" \
+        "$aggregate" "$epoch_coverage" "$status" "$chronological" \
+        "$reply_equal" "$state_equal" >> "$MATRIX"
+done
+
+awk -F '\t' '
+    NR > 1 {
+        rows++
+        order += $16
+        replies += $17
+        states += $18
+    }
+    END {
+        print "cases\tchronological\treply_equal\tstate_equal"
+        print rows "\t" order "\t" replies "\t" states
+        if (rows != 9 || order != 9 ||
+            replies != 9 || states != 9)
+            exit 1
+    }
+' "$MATRIX"
+printf '\nmatrix: %s\n' "$MATRIX"

--- a/scripts/test_deferred_wonder_appetite_transport_chronology_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_transport_chronology_matrix.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_TRANSPORT_CHRONOLOGY_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_transport_chronology_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 15 || $1 != "case" ||
+            $2 != "expected_post_settled" ||
+            $15 != "expected_status")
+            exit 1
+        next
+    }
+    {
+        if (NF != 15 || seen[$1]++)
+            exit 1
+        if ($1 == "chronology-provisional" &&
+            ($9 != "0.471" || $10 != "0.471" ||
+             $11 != "0.471" || $12 != "0.471" ||
+             $13 != 1 || $14 != 1 ||
+             $15 != "provisional"))
+            exit 1
+        if ($1 == "chronology-early-shift" &&
+            ($9 != "0.694" || $11 != "0.324" ||
+             $13 != 1 || $15 != "early-shifted"))
+            exit 1
+        if ($1 == "chronology-recent-shift" &&
+            ($9 != "0.324" || $11 != "0.694" ||
+             $13 != 1 || $15 != "recent-shifted"))
+            exit 1
+        if ($1 == "chronology-both-shift" &&
+            ($9 != "0.694" || $12 != "0.694" ||
+             $13 != 1 || $15 != "both-shifted"))
+            exit 1
+        if ($1 == "chronology-ecology-shift" &&
+            ($5 != 12 || $6 != 4 || $7 != 4 || $8 != 12 ||
+             $13 != 1 || $14 != 0 ||
+             $15 != "ecology-shifted"))
+            exit 1
+        if ($1 == "chronology-aggregate-shift" &&
+            ($13 != 0 || $15 != "aggregate-shifted"))
+            exit 1
+        if ($1 == "chronology-observing" &&
+            ($2 != 31 || $15 != "observing"))
+            exit 1
+        if ($1 == "chronology-coverage-starved" &&
+            ($5 != 16 || $6 != 0 ||
+             $15 != "coverage-starved"))
+            exit 1
+        if ($1 == "chronology-incompatible" &&
+            $15 != "incompatible")
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 9)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite transport chronology plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite transport chronology matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_transport_chronology_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_transport_chronology_dialogue_report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-transport-chronology: epochs=2 attempts=16 min-arm=4 ceiling=0.500 unattested=0 pending=0 refuted=0 incompatible=0 observing=0 coverage-starved=0 aggregate-shifted=0 early-shifted=0 recent-shifted=0 both-shifted=0 ecology-shifted=0 provisional=1 cells=u62-70:134/32/1/1/138/198/16]
+EOF
+
+got="$(
+    awk -v scenario=chronology-provisional -v seed=101 \
+        -f "$ROOT/scripts/wonder_appetite_transport_chronology_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'chronology-provisional\t101\t2\t16\t4\t0.500\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t1\tu62-70:134/32/1/1/138/198/16'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite transport chronology parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite transport chronology report parser: ok\n'

--- a/scripts/wonder_appetite_transport_chronology_dialogue_report.awk
+++ b/scripts/wonder_appetite_transport_chronology_dialogue_report.awk
@@ -1,0 +1,42 @@
+# Extract one A.54 two-epoch transport chronology from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    fields, i, n, prefix, value) {
+    prefix = key "="
+    n = split(line, fields, /[ ]+/)
+    for (i = 1; i <= n; i++) {
+        if (index(fields[i], prefix) != 1)
+            continue
+        value = substr(fields[i], length(prefix) + 1)
+        gsub(/\]$/, "", value)
+        return value
+    }
+    return ""
+}
+
+/\[wonder-appetite-transport-chronology: epochs=/ {
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed),
+           value_after($0, "epochs"),
+           value_after($0, "attempts"),
+           value_after($0, "min-arm"),
+           value_after($0, "ceiling"),
+           value_after($0, "unattested"),
+           value_after($0, "pending"),
+           value_after($0, "refuted"),
+           value_after($0, "incompatible"),
+           value_after($0, "observing"),
+           value_after($0, "coverage-starved"),
+           value_after($0, "aggregate-shifted"),
+           value_after($0, "early-shifted"),
+           value_after($0, "recent-shifted"),
+           value_after($0, "both-shifted"),
+           value_after($0, "ecology-shifted"),
+           value_after($0, "provisional"),
+           value_after($0, "cells")
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -1310,6 +1310,32 @@ static void test_add_appetite_transport_outcomes(
             LEO_WONDER_APPETITE_CALIB_FADED);
 }
 
+static uint64_t test_add_appetite_transport_epoch(
+        Leo *leo, uint64_t proposed, float appetite, int spoken,
+        int supported, int overreach, int missed, int restraint) {
+    for (int i = 0; i < supported; i++, proposed += 4)
+        test_add_appetite_policy_outcome_after(
+            leo, proposed, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < overreach; i++, proposed += 4)
+        test_add_appetite_policy_outcome_after(
+            leo, proposed, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    for (int i = 0; i < missed; i++, proposed += 4)
+        test_add_appetite_policy_outcome_after(
+            leo, proposed, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    for (int i = 0; i < restraint; i++, proposed += 4)
+        test_add_appetite_policy_outcome_after(
+            leo, proposed, appetite, spoken,
+            LEO_WONDER_APPETITE_POLICY_FORMING,
+            LEO_WONDER_APPETITE_CALIB_FADED);
+    return proposed;
+}
+
 static LeoWonderAppetiteHoldoutTrial *
 test_prepare_appetite_transport(Leo *leo) {
     LeoWonderAppetiteHoldoutTrial *trial =
@@ -1536,6 +1562,296 @@ static void test_wonder_appetite_transport_witness(void) {
 
     g_leo_wonder_appetite_transport_on =
         previous_transport;
+    g_leo_wonder_appetite_holdout_on = previous_holdout;
+    g_leo_wonder_appetite_calibration_on =
+        previous_calibration;
+    g_leo_wonder_appetite_policy_on = previous_policy;
+    g_leo_wonder_appetite_admission_on =
+        previous_admission;
+    leo_free(leo);
+    free(leo);
+    free(before);
+}
+
+__attribute__((noinline))
+static void test_wonder_appetite_transport_chronology(void) {
+    Leo *leo = malloc(sizeof *leo);
+    Leo *before = malloc(sizeof *before);
+    CHECK(leo && before,
+          "wonder-appetite-transport-chronology: heap fixtures allocated");
+    if (!leo || !before) {
+        free(leo);
+        free(before);
+        return;
+    }
+
+    int previous_chronology =
+        g_leo_wonder_appetite_transport_chronology_on;
+    int previous_transport =
+        g_leo_wonder_appetite_transport_on;
+    int previous_holdout =
+        g_leo_wonder_appetite_holdout_on;
+    int previous_calibration =
+        g_leo_wonder_appetite_calibration_on;
+    int previous_policy =
+        g_leo_wonder_appetite_policy_on;
+    int previous_admission =
+        g_leo_wonder_appetite_admission_on;
+    g_leo_wonder_appetite_transport_chronology_on = 1;
+    g_leo_wonder_appetite_transport_on = 1;
+    g_leo_wonder_appetite_holdout_on = 1;
+    g_leo_wonder_appetite_calibration_on = 1;
+    g_leo_wonder_appetite_policy_on = 1;
+    g_leo_wonder_appetite_admission_on = 1;
+
+    LeoWonderAppetiteTransportChronology chronology;
+    leo_init(leo);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    CHECK(chronology.unattested == 0 &&
+          chronology.pending == 0 &&
+          chronology.refuted == 0 &&
+          chronology.incompatible == 0 &&
+          chronology.observing == 0 &&
+          chronology.provisional == 0,
+          "wonder-appetite-transport-chronology: an empty life invents no eras");
+
+    LeoWonderAppetiteHoldoutTrial *trial =
+        test_open_appetite_holdout(leo, 0.65f, 0);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    CHECK(trial && chronology.pending == 1 &&
+          chronology.cells[0].status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_PENDING,
+          "wonder-appetite-transport-chronology: chronology cannot precede its unfinished future");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    memset(&leo->wonder_appetite_admissions, 0,
+           sizeof leo->wonder_appetite_admissions);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    CHECK(trial && chronology.unattested == 1 &&
+          chronology.cells[0].status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_UNATTESTED,
+          "wonder-appetite-transport-chronology: chronology cannot manufacture a vanished warrant");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_finish_appetite_holdout(
+        leo, 0.65f, 0, 4, 4, 1, 7, 0, 0);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    CHECK(trial && chronology.refuted == 1 &&
+          chronology.cells[0].status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_REFUTED,
+          "wonder-appetite-transport-chronology: a refuted future has no transport eras");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    uint64_t boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    uint64_t proposed = boundary + 4;
+    proposed = test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 7, 1, 1, 7);
+    test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 7, 1, 1, 7);
+    *before = *leo;
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    const LeoWonderAppetiteTransportChronologyCell *cell =
+        &chronology.cells[0];
+    const LeoWonderAppetiteTransportEpoch *early =
+        &cell->epochs[0];
+    const LeoWonderAppetiteTransportEpoch *recent =
+        &cell->epochs[1];
+    CHECK(chronology.provisional == 1 &&
+          cell->post_settled == 32 &&
+          cell->aggregate_provisional &&
+          cell->epoch_coverage_compatible &&
+          early->attempts == 16 && recent->attempts == 16 &&
+          early->last_proposed_turn <
+              recent->first_proposed_turn &&
+          early->eligible == 8 && early->abstained == 8 &&
+          recent->eligible == 8 && recent->abstained == 8 &&
+          fabsf(early->overreach_upper - 0.4709f) < 1e-3f &&
+          fabsf(recent->missed_upper - 0.4709f) < 1e-3f &&
+          early->motion_bounded && early->restraint_bounded &&
+          recent->motion_bounded && recent->restraint_bounded &&
+          early->history_coverage_compatible &&
+          recent->history_coverage_compatible &&
+          cell->status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_PROVISIONAL,
+          "wonder-appetite-transport-chronology: two bounded adjacent eras preserve only provisional continuity");
+    CHECK(!memcmp(before, leo, sizeof *leo) &&
+          LEO_STATE_VERSION == 24,
+          "wonder-appetite-transport-chronology: reading eras rewrites no body, evidence, or state format");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    proposed = boundary + 4;
+    proposed = test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 5, 3, 0, 8);
+    test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 8, 0, 0, 8);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    cell = &chronology.cells[0];
+    CHECK(chronology.early_shifted == 1 &&
+          cell->aggregate_provisional &&
+          !cell->epochs[0].motion_bounded &&
+          cell->epochs[1].motion_bounded &&
+          cell->status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_EARLY_SHIFTED,
+          "wonder-appetite-transport-chronology: a good recent era cannot average away earlier overreach");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    proposed = boundary + 4;
+    proposed = test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 8, 0, 0, 8);
+    test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 5, 3, 0, 8);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    cell = &chronology.cells[0];
+    CHECK(chronology.recent_shifted == 1 &&
+          cell->aggregate_provisional &&
+          cell->epochs[0].motion_bounded &&
+          !cell->epochs[1].motion_bounded &&
+          cell->status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_RECENT_SHIFTED,
+          "wonder-appetite-transport-chronology: an earlier calm cannot average away recent overreach");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    proposed = boundary + 4;
+    proposed = test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 5, 3, 0, 8);
+    test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 8, 0, 3, 5);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    cell = &chronology.cells[0];
+    CHECK(chronology.both_shifted == 1 &&
+          cell->aggregate_provisional &&
+          !cell->epochs[0].motion_bounded &&
+          cell->epochs[0].restraint_bounded &&
+          cell->epochs[1].motion_bounded &&
+          !cell->epochs[1].restraint_bounded &&
+          cell->status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_BOTH_SHIFTED,
+          "wonder-appetite-transport-chronology: opposite era-local debts cannot cancel in a pooled present");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    proposed = boundary + 4;
+    proposed = test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 11, 1, 0, 4);
+    test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 4, 0, 1, 11);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    cell = &chronology.cells[0];
+    CHECK(chronology.ecology_shifted == 1 &&
+          cell->aggregate_provisional &&
+          cell->epochs[0].history_coverage_compatible &&
+          cell->epochs[1].history_coverage_compatible &&
+          !cell->epoch_coverage_compatible &&
+          cell->epochs[1].coverage_upper <
+              cell->epochs[0].coverage_lower &&
+          cell->status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_ECOLOGY_SHIFTED,
+          "wonder-appetite-transport-chronology: a stable pooled coverage cannot hide an arm ecology inversion");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    proposed = boundary + 4;
+    proposed = test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 4, 4, 0, 8);
+    test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 4, 4, 0, 8);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    CHECK(chronology.aggregate_shifted == 1 &&
+          !chronology.cells[0].aggregate_provisional &&
+          chronology.cells[0].status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_AGGREGATE_SHIFTED,
+          "wonder-appetite-transport-chronology: chronology cannot overrule a failed pooled transport");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    proposed = boundary + 4;
+    proposed = test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 8, 0, 0, 8);
+    test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 8, 0, 0, 7);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    CHECK(chronology.observing == 1 &&
+          chronology.cells[0].post_settled == 31 &&
+          chronology.cells[0].status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_OBSERVING,
+          "wonder-appetite-transport-chronology: thirty-one lives cannot impersonate two eras");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    proposed = boundary + 4;
+    proposed = test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 16, 0, 0, 0);
+    test_add_appetite_transport_epoch(
+        leo, proposed, 0.65f, 0, 8, 0, 0, 8);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    CHECK(chronology.coverage_starved == 1 &&
+          chronology.cells[0].epochs[0].abstained == 0 &&
+          chronology.cells[0].status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED,
+          "wonder-appetite-transport-chronology: an epoch cannot borrow its missing arm from another");
+
+    leo_free(leo);
+    leo_init(leo);
+    trial = test_prepare_appetite_transport(leo);
+    boundary =
+        leo_wonder_appetite_holdout_terminal_boundary(trial);
+    test_add_appetite_policy_outcome_after(
+        leo, boundary + 4, 0.65f, 0,
+        LEO_WONDER_APPETITE_POLICY_LEGACY,
+        LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    leo_wonder_appetite_transport_chronology(
+        leo, &chronology);
+    CHECK(chronology.incompatible == 1 &&
+          chronology.cells[0].epochs[0].incompatible == 1 &&
+          chronology.cells[0].status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE,
+          "wonder-appetite-transport-chronology: an era cannot translate a changed policy language");
+
+    g_leo_wonder_appetite_transport_chronology_on =
+        previous_chronology;
+    g_leo_wonder_appetite_transport_on = previous_transport;
     g_leo_wonder_appetite_holdout_on = previous_holdout;
     g_leo_wonder_appetite_calibration_on =
         previous_calibration;
@@ -4020,6 +4336,7 @@ int main(void) {
     test_wonder_appetite_readiness_frontier();
     test_wonder_appetite_holdout_trial();
     test_wonder_appetite_transport_witness();
+    test_wonder_appetite_transport_chronology();
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
      * concept-slot; a taught word then returns that glyph (no longer -1); the

--- a/tests/wonder_appetite_holdout_fixture.c
+++ b/tests/wonder_appetite_holdout_fixture.c
@@ -159,6 +159,19 @@ static int add_future(Leo *leo, const char *scenario) {
     return 0;
 }
 
+static int chronology_scenario(const char *scenario) {
+    return
+        !strcmp(scenario, "chronology-provisional") ||
+        !strcmp(scenario, "chronology-early-shift") ||
+        !strcmp(scenario, "chronology-recent-shift") ||
+        !strcmp(scenario, "chronology-both-shift") ||
+        !strcmp(scenario, "chronology-ecology-shift") ||
+        !strcmp(scenario, "chronology-aggregate-shift") ||
+        !strcmp(scenario, "chronology-observing") ||
+        !strcmp(scenario, "chronology-coverage-starved") ||
+        !strcmp(scenario, "chronology-incompatible");
+}
+
 static int transport_scenario(const char *scenario) {
     return
         !strcmp(scenario, "transport-provisional") ||
@@ -168,7 +181,8 @@ static int transport_scenario(const char *scenario) {
         !strcmp(scenario, "transport-coverage-shift") ||
         !strcmp(scenario, "transport-holdout-coverage-shift") ||
         !strcmp(scenario, "transport-observing") ||
-        !strcmp(scenario, "transport-incompatible");
+        !strcmp(scenario, "transport-incompatible") ||
+        chronology_scenario(scenario);
 }
 
 static int add_transport_present(Leo *leo, const char *scenario) {
@@ -256,6 +270,66 @@ static int add_transport_present(Leo *leo, const char *scenario) {
     return 0;
 }
 
+static int add_epoch(
+        Leo *leo,
+        int supported, int overreach, int missed, int restraint) {
+    return
+        add_n(leo, supported, 0.65f, 0,
+              LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+              LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(leo, overreach, 0.65f, 0,
+              LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+              LEO_WONDER_APPETITE_CALIB_FADED) &&
+        add_n(leo, missed, 0.65f, 0,
+              LEO_WONDER_APPETITE_POLICY_FORMING,
+              LEO_WONDER_APPETITE_CALIB_SUSTAINED) &&
+        add_n(leo, restraint, 0.65f, 0,
+              LEO_WONDER_APPETITE_POLICY_FORMING,
+              LEO_WONDER_APPETITE_CALIB_FADED);
+}
+
+static int add_chronology_present(
+        Leo *leo, const char *scenario) {
+    if (!strcmp(scenario, "chronology-provisional"))
+        return
+            add_epoch(leo, 7, 1, 1, 7) &&
+            add_epoch(leo, 7, 1, 1, 7);
+    if (!strcmp(scenario, "chronology-early-shift"))
+        return
+            add_epoch(leo, 5, 3, 0, 8) &&
+            add_epoch(leo, 8, 0, 0, 8);
+    if (!strcmp(scenario, "chronology-recent-shift"))
+        return
+            add_epoch(leo, 8, 0, 0, 8) &&
+            add_epoch(leo, 5, 3, 0, 8);
+    if (!strcmp(scenario, "chronology-both-shift"))
+        return
+            add_epoch(leo, 5, 3, 0, 8) &&
+            add_epoch(leo, 8, 0, 3, 5);
+    if (!strcmp(scenario, "chronology-ecology-shift"))
+        return
+            add_epoch(leo, 11, 1, 0, 4) &&
+            add_epoch(leo, 4, 0, 1, 11);
+    if (!strcmp(scenario, "chronology-aggregate-shift"))
+        return
+            add_epoch(leo, 4, 4, 0, 8) &&
+            add_epoch(leo, 4, 4, 0, 8);
+    if (!strcmp(scenario, "chronology-observing"))
+        return
+            add_epoch(leo, 8, 0, 0, 8) &&
+            add_epoch(leo, 8, 0, 0, 7);
+    if (!strcmp(scenario, "chronology-coverage-starved"))
+        return
+            add_epoch(leo, 16, 0, 0, 0) &&
+            add_epoch(leo, 8, 0, 0, 8);
+    if (!strcmp(scenario, "chronology-incompatible"))
+        return add_n(
+            leo, 1, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_LEGACY,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    return 0;
+}
+
 int main(int argc, char **argv) {
     if (argc == 2 && !strcmp(argv[1], "--tail-size")) {
         printf("%zu\n",
@@ -276,7 +350,7 @@ int main(int argc, char **argv) {
          strcmp(argv[2], "coverage-starved") &&
          !transport_scenario(argv[2]))) {
         fprintf(stderr,
-                "usage: %s STATE arm|confirmed|motion-failed|restraint-failed|both-failed|coverage-starved|transport-provisional|transport-motion-shift|transport-restraint-shift|transport-both-shift|transport-coverage-shift|transport-holdout-coverage-shift|transport-observing|transport-incompatible\n",
+                "usage: %s STATE arm|confirmed|motion-failed|restraint-failed|both-failed|coverage-starved|transport-*|chronology-*\n",
                 argv[0]);
         return 2;
     }
@@ -319,7 +393,10 @@ int main(int argc, char **argv) {
             trial->missed = 1;
             trial->restraint = 11;
         }
-        if (ok) ok = add_transport_present(&leo, argv[2]);
+        if (ok)
+            ok = chronology_scenario(argv[2]) ?
+                add_chronology_present(&leo, argv[2]) :
+                add_transport_present(&leo, argv[2]);
     } else if (ok && strcmp(argv[2], "arm")) {
         leo_wonder_appetite_holdout_update(&leo);
         ok = add_future(&leo, argv[2]);


### PR DESCRIPTION
Add a readerless two-epoch chronology over A.53 transport evidence, with independent temporal risk and policy-ecology vetoes plus reproducible process contracts.

Quote: "A calm average can be made from two incompatible storms." - Sol

Method: The Arianna Method asks each era to testify separately before a pooled present may speak for continuity.