### PR TITLE
the method gives time non-overlapping memory

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4822,3 +4822,86 @@ No field was added to `Leo`; no state version moved beyond 24. The chronology
 has no reader in School, Flow, shadow, routing, sampling, scheduling, or
 generation. A pooled present can no longer pass for continuity until each era
 has testified separately.
+
+## Phase A.55 — time cannot borrow its own evidence (2026-07-28)
+
+A.54 could split the current observable ring into early and recent epochs, but
+the ring still rotated. It could say what the present looked like, not whether
+the same geometry survived several disjoint lives. Re-reading a favorable
+receipt in two windows would have made repetition look like persistence.
+
+A.55 gives each confirmed and attested A.51/A.52 trial a persisted checkpoint
+lane. One checkpoint owns exactly 32 newly settled policy attempts after an
+exclusive proposal boundary in an ordinary comparable life; incompatible
+policy language closes that budget early:
+
+```text
+checkpoint 1  (trial terminal, proposal p1 .. p32]
+checkpoint 2  (p32, proposal p33 .. p64]
+```
+
+Each proposal identity is stored, strictly increasing, alongside raw counts
+for exact eligible/abstained outcomes, support, overreach, miss, restraint,
+confounds, other strata, and incompatible policy language. The first and last
+identity of each 16-attempt epoch must agree with the raw identity vector.
+The derived Wilson geometry and final status are recomputed during validation.
+A duplicate ID, an overlapping checkpoint, or a verdict that disagrees with
+its counts invalidates the whole optional v25 ledger.
+
+Only the two newest terminal checkpoints are retained, plus an active one. The
+pair is classified without gaining a speech reader:
+
+```text
+one                 one observation is not a regime
+stable-provisional  provisional -> provisional
+emerging-shift      provisional -> any measured shift
+persistent-shift    shift -> shift, even when the debt changes axis
+recovered           shift -> provisional
+insufficient        a life lacks one measured arm
+incompatible        the policy language changed and the lane closes
+```
+
+`persistent-shift` deliberately does not require the same subtype twice. An
+early motion failure followed by a recent motion failure still says the
+transport geometry remained displaced, while `same_signature=0` preserves
+that its temporal face changed. None of these names is permission to intervene.
+
+State moved from v24 to v25. An older body anchors every eligible lane after
+the newest calibration receipt already present, so migration observes only
+future lives. A truncated or internally impossible v25 tail fails soft: the
+checkpoint ledger is cleared and re-anchored after surviving history, while
+the body, calibration diary, holdout trial, and admission receipt remain.
+Thirty-one attempts survive sleep as thirty-one; they cannot become a
+completed era.
+
+Twenty direct contracts raised the suite from **449/449** to **469/469**.
+They cover one complete life, exact proposal ownership, strict non-overlap,
+stable provisionality, emerging and persistent shifts, changing shift
+signature, recovery, insufficient coverage, 31/32 persistence, exact v25
+round-trip, future-only v24 migration, truncated and corrupt v25 tails,
+confound/other time cost, policy incompatibility, ablation, duplicate IDs,
+false verdicts, forged overlap, and internally coherent evidence dated beyond
+Leo's lived clock.
+
+The real-process matrix produced:
+
+```text
+one           1  provisional       -> one
+stable        2  provisional       -> stable-provisional
+emerging      2  early-shifted      -> emerging-shift
+persistent    2  recent-shifted     -> persistent-shift
+recovered     2  provisional       -> recovered
+insufficient  2  coverage-starved  -> insufficient
+incompatible  1  incompatible      -> incompatible
+pending       0  pending 31/32     -> no sequence
+
+checkpoint chronology  8/8
+reply equality          8/8
+complete state equality 8/8
+writer prefix equality  yes
+writer reply equality   yes
+```
+
+The on/off writer pair differed only in the fixed v25 checkpoint tail. With
+that tail preserved, both bodies spoke the same reply. Time is now durable
+without becoming a hidden voice.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint
 
 all: leo
 
@@ -97,6 +97,9 @@ deferred-wonder-appetite-transport: leo
 deferred-wonder-appetite-transport-chronology: leo
 	./scripts/deferred_wonder_appetite_transport_chronology_matrix.sh
 
+deferred-wonder-appetite-checkpoint: leo
+	./scripts/deferred_wonder_appetite_checkpoint_matrix.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -116,6 +119,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_wonder_appetite_admission_dialogue_report.sh
 	./scripts/test_wonder_appetite_transport_dialogue_report.sh
 	./scripts/test_wonder_appetite_transport_chronology_dialogue_report.sh
+	./scripts/test_wonder_appetite_checkpoint_dialogue_report.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh
@@ -133,6 +137,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_admission_matrix.sh
 	./scripts/test_deferred_wonder_appetite_transport_matrix.sh
 	./scripts/test_deferred_wonder_appetite_transport_chronology_matrix.sh
+	./scripts/test_deferred_wonder_appetite_checkpoint_matrix.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -2226,6 +2226,86 @@ typedef struct {
     int provisional;
 } LeoWonderAppetiteTransportChronology;
 
+/* A.55: transport evidence advances through fixed, non-overlapping lives.
+ * Checkpoints persist raw proposal identities and outcome counts; all rates
+ * and sequence claims are recomputed. Two terminal checkpoints are enough to
+ * distinguish one transition from a repeated regime without authorizing it. */
+#define LEO_WONDER_APPETITE_CHECKPOINT_BUDGET 32
+#define LEO_WONDER_APPETITE_CHECKPOINT_HISTORY 2
+typedef struct {
+    uint64_t first_proposed_turn;
+    uint64_t last_proposed_turn;
+    uint8_t attempts;
+    uint8_t exact;
+    uint8_t eligible;
+    uint8_t abstained;
+    uint8_t supported;
+    uint8_t overreach;
+    uint8_t missed;
+    uint8_t restraint;
+    uint8_t confounded;
+    uint8_t other;
+    uint8_t incompatible;
+} LeoWonderAppetiteCheckpointEpoch;
+typedef struct {
+    uint64_t opened_turn;
+    uint64_t after_proposed_turn;
+    uint64_t through_proposed_turn;
+    uint64_t seen_proposed_turn[
+        LEO_WONDER_APPETITE_CHECKPOINT_BUDGET];
+    uint8_t spoken;
+    uint8_t bin;
+    uint8_t status;
+    uint8_t attempts;
+    LeoWonderAppetiteCheckpointEpoch
+        epochs[LEO_WONDER_APPETITE_TRANSPORT_EPOCHS];
+} LeoWonderAppetiteCheckpoint;
+typedef struct {
+    uint64_t next_after_proposed_turn;
+    LeoWonderAppetiteCheckpoint active;
+    LeoWonderAppetiteCheckpoint
+        history[LEO_WONDER_APPETITE_CHECKPOINT_HISTORY];
+    uint8_t n;
+    uint8_t ptr;
+    uint8_t blocked;
+} LeoWonderAppetiteCheckpointLane;
+typedef struct {
+    LeoWonderAppetiteCheckpointLane
+        lanes[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+} LeoWonderAppetiteCheckpoints;
+
+enum {
+    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_EMPTY = 0,
+    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_ONE,
+    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_STABLE_PROVISIONAL,
+    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_EMERGING_SHIFT,
+    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_PERSISTENT_SHIFT,
+    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_RECOVERED,
+    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INSUFFICIENT,
+    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INCOMPATIBLE,
+    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_STATUS_COUNT
+};
+typedef struct {
+    uint8_t spoken;
+    uint8_t bin;
+    uint8_t n;
+    uint8_t previous_status;
+    uint8_t recent_status;
+    uint8_t same_signature;
+    uint8_t status;
+} LeoWonderAppetiteCheckpointSequenceCell;
+typedef struct {
+    LeoWonderAppetiteCheckpointSequenceCell
+        cells[LEO_WONDER_APPETITE_RELIABILITY_CELLS];
+    int one;
+    int stable_provisional;
+    int emerging_shift;
+    int persistent_shift;
+    int recovered;
+    int insufficient;
+    int incompatible;
+} LeoWonderAppetiteCheckpointSequence;
+
 /* A.42: before School grounds an adjacent answer, compare its semantic address
  * with the open Wonder and the waiting pre-Wonders. This receipt is transient.
  * A confident sibling may veto a destructive close, but can never learn, open,
@@ -2400,6 +2480,9 @@ typedef struct {
     /* A.52/state v24: immutable proof of the A.50 geometry that admitted each
      * trial. Separate so v23 trials migrate visibly unattested, never invented. */
     LeoWonderAppetiteAdmissions wonder_appetite_admissions;
+    /* A.55/state v25: raw fixed-budget transport checkpoints. They persist
+     * evidence chronology, but no cognition or generation path reads them. */
+    LeoWonderAppetiteCheckpoints wonder_appetite_checkpoints;
     /* A.42/A.43: pre-grounding address witness. Semantic conflict can only
      * guard; an exact waiting name may redirect without assigning meaning. */
     LeoWonderAddressReceipt wonder_address;
@@ -2686,6 +2769,7 @@ static int g_leo_wonder_appetite_holdout_on = 1; /* fixed future trial; persiste
 static int g_leo_wonder_appetite_admission_on = 1; /* immutable candidate provenance; no reader in speech. */
 static int g_leo_wonder_appetite_transport_on = 1; /* current-life transport witness; derived and readerless. */
 static int g_leo_wonder_appetite_transport_chronology_on = 1; /* two-epoch transport chronology; derived and readerless. */
+static int g_leo_wonder_appetite_checkpoint_on = 1; /* persisted non-overlapping transport checkpoints; readerless. */
 static int g_leo_wonder_attribution_on = 1; /* address witness: semantic siblings only guard; a literal sibling may be handed to the explicit redirection layer. */
 static int g_leo_wonder_redirection_on = 1; /* an explicitly named waiting sibling may receive the mouth while the active origin returns to the queue. */
 static int g_leo_wonder_return_on = 1;  /* resolved wonder may re-enter one reply's meaning vector. --no-wonder-return is the strict ablation. */
@@ -8092,6 +8176,21 @@ static const char *leo_wonder_appetite_transport_chronology_status_name(
         names[status] : "empty";
 }
 
+__attribute__((unused))  /* main diagnostic; the test TU excludes main */
+static const char *leo_wonder_appetite_checkpoint_sequence_status_name(
+        int status) {
+    static const char
+        *names[LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_STATUS_COUNT] = {
+            "empty", "one", "stable-provisional", "emerging-shift",
+            "persistent-shift", "recovered", "insufficient",
+            "incompatible"
+        };
+    return status >= 0 &&
+           status <
+               LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_STATUS_COUNT ?
+        names[status] : "empty";
+}
+
 static int leo_interval_overlaps(
         float a_lower, float a_upper,
         float b_lower, float b_upper) {
@@ -8406,6 +8505,631 @@ static void leo_wonder_appetite_transport_chronology(
         leo_wonder_appetite_transport_chronology_count(
             chronology, cell->status);
     }
+}
+
+static int leo_wonder_appetite_checkpoint_grade(
+        const LeoWonderAppetiteCheckpoint *checkpoint,
+        const LeoWonderAppetiteAdmissionReceipt *admission,
+        const LeoWonderAppetiteHoldoutTrial *trial) {
+    if (!checkpoint || !admission || !trial)
+        return LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY;
+    const LeoWonderAppetiteCheckpointEpoch *early_raw =
+        &checkpoint->epochs[0];
+    const LeoWonderAppetiteCheckpointEpoch *recent_raw =
+        &checkpoint->epochs[1];
+    if (early_raw->incompatible > 0 ||
+        recent_raw->incompatible > 0)
+        return LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE;
+    if (checkpoint->attempts <
+        LEO_WONDER_APPETITE_CHECKPOINT_BUDGET)
+        return LEO_WONDER_APPETITE_CHRONOLOGY_PENDING;
+    if (early_raw->eligible <
+            LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N ||
+        early_raw->abstained <
+            LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N ||
+        recent_raw->eligible <
+            LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N ||
+        recent_raw->abstained <
+            LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N)
+        return LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED;
+
+    LeoWonderAppetiteTransportEpoch early = {0}, recent = {0};
+    early.attempts = early_raw->attempts;
+    early.exact = early_raw->exact;
+    early.eligible = early_raw->eligible;
+    early.abstained = early_raw->abstained;
+    early.supported = early_raw->supported;
+    early.overreach = early_raw->overreach;
+    early.missed = early_raw->missed;
+    early.restraint = early_raw->restraint;
+    recent.attempts = recent_raw->attempts;
+    recent.exact = recent_raw->exact;
+    recent.eligible = recent_raw->eligible;
+    recent.abstained = recent_raw->abstained;
+    recent.supported = recent_raw->supported;
+    recent.overreach = recent_raw->overreach;
+    recent.missed = recent_raw->missed;
+    recent.restraint = recent_raw->restraint;
+    leo_wonder_appetite_transport_epoch_finish(
+        &early, admission, trial);
+    leo_wonder_appetite_transport_epoch_finish(
+        &recent, admission, trial);
+
+    int eligible = early.eligible + recent.eligible;
+    int abstained = early.abstained + recent.abstained;
+    int exact = eligible + abstained;
+    int overreach = early.overreach + recent.overreach;
+    int missed = early.missed + recent.missed;
+    float overreach_lower = 0.0f, overreach_upper = 0.0f;
+    float missed_lower = 0.0f, missed_upper = 0.0f;
+    float coverage_lower = 0.0f, coverage_upper = 0.0f;
+    float admission_lower = 0.0f, admission_upper = 0.0f;
+    float holdout_lower = 0.0f, holdout_upper = 0.0f;
+    leo_wilson_interval(
+        overreach, eligible,
+        &overreach_lower, &overreach_upper);
+    leo_wilson_interval(
+        missed, abstained,
+        &missed_lower, &missed_upper);
+    leo_wilson_interval(
+        eligible, exact,
+        &coverage_lower, &coverage_upper);
+    leo_wilson_interval(
+        admission->eligible,
+        admission->eligible + admission->abstained,
+        &admission_lower, &admission_upper);
+    leo_wilson_interval(
+        trial->eligible, trial->eligible + trial->abstained,
+        &holdout_lower, &holdout_upper);
+    (void)overreach_lower;
+    (void)missed_lower;
+
+    int aggregate_provisional =
+        eligible >= LEO_WONDER_APPETITE_TRANSPORT_MIN_ARM_N &&
+        abstained >= LEO_WONDER_APPETITE_TRANSPORT_MIN_ARM_N &&
+        overreach_upper <
+            LEO_WONDER_APPETITE_READINESS_RISK_CEILING &&
+        missed_upper <
+            LEO_WONDER_APPETITE_READINESS_RISK_CEILING &&
+        leo_interval_overlaps(
+            coverage_lower, coverage_upper,
+            admission_lower, admission_upper) &&
+        leo_interval_overlaps(
+            coverage_lower, coverage_upper,
+            holdout_lower, holdout_upper);
+    int early_ok =
+        early.motion_bounded &&
+        early.restraint_bounded &&
+        early.history_coverage_compatible;
+    int recent_ok =
+        recent.motion_bounded &&
+        recent.restraint_bounded &&
+        recent.history_coverage_compatible;
+    int epoch_coverage_compatible =
+        leo_interval_overlaps(
+            early.coverage_lower, early.coverage_upper,
+            recent.coverage_lower, recent.coverage_upper);
+    if (!aggregate_provisional)
+        return LEO_WONDER_APPETITE_CHRONOLOGY_AGGREGATE_SHIFTED;
+    if (!early_ok && !recent_ok)
+        return LEO_WONDER_APPETITE_CHRONOLOGY_BOTH_SHIFTED;
+    if (!early_ok)
+        return LEO_WONDER_APPETITE_CHRONOLOGY_EARLY_SHIFTED;
+    if (!recent_ok)
+        return LEO_WONDER_APPETITE_CHRONOLOGY_RECENT_SHIFTED;
+    if (!epoch_coverage_compatible)
+        return LEO_WONDER_APPETITE_CHRONOLOGY_ECOLOGY_SHIFTED;
+    return LEO_WONDER_APPETITE_CHRONOLOGY_PROVISIONAL;
+}
+
+static const LeoWonderAppetiteCheckpoint *
+leo_wonder_appetite_checkpoint_at(
+        const LeoWonderAppetiteCheckpointLane *lane, int chronological) {
+    if (!lane || chronological < 0 || chronological >= lane->n)
+        return NULL;
+    int start =
+        (lane->ptr - lane->n +
+         LEO_WONDER_APPETITE_CHECKPOINT_HISTORY) %
+        LEO_WONDER_APPETITE_CHECKPOINT_HISTORY;
+    int index =
+        (start + chronological) %
+        LEO_WONDER_APPETITE_CHECKPOINT_HISTORY;
+    return &lane->history[index];
+}
+
+static int leo_wonder_appetite_checkpoint_is_shift(int status) {
+    return status ==
+               LEO_WONDER_APPETITE_CHRONOLOGY_AGGREGATE_SHIFTED ||
+           status ==
+               LEO_WONDER_APPETITE_CHRONOLOGY_EARLY_SHIFTED ||
+           status ==
+               LEO_WONDER_APPETITE_CHRONOLOGY_RECENT_SHIFTED ||
+           status ==
+               LEO_WONDER_APPETITE_CHRONOLOGY_BOTH_SHIFTED ||
+           status ==
+               LEO_WONDER_APPETITE_CHRONOLOGY_ECOLOGY_SHIFTED;
+}
+
+static void leo_wonder_appetite_checkpoint_push(
+        LeoWonderAppetiteCheckpointLane *lane) {
+    if (!lane ||
+        lane->active.status ==
+            LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY ||
+        lane->active.status ==
+            LEO_WONDER_APPETITE_CHRONOLOGY_PENDING)
+        return;
+    lane->history[lane->ptr] = lane->active;
+    lane->ptr =
+        (uint8_t)((lane->ptr + 1) %
+            LEO_WONDER_APPETITE_CHECKPOINT_HISTORY);
+    if (lane->n < LEO_WONDER_APPETITE_CHECKPOINT_HISTORY)
+        lane->n++;
+    lane->next_after_proposed_turn =
+        lane->active.through_proposed_turn;
+    lane->blocked =
+        lane->active.status ==
+            LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE;
+    memset(&lane->active, 0, sizeof lane->active);
+}
+
+static void leo_wonder_appetite_checkpoint_open(
+        LeoWonderAppetiteCheckpointLane *lane,
+        const LeoWonderAppetiteHoldoutTrial *trial,
+        uint64_t opened_turn) {
+    if (!lane || !trial || lane->blocked)
+        return;
+    if (lane->next_after_proposed_turn == 0)
+        lane->next_after_proposed_turn =
+            leo_wonder_appetite_holdout_terminal_boundary(trial);
+    LeoWonderAppetiteCheckpoint *checkpoint = &lane->active;
+    if (checkpoint->status !=
+        LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY)
+        return;
+    memset(checkpoint, 0, sizeof *checkpoint);
+    checkpoint->opened_turn = opened_turn;
+    checkpoint->after_proposed_turn =
+        lane->next_after_proposed_turn;
+    checkpoint->through_proposed_turn =
+        checkpoint->after_proposed_turn;
+    checkpoint->spoken = trial->spoken;
+    checkpoint->bin = trial->bin;
+    checkpoint->status =
+        LEO_WONDER_APPETITE_CHRONOLOGY_PENDING;
+}
+
+static void leo_wonder_appetite_checkpoint_update(Leo *leo) {
+    if (!leo || !g_leo_wonder_appetite_checkpoint_on ||
+        !g_leo_wonder_appetite_calibration_on)
+        return;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteHoldoutTrial *trial =
+            &leo->wonder_appetite_holdouts.trials[i];
+        const LeoWonderAppetiteAdmissionReceipt *admission =
+            &leo->wonder_appetite_admissions.receipts[i];
+        LeoWonderAppetiteCheckpointLane *lane =
+            &leo->wonder_appetite_checkpoints.lanes[i];
+        if (trial->status !=
+                LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED ||
+            !leo_wonder_appetite_admission_valid(
+                admission, trial) ||
+            admission->status !=
+                LEO_WONDER_APPETITE_ADMISSION_ATTESTED ||
+            lane->blocked)
+            continue;
+        leo_wonder_appetite_checkpoint_open(
+            lane, trial, (uint64_t)leo->school.turn_clock);
+        LeoWonderAppetiteCheckpoint *checkpoint = &lane->active;
+        if (checkpoint->status !=
+            LEO_WONDER_APPETITE_CHRONOLOGY_PENDING)
+            continue;
+
+        for (int j = 0;
+             j < leo->wonder_appetite_calibration.n; j++) {
+            const LeoWonderAppetiteCalibrationReceipt *receipt =
+                leo_wonder_appetite_calibration_at(
+                    &leo->wonder_appetite_calibration, j);
+            if (!receipt ||
+                receipt->proposed_turn <=
+                    checkpoint->through_proposed_turn)
+                continue;
+            int result =
+                leo_wonder_appetite_policy_result(receipt);
+            if (result ==
+                LEO_WONDER_APPETITE_POLICY_RESULT_PENDING)
+                continue;
+            if (checkpoint->attempts >=
+                LEO_WONDER_APPETITE_CHECKPOINT_BUDGET)
+                break;
+
+            int attempt = checkpoint->attempts;
+            int epoch_index =
+                attempt /
+                    LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS;
+            LeoWonderAppetiteCheckpointEpoch *epoch =
+                &checkpoint->epochs[epoch_index];
+            checkpoint->seen_proposed_turn[attempt] =
+                receipt->proposed_turn;
+            checkpoint->through_proposed_turn =
+                receipt->proposed_turn;
+            checkpoint->attempts++;
+            if (epoch->attempts == 0)
+                epoch->first_proposed_turn =
+                    receipt->proposed_turn;
+            epoch->last_proposed_turn = receipt->proposed_turn;
+            epoch->attempts++;
+
+            if (result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_NONE ||
+                result ==
+                    LEO_WONDER_APPETITE_POLICY_RESULT_LEGACY) {
+                epoch->incompatible++;
+                checkpoint->status =
+                    LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE;
+                leo_wonder_appetite_checkpoint_push(lane);
+                break;
+            }
+            int bin = leo_wonder_appetite_reliability_bin(
+                receipt->appetite);
+            int exact =
+                bin == trial->bin &&
+                (receipt->spoken ? 1 : 0) == trial->spoken;
+            if (!exact) {
+                epoch->other++;
+            } else if (result ==
+                LEO_WONDER_APPETITE_POLICY_RESULT_CONFOUNDED) {
+                epoch->confounded++;
+            } else {
+                epoch->exact++;
+                if (receipt->policy ==
+                    LEO_WONDER_APPETITE_POLICY_ELIGIBLE) {
+                    epoch->eligible++;
+                    if (result ==
+                        LEO_WONDER_APPETITE_POLICY_RESULT_SUPPORTED)
+                        epoch->supported++;
+                    else
+                        epoch->overreach++;
+                } else {
+                    epoch->abstained++;
+                    if (result ==
+                        LEO_WONDER_APPETITE_POLICY_RESULT_MISSED)
+                        epoch->missed++;
+                    else
+                        epoch->restraint++;
+                }
+            }
+            if (checkpoint->attempts ==
+                LEO_WONDER_APPETITE_CHECKPOINT_BUDGET) {
+                checkpoint->status =
+                    (uint8_t)
+                    leo_wonder_appetite_checkpoint_grade(
+                        checkpoint, admission, trial);
+                leo_wonder_appetite_checkpoint_push(lane);
+                break;
+            }
+        }
+    }
+}
+
+static void leo_wonder_appetite_checkpoint_anchor_existing(
+        Leo *leo) {
+    if (!leo) return;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteHoldoutTrial *trial =
+            &leo->wonder_appetite_holdouts.trials[i];
+        const LeoWonderAppetiteAdmissionReceipt *admission =
+            &leo->wonder_appetite_admissions.receipts[i];
+        LeoWonderAppetiteCheckpointLane *lane =
+            &leo->wonder_appetite_checkpoints.lanes[i];
+        if (trial->status !=
+                LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED ||
+            !leo_wonder_appetite_admission_valid(
+                admission, trial) ||
+            admission->status !=
+                LEO_WONDER_APPETITE_ADMISSION_ATTESTED ||
+            lane->next_after_proposed_turn != 0 ||
+            lane->active.status !=
+                LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY ||
+            lane->n != 0)
+            continue;
+        uint64_t boundary =
+            leo_wonder_appetite_holdout_terminal_boundary(trial);
+        for (int j = 0;
+             j < leo->wonder_appetite_calibration.n; j++) {
+            const LeoWonderAppetiteCalibrationReceipt *receipt =
+                leo_wonder_appetite_calibration_at(
+                    &leo->wonder_appetite_calibration, j);
+            if (receipt &&
+                receipt->proposed_turn > boundary)
+                boundary = receipt->proposed_turn;
+        }
+        lane->next_after_proposed_turn = boundary;
+    }
+}
+
+static void leo_wonder_appetite_checkpoint_sequence(
+        const Leo *leo,
+        LeoWonderAppetiteCheckpointSequence *sequence) {
+    if (!sequence) return;
+    memset(sequence, 0, sizeof *sequence);
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        LeoWonderAppetiteCheckpointSequenceCell *cell =
+            &sequence->cells[i];
+        cell->spoken =
+            (uint8_t)(i /
+                LEO_WONDER_APPETITE_RELIABILITY_BINS);
+        cell->bin =
+            (uint8_t)(i %
+                LEO_WONDER_APPETITE_RELIABILITY_BINS);
+        if (!leo) continue;
+        const LeoWonderAppetiteCheckpointLane *lane =
+            &leo->wonder_appetite_checkpoints.lanes[i];
+        cell->n = lane->n;
+        if (lane->n == 0)
+            continue;
+        const LeoWonderAppetiteCheckpoint *recent =
+            leo_wonder_appetite_checkpoint_at(
+                lane, lane->n - 1);
+        cell->recent_status = recent ? recent->status :
+            LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY;
+        if (lane->n == 1) {
+            if (cell->recent_status ==
+                LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE) {
+                cell->status =
+                    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INCOMPATIBLE;
+                sequence->incompatible++;
+            } else if (cell->recent_status ==
+                LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED) {
+                cell->status =
+                    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INSUFFICIENT;
+                sequence->insufficient++;
+            } else {
+                cell->status =
+                    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_ONE;
+                sequence->one++;
+            }
+            continue;
+        }
+        const LeoWonderAppetiteCheckpoint *previous =
+            leo_wonder_appetite_checkpoint_at(
+                lane, lane->n - 2);
+        cell->previous_status = previous ? previous->status :
+            LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY;
+        cell->same_signature =
+            cell->previous_status == cell->recent_status;
+        if (cell->previous_status ==
+                LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE ||
+            cell->recent_status ==
+                LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INCOMPATIBLE;
+            sequence->incompatible++;
+        } else if (
+            cell->previous_status ==
+                    LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED ||
+            cell->recent_status ==
+                    LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED) {
+            cell->status =
+                LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INSUFFICIENT;
+            sequence->insufficient++;
+        } else {
+            int previous_shift =
+                leo_wonder_appetite_checkpoint_is_shift(
+                    cell->previous_status);
+            int recent_shift =
+                leo_wonder_appetite_checkpoint_is_shift(
+                    cell->recent_status);
+            if (!previous_shift && !recent_shift) {
+                cell->status =
+                    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_STABLE_PROVISIONAL;
+                sequence->stable_provisional++;
+            } else if (!previous_shift && recent_shift) {
+                cell->status =
+                    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_EMERGING_SHIFT;
+                sequence->emerging_shift++;
+            } else if (previous_shift && recent_shift) {
+                cell->status =
+                    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_PERSISTENT_SHIFT;
+                sequence->persistent_shift++;
+            } else {
+                cell->status =
+                    LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_RECOVERED;
+                sequence->recovered++;
+            }
+        }
+    }
+}
+
+static int leo_wonder_appetite_checkpoint_epoch_valid(
+        const LeoWonderAppetiteCheckpointEpoch *epoch,
+        const LeoWonderAppetiteCheckpoint *checkpoint,
+        int epoch_index) {
+    if (!epoch || !checkpoint ||
+        epoch_index < 0 ||
+        epoch_index >= LEO_WONDER_APPETITE_TRANSPORT_EPOCHS)
+        return 0;
+    int offset =
+        epoch_index *
+        LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS;
+    int expected = checkpoint->attempts - offset;
+    if (expected < 0) expected = 0;
+    if (expected >
+        LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS)
+        expected =
+            LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS;
+    if (epoch->attempts != expected ||
+        epoch->exact != epoch->eligible + epoch->abstained ||
+        epoch->eligible != epoch->supported + epoch->overreach ||
+        epoch->abstained != epoch->missed + epoch->restraint ||
+        epoch->attempts !=
+            epoch->exact + epoch->confounded +
+            epoch->other + epoch->incompatible)
+        return 0;
+    if (expected == 0)
+        return epoch->first_proposed_turn == 0 &&
+               epoch->last_proposed_turn == 0;
+    return epoch->first_proposed_turn ==
+               checkpoint->seen_proposed_turn[offset] &&
+           epoch->last_proposed_turn ==
+               checkpoint->seen_proposed_turn[
+                   offset + expected - 1];
+}
+
+static int leo_wonder_appetite_checkpoint_record_valid(
+        const LeoWonderAppetiteCheckpoint *checkpoint,
+        const LeoWonderAppetiteAdmissionReceipt *admission,
+        const LeoWonderAppetiteHoldoutTrial *trial,
+        uint64_t current_turn, int active) {
+    if (!checkpoint || !admission || !trial)
+        return 0;
+    LeoWonderAppetiteCheckpoint zero = {0};
+    if (checkpoint->status ==
+        LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY)
+        return !memcmp(checkpoint, &zero, sizeof zero);
+    if (checkpoint->spoken != trial->spoken ||
+        checkpoint->bin != trial->bin ||
+        checkpoint->opened_turn == 0 ||
+        checkpoint->opened_turn > current_turn ||
+        checkpoint->after_proposed_turn <
+            leo_wonder_appetite_holdout_terminal_boundary(trial) ||
+        checkpoint->through_proposed_turn <
+            checkpoint->after_proposed_turn ||
+        checkpoint->through_proposed_turn > current_turn ||
+        checkpoint->attempts >
+            LEO_WONDER_APPETITE_CHECKPOINT_BUDGET)
+        return 0;
+    uint64_t previous = checkpoint->after_proposed_turn;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_CHECKPOINT_BUDGET; i++) {
+        uint64_t proposed =
+            checkpoint->seen_proposed_turn[i];
+        if (i < checkpoint->attempts) {
+            if (proposed <= previous)
+                return 0;
+            previous = proposed;
+        } else if (proposed != 0) {
+            return 0;
+        }
+    }
+    if (checkpoint->through_proposed_turn != previous)
+        return 0;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_TRANSPORT_EPOCHS; i++)
+        if (!leo_wonder_appetite_checkpoint_epoch_valid(
+                &checkpoint->epochs[i], checkpoint, i))
+            return 0;
+
+    int incompatible =
+        checkpoint->epochs[0].incompatible +
+        checkpoint->epochs[1].incompatible;
+    if (active)
+        return checkpoint->status ==
+                   LEO_WONDER_APPETITE_CHRONOLOGY_PENDING &&
+               checkpoint->attempts <
+                   LEO_WONDER_APPETITE_CHECKPOINT_BUDGET &&
+               incompatible == 0;
+    if (checkpoint->status ==
+        LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE)
+        return checkpoint->attempts > 0 && incompatible > 0;
+    return checkpoint->attempts ==
+               LEO_WONDER_APPETITE_CHECKPOINT_BUDGET &&
+           incompatible == 0 &&
+           checkpoint->status ==
+               leo_wonder_appetite_checkpoint_grade(
+                   checkpoint, admission, trial);
+}
+
+static int leo_wonder_appetite_checkpoint_lane_valid(
+        const LeoWonderAppetiteCheckpointLane *lane,
+        const LeoWonderAppetiteAdmissionReceipt *admission,
+        const LeoWonderAppetiteHoldoutTrial *trial,
+        uint64_t current_turn) {
+    if (!lane || !admission || !trial)
+        return 0;
+    LeoWonderAppetiteCheckpointLane zero = {0};
+    if (trial->status !=
+            LEO_WONDER_APPETITE_HOLDOUT_CONFIRMED ||
+        !leo_wonder_appetite_admission_valid(
+            admission, trial) ||
+        admission->status !=
+            LEO_WONDER_APPETITE_ADMISSION_ATTESTED)
+        return !memcmp(lane, &zero, sizeof zero);
+    if (lane->n > LEO_WONDER_APPETITE_CHECKPOINT_HISTORY ||
+        lane->ptr >= LEO_WONDER_APPETITE_CHECKPOINT_HISTORY ||
+        (lane->n == 0 && lane->ptr != 0) ||
+        (lane->n == 1 && lane->ptr != 1) ||
+        lane->next_after_proposed_turn > current_turn ||
+        (lane->next_after_proposed_turn != 0 &&
+         lane->next_after_proposed_turn <
+             leo_wonder_appetite_holdout_terminal_boundary(trial)))
+        return 0;
+
+    int active =
+        lane->active.status !=
+            LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY;
+    if (!leo_wonder_appetite_checkpoint_record_valid(
+            &lane->active, admission, trial,
+            current_turn, active))
+        return 0;
+    LeoWonderAppetiteCheckpoint empty = {0};
+    for (int slot = 0;
+         slot < LEO_WONDER_APPETITE_CHECKPOINT_HISTORY; slot++) {
+        int used = 0;
+        for (int j = 0; j < lane->n; j++)
+            if (leo_wonder_appetite_checkpoint_at(lane, j) ==
+                &lane->history[slot])
+                used = 1;
+        if (!used &&
+            memcmp(&lane->history[slot], &empty, sizeof empty))
+            return 0;
+    }
+
+    const LeoWonderAppetiteCheckpoint *previous = NULL;
+    for (int j = 0; j < lane->n; j++) {
+        const LeoWonderAppetiteCheckpoint *checkpoint =
+            leo_wonder_appetite_checkpoint_at(lane, j);
+        if (!leo_wonder_appetite_checkpoint_record_valid(
+                checkpoint, admission, trial,
+                current_turn, 0) ||
+            (previous &&
+             checkpoint->after_proposed_turn !=
+                 previous->through_proposed_turn))
+            return 0;
+        previous = checkpoint;
+    }
+    if (active &&
+        (lane->active.after_proposed_turn !=
+             lane->next_after_proposed_turn ||
+         (previous &&
+          lane->active.after_proposed_turn !=
+              previous->through_proposed_turn)))
+        return 0;
+    if (!active && previous &&
+        lane->next_after_proposed_turn !=
+            previous->through_proposed_turn)
+        return 0;
+    int should_block =
+        previous &&
+        previous->status ==
+            LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE;
+    return lane->blocked == should_block &&
+           (!lane->blocked || !active);
+}
+
+static int leo_wonder_appetite_checkpoints_valid(
+        const Leo *leo) {
+    if (!leo) return 0;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++)
+        if (!leo_wonder_appetite_checkpoint_lane_valid(
+                &leo->wonder_appetite_checkpoints.lanes[i],
+                &leo->wonder_appetite_admissions.receipts[i],
+                &leo->wonder_appetite_holdouts.trials[i],
+                (uint64_t)leo->school.turn_clock))
+            return 0;
+    return 1;
 }
 
 static void leo_wonder_appetite_holdout_update(Leo *leo) {
@@ -9558,6 +10282,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
         leo, prompt, prewonder_field_token, prewonder_field_weight);
     leo_wonder_appetite_calibrate(leo, prompt);
     leo_wonder_appetite_holdout_update(leo);
+    leo_wonder_appetite_checkpoint_update(leo);
     leo_shadow_calibrate(leo, prompt);            /* judge t-1 only after t has become history */
     leo_shadow_observe(leo);                      /* after speech: a proposal for the next turn, never a reader */
     leo->gravity = NULL;
@@ -9610,9 +10335,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v22      : forecast-birth shadow abstention snapshots
  *   v23      : fixed-budget out-of-sample trials over readiness candidates
  *   v24      : immutable A.50 admission receipts for those trials
+ *   v25      : non-overlapping raw transport checkpoints and their sequence
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 24  /* A.52 preserves why a trial was admitted; v5..v23 soft-migrate */
+#define LEO_STATE_VERSION 25  /* A.55 carries transport lives; v5..v24 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -9848,6 +10574,11 @@ static int leo_save_state(const Leo *leo, const char *path) {
      * It may be lost fail-soft without rewriting either history or verdict. */
     fwrite(&leo->wonder_appetite_admissions,
            sizeof leo->wonder_appetite_admissions, 1, f);
+
+    /* A.55 (v25): each checkpoint owns its proposal identities and raw counts.
+     * Derived verdicts are checked again on load; no speech path reads this. */
+    fwrite(&leo->wonder_appetite_checkpoints,
+           sizeof leo->wonder_appetite_checkpoints, 1, f);
 
     int ok = (ferror(f) == 0);
     if (fclose(f) != 0) ok = 0;                 /* L-2: the final flush can fail (ENOSPC) — never report success on a truncated file */
@@ -10629,6 +11360,22 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
                    sizeof leo->wonder_appetite_admissions);
         }
     }
+
+    /* A.55 transport lives (v25). Older bodies begin after every receipt they
+     * already carry: migration may observe the future, never retrofit a past
+     * checkpoint. A malformed v25 tail loses only this readerless ledger. */
+    if (version >= 25) {
+        int checkpoint_ok =
+            fread(&leo->wonder_appetite_checkpoints,
+                  sizeof leo->wonder_appetite_checkpoints, 1, f) == 1 &&
+            leo_wonder_appetite_checkpoints_valid(leo);
+        if (!checkpoint_ok) {
+            fprintf(stderr, "[leo] WARNING: v25 transport-checkpoint tail truncated/corrupt — organism lives without checkpoints.\n");
+            memset(&leo->wonder_appetite_checkpoints, 0,
+                   sizeof leo->wonder_appetite_checkpoints);
+        }
+    }
+    leo_wonder_appetite_checkpoint_anchor_existing(leo);
 
     fclose(f);
     /* rebuild the derived tables (same as the main startup path) */
@@ -11573,6 +12320,149 @@ static void print_wonder_appetite_transport_chronology_stats(
     printf("]\n");
 }
 
+static void print_wonder_appetite_checkpoint_record(
+        const LeoWonderAppetiteCheckpoint *checkpoint) {
+    if (!checkpoint ||
+        checkpoint->status ==
+            LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY) {
+        printf("/0/0/empty/0/0/0/0/0/0/0/0/0/0");
+        return;
+    }
+    printf("/%llu/%llu/%s",
+           (unsigned long long)checkpoint->after_proposed_turn,
+           (unsigned long long)checkpoint->through_proposed_turn,
+           leo_wonder_appetite_transport_chronology_status_name(
+               checkpoint->status));
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_TRANSPORT_EPOCHS; i++) {
+        const LeoWonderAppetiteCheckpointEpoch *epoch =
+            &checkpoint->epochs[i];
+        printf("/%u/%u/%u/%u/%u",
+               (unsigned)epoch->attempts,
+               (unsigned)epoch->eligible,
+               (unsigned)epoch->abstained,
+               (unsigned)epoch->overreach,
+               (unsigned)epoch->missed);
+    }
+}
+
+static void print_wonder_appetite_checkpoint_stats(const Leo *leo) {
+    if (!g_leo_wonder_appetite_checkpoint_on || !leo)
+        return;
+    int occupied = 0, active = 0, terminal = 0, blocked = 0;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteCheckpointLane *lane =
+            &leo->wonder_appetite_checkpoints.lanes[i];
+        if (lane->next_after_proposed_turn != 0 ||
+            lane->active.status !=
+                LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY ||
+            lane->n != 0)
+            occupied++;
+        if (lane->active.status !=
+            LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY)
+            active++;
+        terminal += lane->n;
+        blocked += lane->blocked ? 1 : 0;
+    }
+    if (occupied == 0) return;
+
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+    printf("     [wonder-appetite-checkpoint: budget=%d epochs=%d history=%d active=%d terminal=%d blocked=%d cells=",
+           LEO_WONDER_APPETITE_CHECKPOINT_BUDGET,
+           LEO_WONDER_APPETITE_TRANSPORT_EPOCHS,
+           LEO_WONDER_APPETITE_CHECKPOINT_HISTORY,
+           active, terminal, blocked);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteCheckpointLane *lane =
+            &leo->wonder_appetite_checkpoints.lanes[i];
+        if (lane->next_after_proposed_turn == 0 &&
+            lane->active.status ==
+                LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY &&
+            lane->n == 0)
+            continue;
+        int bin =
+            i % LEO_WONDER_APPETITE_RELIABILITY_BINS;
+        printf("%s%c%d-%d:%llu/%u/%llu/%llu/%u/%s/%u",
+               separator,
+               i / LEO_WONDER_APPETITE_RELIABILITY_BINS ?
+                   's' : 'u',
+               lower[bin], upper[bin],
+               (unsigned long long)
+                   lane->next_after_proposed_turn,
+               (unsigned)lane->blocked,
+               (unsigned long long)
+                   lane->active.after_proposed_turn,
+               (unsigned long long)
+                   lane->active.through_proposed_turn,
+               (unsigned)lane->active.attempts,
+               leo_wonder_appetite_transport_chronology_status_name(
+                   lane->active.status),
+               (unsigned)lane->n);
+        for (int j = 0;
+             j < LEO_WONDER_APPETITE_CHECKPOINT_HISTORY; j++)
+            print_wonder_appetite_checkpoint_record(
+                leo_wonder_appetite_checkpoint_at(lane, j));
+        separator = "|";
+    }
+    printf("]\n");
+}
+
+static void print_wonder_appetite_checkpoint_sequence_stats(
+        const Leo *leo) {
+    if (!g_leo_wonder_appetite_checkpoint_on || !leo)
+        return;
+    LeoWonderAppetiteCheckpointSequence sequence;
+    leo_wonder_appetite_checkpoint_sequence(leo, &sequence);
+    int occupied = 0;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteCheckpointLane *lane =
+            &leo->wonder_appetite_checkpoints.lanes[i];
+        if (lane->next_after_proposed_turn != 0 ||
+            lane->active.status !=
+                LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY ||
+            lane->n != 0) {
+            occupied = 1;
+            break;
+        }
+    }
+    if (!occupied) return;
+
+    static const int lower[] = {62, 70, 80, 90};
+    static const int upper[] = {70, 80, 90, 100};
+    printf("     [wonder-appetite-checkpoint-sequence: one=%d stable-provisional=%d emerging-shift=%d persistent-shift=%d recovered=%d insufficient=%d incompatible=%d cells=",
+           sequence.one, sequence.stable_provisional,
+           sequence.emerging_shift, sequence.persistent_shift,
+           sequence.recovered, sequence.insufficient,
+           sequence.incompatible);
+    const char *separator = "";
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_RELIABILITY_CELLS; i++) {
+        const LeoWonderAppetiteCheckpointSequenceCell *cell =
+            &sequence.cells[i];
+        if (cell->status ==
+            LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_EMPTY)
+            continue;
+        printf("%s%c%d-%d:%u/%s/%s/%u/%s",
+               separator, cell->spoken ? 's' : 'u',
+               lower[cell->bin], upper[cell->bin],
+               (unsigned)cell->n,
+               leo_wonder_appetite_transport_chronology_status_name(
+                   cell->previous_status),
+               leo_wonder_appetite_transport_chronology_status_name(
+                   cell->recent_status),
+               (unsigned)cell->same_signature,
+               leo_wonder_appetite_checkpoint_sequence_status_name(
+                   cell->status));
+        separator = "|";
+    }
+    printf("]\n");
+}
+
 static void print_wonder_address_stats(const Leo *leo) {
     if (!g_leo_wonder_attribution_on || !leo ||
         leo->wonder_address.status == LEO_WONDER_ADDRESS_EMPTY)
@@ -11817,6 +12707,7 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--no-wonder-appetite-admission")) g_leo_wonder_appetite_admission_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-transport")) g_leo_wonder_appetite_transport_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-appetite-transport-chronology")) g_leo_wonder_appetite_transport_chronology_on = 0;
+        else if (!strcmp(argv[i], "--no-wonder-appetite-checkpoint")) g_leo_wonder_appetite_checkpoint_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-attribution")) g_leo_wonder_attribution_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-redirection")) g_leo_wonder_redirection_on = 0;
         else if (!strcmp(argv[i], "--no-wonder-return")) g_leo_wonder_return_on = 0;
@@ -12042,6 +12933,8 @@ int main(int argc, char **argv) {
             print_wonder_appetite_admission_stats(&leo);
             print_wonder_appetite_transport_stats(&leo);
             print_wonder_appetite_transport_chronology_stats(&leo);
+            print_wonder_appetite_checkpoint_stats(&leo);
+            print_wonder_appetite_checkpoint_sequence_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
         }
@@ -12110,6 +13003,8 @@ int main(int argc, char **argv) {
             print_wonder_appetite_admission_stats(&leo);
             print_wonder_appetite_transport_stats(&leo);
             print_wonder_appetite_transport_chronology_stats(&leo);
+            print_wonder_appetite_checkpoint_stats(&leo);
+            print_wonder_appetite_checkpoint_sequence_stats(&leo);
             print_deferred_wonder_stats(&leo);
             print_flow_stats(&leo);
             if (async_on) {   /* all field access above was under the write lock; release, report, dispatch a ring on this reply */

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -679,3 +679,58 @@ states in every row.
 
 A.54 adds no state and no speech, scheduler, routing, sampling, or generation
 reader. It is a readerless chronology of evidence, not permission to intervene.
+
+Run the persisted transport-life sequence:
+
+```sh
+make deferred-wonder-appetite-checkpoint
+```
+
+A.55 stops asking the rotating A.48 diary to impersonate long time. Once an
+A.51 trial is confirmed and its A.52 admission receipt is attested, a
+checkpoint opens after that trial's terminal proposal. It owns exactly the
+next 32 settled policy attempts as two adjacent 16-attempt epochs unless a
+changed policy language invalidates comparison earlier. Every attempt stores
+its proposal identity and raw outcome category. Another stratum or a confound
+spends time without filling either arm; pending forecasts spend no slot.
+`none` or `legacy` closes the lane early as `incompatible`.
+
+When a checkpoint terminates, its `through_proposed_turn` becomes the next
+checkpoint's exclusive boundary. The next life therefore cannot reuse an
+outcome from the previous one. The v25 state keeps at most the two most recent
+terminal lives per trial plus one active life. Rates, intervals, and the
+terminal status are not trusted as opaque claims: load validation recomputes
+the verdict from raw counts and rejects duplicate proposal identities,
+non-monotonic proposals, overlap, and mismatched stored status.
+
+The last two terminal lives produce a readerless sequence:
+
+```text
+one                 one complete life, no regime claim
+stable-provisional  both lives are provisional
+emerging-shift      provisional -> shifted
+persistent-shift    shifted -> shifted, even on different risk axes
+recovered           shifted -> provisional
+insufficient        either life is coverage-starved
+incompatible        policy language changed; no translation is attempted
+```
+
+An unfinished 31-attempt life remains `pending` across save/load and produces
+no sequence claim. A v24 body starts its first checkpoint after every
+calibration receipt it already carries; migration cannot retrospectively turn
+old diary entries into a new experiment. A truncated or corrupt v25 tail
+fails soft by discarding only checkpoints and anchoring future observation
+after the surviving diary. The body, trial, and admission proof remain intact.
+
+The eight-case process matrix covers one life, stable provisionality, emerging
+and persistent shifts, recovery, insufficient coverage, policy
+incompatibility, and a 31/32 active life. Default and
+`--no-wonder-appetite-checkpoint` forks keep strict checkpoint boundaries,
+identical replies, and byte-identical complete states in all eight rows. A
+separate writer isolation pair holds all pre-v25 bytes equal while the
+checkpoint tail differs, then confirms that those two distinct readerless
+states still produce the same reply.
+
+A.55 persists evidence, not authority. School, Flow, shadow, routing,
+sampling, scheduling, and generation do not read the checkpoint or its
+sequence.

--- a/scripts/deferred_wonder_appetite_checkpoint_matrix.sh
+++ b/scripts/deferred_wonder_appetite_checkpoint_matrix.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# A.55: persist non-overlapping transport lives and classify their sequence.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-checkpoint-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT"
+
+PLAN="$OUT/plan.tsv"
+printf 'case\texpected_n\texpected_recent\texpected_sequence\n' > "$PLAN"
+printf 'checkpoint-one\t1\tprovisional\tone\n' >> "$PLAN"
+printf 'checkpoint-stable\t2\tprovisional\tstable-provisional\n' >> "$PLAN"
+printf 'checkpoint-emerging\t2\tearly-shifted\temerging-shift\n' >> "$PLAN"
+printf 'checkpoint-persistent\t2\trecent-shifted\tpersistent-shift\n' >> "$PLAN"
+printf 'checkpoint-recovered\t2\tprovisional\trecovered\n' >> "$PLAN"
+printf 'checkpoint-insufficient\t2\tcoverage-starved\tinsufficient\n' >> "$PLAN"
+printf 'checkpoint-incompatible\t1\tincompatible\tincompatible\n' >> "$PLAN"
+printf 'checkpoint-pending\t0\tpending\tempty\n' >> "$PLAN"
+
+if [ "${LEO_APPETITE_CHECKPOINT_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+"${CC:-cc}" -O2 -Wall -Wextra -Wno-unused-function \
+    "$ROOT/tests/wonder_appetite_holdout_fixture.c" -lm \
+    -o "$OUT/holdout-fixture"
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+report_from_log() {
+    awk -v scenario="$2" -v seed="$3" \
+        -f "$ROOT/scripts/wonder_appetite_checkpoint_dialogue_report.awk" \
+        "$1"
+}
+
+cell_values() {
+    local cells="$1"
+    local wanted="$2"
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 33; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+sequence_status() {
+    local cells="$1"
+    local wanted="$2"
+    if [ -z "$cells" ]; then
+        printf 'empty\n'
+        return
+    fi
+    printf '%s\n' "$cells" |
+        awk -v wanted="$wanted" '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != wanted) continue
+                    split(pair[2], values, /\//)
+                    print values[5]
+                    exit
+                }
+            }
+        '
+}
+
+# Writer isolation: identical evidence with the organ on/off may differ only
+# in the fixed v25 tail, and the distinct states must still speak identically.
+"$OUT/holdout-fixture" "$OUT/writer-on.state" checkpoint-one
+"$OUT/holdout-fixture" "$OUT/writer-off.state" checkpoint-ablated
+checkpoint_tail="$("$OUT/holdout-fixture" --checkpoint-tail-size)"
+writer_size="$(wc -c < "$OUT/writer-on.state" | tr -d ' ')"
+writer_prefix=$((writer_size - checkpoint_tail))
+[ "$writer_prefix" -gt 0 ] &&
+    cmp -s -n "$writer_prefix" \
+        "$OUT/writer-on.state" "$OUT/writer-off.state" &&
+    ! cmp -s "$OUT/writer-on.state" "$OUT/writer-off.state" || {
+        printf 'checkpoint writer escaped its v25 tail\n' >&2
+        exit 1
+    }
+for side in on off; do
+    cp "$OUT/writer-$side.state" "$OUT/writer-$side-run.state"
+    "$ROOT/leo" --load "$OUT/writer-$side-run.state" \
+        --seed 5599 --respond "The rain falls softly." \
+        --no-wonder-appetite-calibration \
+        --save "$OUT/writer-$side-run.state" \
+        > "$OUT/writer-$side.log" 2>&1
+done
+writer_reply_equal=0
+[ "$(reply_from_log "$OUT/writer-on.log")" = \
+  "$(reply_from_log "$OUT/writer-off.log")" ] &&
+    writer_reply_equal=1
+[ "$writer_reply_equal" = 1 ] || {
+    printf 'checkpoint-only state changed Leo voice\n' >&2
+    exit 1
+}
+
+MATRIX="$OUT/matrix.tsv"
+printf 'case\tn\tactive_attempts\trecent\tsequence\tchronological\treply_equal\tstate_equal\n' > "$MATRIX"
+
+tail -n +2 "$PLAN" |
+while IFS=$'\t' read -r case_name expected_n \
+        expected_recent expected_sequence; do
+    case_dir="$OUT/$case_name"
+    mkdir -p "$case_dir"
+    "$OUT/holdout-fixture" "$case_dir/base.state" "$case_name"
+    cp "$case_dir/base.state" "$case_dir/on.state"
+    cp "$case_dir/base.state" "$case_dir/off.state"
+    seed=5501
+    prompt="The rain falls softly."
+
+    "$ROOT/leo" --load "$case_dir/on.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --save "$case_dir/on.state" > "$case_dir/on.log" 2>&1
+    "$ROOT/leo" --load "$case_dir/off.state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-calibration \
+        --no-wonder-appetite-checkpoint \
+        --save "$case_dir/off.state" > "$case_dir/off.log" 2>&1
+
+    report="$(report_from_log "$case_dir/on.log" "$case_name" "$seed")"
+    [ -n "$report" ] || {
+        printf '%s emitted no A.55 checkpoint witness\n' \
+            "$case_name" >&2
+        exit 1
+    }
+    [ -z "$(report_from_log \
+        "$case_dir/off.log" "$case_name" "$seed")" ] || {
+        printf '%s checkpoint ablation remained visible\n' \
+            "$case_name" >&2
+        exit 1
+    }
+
+    IFS=$'\t' read -r _ _ budget epochs history active terminal \
+        blocked checkpoint_cells one stable emerging persistent \
+        recovered insufficient incompatible sequence_cells <<< "$report"
+    cell="$(cell_values "$checkpoint_cells" u62-70)"
+    [ -n "$cell" ] || {
+        printf '%s lost its checkpoint cell\n' "$case_name" >&2
+        exit 1
+    }
+    IFS=$'\t' read -r next_after blocked_cell active_after \
+        active_through active_attempts active_status n \
+        first_after first_through first_status \
+        _ _ _ _ _ _ _ _ _ _ \
+        second_after second_through second_status \
+        _ _ _ _ _ _ _ _ _ _ extra <<< "$cell"
+
+    if [ "$n" = 0 ]; then
+        recent="$active_status"
+    elif [ "$n" = 1 ]; then
+        recent="$first_status"
+    else
+        recent="$second_status"
+    fi
+    actual_sequence="$(
+        sequence_status "$sequence_cells" u62-70
+    )"
+    chronological=1
+    if [ "$n" = 2 ] &&
+       { [ "$first_through" != "$second_after" ] ||
+         [ "$second_through" -le "$second_after" ]; }; then
+        chronological=0
+    fi
+    reply_equal=0
+    [ "$(reply_from_log "$case_dir/on.log")" = \
+      "$(reply_from_log "$case_dir/off.log")" ] &&
+        reply_equal=1
+    state_equal=0
+    cmp -s "$case_dir/on.state" "$case_dir/off.state" &&
+        state_equal=1
+
+    expected_active=0
+    expected_terminal="$expected_n"
+    expected_blocked=0
+    if [ "$case_name" = checkpoint-pending ]; then
+        expected_active=1
+        expected_terminal=0
+    fi
+    if [ "$case_name" = checkpoint-incompatible ]; then
+        expected_blocked=1
+    fi
+
+    [ -z "${extra:-}" ] &&
+    [ "$budget" = 32 ] && [ "$epochs" = 2 ] &&
+    [ "$history" = 2 ] &&
+    [ "$active" = "$expected_active" ] &&
+    [ "$terminal" = "$expected_terminal" ] &&
+    [ "$blocked" = "$expected_blocked" ] &&
+    [ "$blocked_cell" = "$expected_blocked" ] &&
+    [ "$n" = "$expected_n" ] &&
+    [ "$recent" = "$expected_recent" ] &&
+    [ "$actual_sequence" = "$expected_sequence" ] &&
+    [ "$chronological" = 1 ] &&
+    [ "$reply_equal" = 1 ] && [ "$state_equal" = 1 ] || {
+        printf '%s checkpoint contract failed: n=%s active=%s/%s recent=%s sequence=%s chronological=%s reply=%s state=%s\n' \
+            "$case_name" "$n" "$active" "$active_attempts" \
+            "$recent" "$actual_sequence" "$chronological" \
+            "$reply_equal" "$state_equal" >&2
+        exit 1
+    }
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$case_name" "$n" "$active_attempts" "$recent" \
+        "$actual_sequence" "$chronological" \
+        "$reply_equal" "$state_equal" >> "$MATRIX"
+done
+
+awk -F '\t' -v writer_reply_equal="$writer_reply_equal" '
+    NR > 1 {
+        rows++
+        chronology += $6
+        replies += $7
+        states += $8
+    }
+    END {
+        print "cases\tchronological\treply_equal\tstate_equal\twriter_prefix_equal\twriter_reply_equal"
+        print rows "\t" chronology "\t" replies "\t" states \
+              "\t1\t" writer_reply_equal
+        if (rows != 8 || chronology != 8 ||
+            replies != 8 || states != 8 ||
+            writer_reply_equal != 1)
+            exit 1
+    }
+' "$MATRIX"
+printf '\nmatrix: %s\n' "$MATRIX"

--- a/scripts/test_deferred_wonder_appetite_checkpoint_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_checkpoint_matrix.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+LEO_APPETITE_CHECKPOINT_PLAN_ONLY=1 \
+    "$ROOT/scripts/deferred_wonder_appetite_checkpoint_matrix.sh" \
+    "$OUT/plan" > "$OUT/plan.tsv"
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 4 || $1 != "case" ||
+            $4 != "expected_sequence")
+            exit 1
+        next
+    }
+    {
+        if (NF != 4 || seen[$1]++)
+            exit 1
+        expected["checkpoint-one"] = "1/provisional/one"
+        expected["checkpoint-stable"] = "2/provisional/stable-provisional"
+        expected["checkpoint-emerging"] = "2/early-shifted/emerging-shift"
+        expected["checkpoint-persistent"] = "2/recent-shifted/persistent-shift"
+        expected["checkpoint-recovered"] = "2/provisional/recovered"
+        expected["checkpoint-insufficient"] = "2/coverage-starved/insufficient"
+        expected["checkpoint-incompatible"] = "1/incompatible/incompatible"
+        expected["checkpoint-pending"] = "0/pending/empty"
+        if (($2 "/" $3 "/" $4) != expected[$1])
+            exit 1
+        rows++
+    }
+    END {
+        if (rows != 8)
+            exit 1
+    }
+' "$OUT/plan.tsv" || {
+    printf 'invalid deferred Wonder appetite checkpoint plan\n' >&2
+    exit 1
+}
+
+printf 'deferred Wonder appetite checkpoint matrix plan: ok\n'

--- a/scripts/test_wonder_appetite_checkpoint_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_checkpoint_dialogue_report.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+cat > "$TMP" <<'EOF'
+     [wonder-appetite-checkpoint: budget=32 epochs=2 history=2 active=0 terminal=2 blocked=0 cells=u62-70:390/0/0/0/0/empty/2/134/262/provisional/16/8/8/1/1/16/8/8/1/1/262/390/provisional/16/8/8/1/1/16/8/8/1/1]
+     [wonder-appetite-checkpoint-sequence: one=0 stable-provisional=1 emerging-shift=0 persistent-shift=0 recovered=0 insufficient=0 incompatible=0 cells=u62-70:2/provisional/provisional/1/stable-provisional]
+EOF
+
+got="$(
+    awk -v scenario=checkpoint-stable -v seed=5501 \
+        -f "$ROOT/scripts/wonder_appetite_checkpoint_dialogue_report.awk" \
+        "$TMP"
+)"
+expected=$'checkpoint-stable\t5501\t32\t2\t2\t0\t2\t0\tu62-70:390/0/0/0/0/empty/2/134/262/provisional/16/8/8/1/1/16/8/8/1/1/262/390/provisional/16/8/8/1/1/16/8/8/1/1\t0\t1\t0\t0\t0\t0\t0\tu62-70:2/provisional/provisional/1/stable-provisional'
+
+if [ "$got" != "$expected" ]; then
+    printf 'unexpected Wonder appetite checkpoint parser output:\n%s\n' \
+        "$got" >&2
+    exit 1
+fi
+
+printf 'Wonder appetite checkpoint report parser: ok\n'

--- a/scripts/wonder_appetite_checkpoint_dialogue_report.awk
+++ b/scripts/wonder_appetite_checkpoint_dialogue_report.awk
@@ -1,0 +1,53 @@
+# Extract the A.55 raw checkpoint and two-life sequence from a Leo debug log.
+
+function clean(value) {
+    gsub(/\t/, "\\t", value)
+    gsub(/\r/, "", value)
+    return value
+}
+
+function value_after(line, key,    fields, i, n, prefix, value) {
+    prefix = key "="
+    n = split(line, fields, /[ ]+/)
+    for (i = 1; i <= n; i++) {
+        if (index(fields[i], prefix) != 1)
+            continue
+        value = substr(fields[i], length(prefix) + 1)
+        gsub(/\]$/, "", value)
+        return value
+    }
+    return ""
+}
+
+/\[wonder-appetite-checkpoint: budget=/ {
+    checkpoint = 1
+    budget = value_after($0, "budget")
+    epochs = value_after($0, "epochs")
+    history = value_after($0, "history")
+    active = value_after($0, "active")
+    terminal = value_after($0, "terminal")
+    blocked = value_after($0, "blocked")
+    checkpoint_cells = value_after($0, "cells")
+}
+
+/\[wonder-appetite-checkpoint-sequence: one=/ {
+    sequence = 1
+    one = value_after($0, "one")
+    stable = value_after($0, "stable-provisional")
+    emerging = value_after($0, "emerging-shift")
+    persistent = value_after($0, "persistent-shift")
+    recovered = value_after($0, "recovered")
+    insufficient = value_after($0, "insufficient")
+    incompatible = value_after($0, "incompatible")
+    sequence_cells = value_after($0, "cells")
+}
+
+END {
+    if (!checkpoint || !sequence)
+        exit
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           clean(scenario), clean(seed), budget, epochs, history,
+           active, terminal, blocked, clean(checkpoint_cells),
+           one, stable, emerging, persistent, recovered,
+           insufficient, incompatible, clean(sequence_cells)
+}

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -59,7 +59,8 @@ static long test_appetite_and_later_tail_size(const Leo *leo) {
         leo->wonder_appetite_calibration.n *
             (int)sizeof(LeoWonderAppetiteCalibrationReceipt) +
         sizeof(LeoWonderAppetiteHoldouts) +
-        sizeof(LeoWonderAppetiteAdmissions));
+        sizeof(LeoWonderAppetiteAdmissions) +
+        sizeof(LeoWonderAppetiteCheckpoints));
 }
 
 static void test_add_appetite_calibration(
@@ -734,7 +735,7 @@ static void test_wonder_appetite_regret_surface(void) {
                   sizeof *school_before) &&
           !memcmp(flow_before, &leo->flow,
                   sizeof *flow_before) &&
-          LEO_STATE_VERSION == 24,
+          LEO_STATE_VERSION == 25,
           "wonder-appetite-regret: observing cost rewrites no evidence, body, or state format");
     free(school_before);
     free(flow_before);
@@ -863,7 +864,7 @@ static void test_wonder_appetite_readiness_frontier(void) {
                   sizeof *school_before) &&
           !memcmp(flow_before, &leo->flow,
                   sizeof *flow_before) &&
-          LEO_STATE_VERSION == 24,
+          LEO_STATE_VERSION == 25,
           "wonder-appetite-readiness: candidacy rewrites no evidence, body, or state format");
     free(school_before);
     free(flow_before);
@@ -999,7 +1000,7 @@ static void test_wonder_appetite_holdout_trial(void) {
     CHECK(!memcmp(&terminal, trial, sizeof terminal),
           "wonder-appetite-holdout: a terminal trial cannot restart on its favorable history");
 
-    const char *state = "/tmp/leo_appetite_holdout_v24.state";
+    const char *state = "/tmp/leo_appetite_holdout_v25.state";
     const char *v22 = "/tmp/leo_appetite_holdout_v22.state";
     const char *v23 = "/tmp/leo_appetite_holdout_v23.state";
     const char *cut = "/tmp/leo_appetite_holdout_v23_cut.state";
@@ -1022,7 +1023,7 @@ static void test_wonder_appetite_holdout_trial(void) {
           !memcmp(&woke->wonder_appetite_admissions,
                   &leo->wonder_appetite_admissions,
                   sizeof leo->wonder_appetite_admissions),
-          "wonder-appetite-admission: trial and its admission proof survive v24 sleep exactly");
+          "wonder-appetite-admission: trial and its admission proof survive current sleep exactly");
 
     int built_v22 = 0, built_v23 = 0;
     int built_cut = 0, built_bad = 0;
@@ -1036,14 +1037,18 @@ static void test_wonder_appetite_holdout_trial(void) {
             malloc(size > 0 ? (size_t)size : 1);
         if (bytes &&
             size > (long)(sizeof(LeoWonderAppetiteHoldouts) +
-                          sizeof(LeoWonderAppetiteAdmissions)) &&
+                          sizeof(LeoWonderAppetiteAdmissions) +
+                          sizeof(LeoWonderAppetiteCheckpoints)) &&
             (long)fread(bytes, 1, (size_t)size, fi) == size) {
+            long checkpoint_tail =
+                (long)sizeof(LeoWonderAppetiteCheckpoints);
             long admission_tail =
                 (long)sizeof(LeoWonderAppetiteAdmissions);
             long holdout_tail =
                 (long)sizeof(LeoWonderAppetiteHoldouts);
             long holdout_start =
-                size - admission_tail - holdout_tail;
+                size - checkpoint_tail -
+                    admission_tail - holdout_tail;
             uint32_t twenty_two = 22;
             memcpy(bytes + sizeof(uint32_t), &twenty_two,
                    sizeof twenty_two);
@@ -1063,17 +1068,19 @@ static void test_wonder_appetite_holdout_trial(void) {
                 built_v23 =
                     (long)fwrite(
                         bytes, 1,
-                        (size_t)(size - admission_tail), fo) ==
-                    size - admission_tail;
+                        (size_t)(size - checkpoint_tail -
+                                 admission_tail), fo) ==
+                    size - checkpoint_tail - admission_tail;
                 fclose(fo);
             }
             fo = fopen(cut, "wb");
             if (fo) {
                 built_cut =
                     (long)fwrite(bytes, 1,
-                                 (size_t)(size - admission_tail - 1),
+                                 (size_t)(size - checkpoint_tail -
+                                          admission_tail - 1),
                                  fo) ==
-                    size - admission_tail - 1;
+                    size - checkpoint_tail - admission_tail - 1;
                 fclose(fo);
             }
             uint32_t twenty_four = 24;
@@ -1083,30 +1090,33 @@ static void test_wonder_appetite_holdout_trial(void) {
             if (fo) {
                 built_admission_cut =
                     (long)fwrite(bytes, 1,
-                                 (size_t)(size - 1), fo) ==
-                    size - 1;
+                                 (size_t)(size - checkpoint_tail - 1),
+                                 fo) ==
+                    size - checkpoint_tail - 1;
                 fclose(fo);
             }
             LeoWonderAppetiteAdmissions corrupted_admission;
             memcpy(
                 &corrupted_admission,
-                bytes + size - admission_tail,
+                bytes + size - checkpoint_tail - admission_tail,
                 sizeof corrupted_admission);
             corrupted_admission.receipts[0].supported = 4;
             corrupted_admission.receipts[0].overreach = 4;
             memcpy(
-                bytes + size - admission_tail,
+                bytes + size - checkpoint_tail - admission_tail,
                 &corrupted_admission,
                 sizeof corrupted_admission);
             fo = fopen(admission_bad, "wb");
             if (fo) {
                 built_admission_bad =
                     (long)fwrite(bytes, 1,
-                                 (size_t)size, fo) == size;
+                                 (size_t)(size - checkpoint_tail),
+                                 fo) ==
+                    size - checkpoint_tail;
                 fclose(fo);
             }
             memcpy(
-                bytes + size - admission_tail,
+                bytes + size - checkpoint_tail - admission_tail,
                 &leo->wonder_appetite_admissions,
                 sizeof leo->wonder_appetite_admissions);
             memcpy(bytes + sizeof(uint32_t), &twenty_three,
@@ -1124,9 +1134,10 @@ static void test_wonder_appetite_holdout_trial(void) {
             if (fo) {
                 built_bad =
                     (long)fwrite(bytes, 1,
-                                 (size_t)(size - admission_tail),
+                                 (size_t)(size - checkpoint_tail -
+                                          admission_tail),
                                  fo) ==
-                    size - admission_tail;
+                    size - checkpoint_tail - admission_tail;
                 fclose(fo);
             }
         }
@@ -1446,7 +1457,7 @@ static void test_wonder_appetite_transport_witness(void) {
               LEO_WONDER_APPETITE_TRANSPORT_PROVISIONAL,
           "wonder-appetite-transport: a confirmed result remains applicable only on a new bounded life");
     CHECK(!memcmp(before, leo, sizeof *leo) &&
-          LEO_STATE_VERSION == 24,
+          LEO_STATE_VERSION == 25,
           "wonder-appetite-transport: reading applicability rewrites no body, evidence, or state format");
 
     leo_free(leo);
@@ -1686,7 +1697,7 @@ static void test_wonder_appetite_transport_chronology(void) {
               LEO_WONDER_APPETITE_CHRONOLOGY_PROVISIONAL,
           "wonder-appetite-transport-chronology: two bounded adjacent eras preserve only provisional continuity");
     CHECK(!memcmp(before, leo, sizeof *leo) &&
-          LEO_STATE_VERSION == 24,
+          LEO_STATE_VERSION == 25,
           "wonder-appetite-transport-chronology: reading eras rewrites no body, evidence, or state format");
 
     leo_free(leo);
@@ -1861,6 +1872,442 @@ static void test_wonder_appetite_transport_chronology(void) {
     leo_free(leo);
     free(leo);
     free(before);
+}
+
+enum {
+    TEST_APPETITE_CHECKPOINT_PROVISIONAL = 0,
+    TEST_APPETITE_CHECKPOINT_EARLY_SHIFT,
+    TEST_APPETITE_CHECKPOINT_RECENT_SHIFT,
+    TEST_APPETITE_CHECKPOINT_COVERAGE_STARVED,
+    TEST_APPETITE_CHECKPOINT_PENDING,
+    TEST_APPETITE_CHECKPOINT_MIXED,
+    TEST_APPETITE_CHECKPOINT_INCOMPATIBLE
+};
+
+static void test_add_appetite_checkpoint_pattern(
+        Leo *leo, int pattern) {
+    if (!leo) return;
+    LeoWonderAppetiteHoldoutTrial *trial =
+        &leo->wonder_appetite_holdouts.trials[0];
+    LeoWonderAppetiteCheckpointLane *lane =
+        &leo->wonder_appetite_checkpoints.lanes[0];
+    uint64_t boundary =
+        lane->next_after_proposed_turn ?
+            lane->next_after_proposed_turn :
+            leo_wonder_appetite_holdout_terminal_boundary(trial);
+    uint64_t proposed = boundary + 4;
+    test_reset_appetite_policy_outcomes(leo);
+
+    if (pattern == TEST_APPETITE_CHECKPOINT_PROVISIONAL) {
+        proposed = test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 7, 1, 1, 7);
+        test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 7, 1, 1, 7);
+    } else if (
+        pattern == TEST_APPETITE_CHECKPOINT_EARLY_SHIFT) {
+        proposed = test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 5, 3, 0, 8);
+        test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 8, 0, 0, 8);
+    } else if (
+        pattern == TEST_APPETITE_CHECKPOINT_RECENT_SHIFT) {
+        proposed = test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 8, 0, 0, 8);
+        test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 5, 3, 0, 8);
+    } else if (
+        pattern == TEST_APPETITE_CHECKPOINT_COVERAGE_STARVED) {
+        proposed = test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 16, 0, 0, 0);
+        test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 8, 0, 0, 8);
+    } else if (
+        pattern == TEST_APPETITE_CHECKPOINT_PENDING) {
+        proposed = test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 8, 0, 0, 8);
+        test_add_appetite_transport_epoch(
+            leo, proposed, 0.65f, 0, 8, 0, 0, 7);
+    } else if (
+        pattern == TEST_APPETITE_CHECKPOINT_MIXED) {
+        for (int epoch = 0;
+             epoch < LEO_WONDER_APPETITE_TRANSPORT_EPOCHS;
+             epoch++) {
+            proposed = test_add_appetite_transport_epoch(
+                leo, proposed, 0.65f, 0, 4, 0, 0, 4);
+            for (int i = 0; i < 4; i++, proposed += 4)
+                test_add_appetite_policy_outcome_after(
+                    leo, proposed, 0.65f, 0,
+                    LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                    LEO_WONDER_APPETITE_CALIB_EXTERNAL);
+            for (int i = 0; i < 4; i++, proposed += 4)
+                test_add_appetite_policy_outcome_after(
+                    leo, proposed, 0.75f, 0,
+                    LEO_WONDER_APPETITE_POLICY_ELIGIBLE,
+                    LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+        }
+    } else if (
+        pattern == TEST_APPETITE_CHECKPOINT_INCOMPATIBLE) {
+        test_add_appetite_policy_outcome_after(
+            leo, proposed, 0.65f, 0,
+            LEO_WONDER_APPETITE_POLICY_LEGACY,
+            LEO_WONDER_APPETITE_CALIB_SUSTAINED);
+    }
+    leo_wonder_appetite_checkpoint_update(leo);
+}
+
+static void test_build_appetite_checkpoint_pair(
+        Leo *leo, int first, int second) {
+    leo_init(leo);
+    test_prepare_appetite_transport(leo);
+    test_add_appetite_checkpoint_pattern(leo, first);
+    test_add_appetite_checkpoint_pattern(leo, second);
+}
+
+__attribute__((noinline))
+static void test_wonder_appetite_transport_checkpoints(void) {
+    Leo *leo = malloc(sizeof *leo);
+    Leo *woke = malloc(sizeof *woke);
+    Leo *old = malloc(sizeof *old);
+    Leo *damaged = malloc(sizeof *damaged);
+    CHECK(leo && woke && old && damaged,
+          "wonder-appetite-checkpoint: heap fixtures allocated");
+    if (!leo || !woke || !old || !damaged) {
+        free(leo);
+        free(woke);
+        free(old);
+        free(damaged);
+        return;
+    }
+
+    int previous_checkpoint =
+        g_leo_wonder_appetite_checkpoint_on;
+    int previous_holdout =
+        g_leo_wonder_appetite_holdout_on;
+    int previous_calibration =
+        g_leo_wonder_appetite_calibration_on;
+    int previous_policy =
+        g_leo_wonder_appetite_policy_on;
+    int previous_admission =
+        g_leo_wonder_appetite_admission_on;
+    g_leo_wonder_appetite_checkpoint_on = 1;
+    g_leo_wonder_appetite_holdout_on = 1;
+    g_leo_wonder_appetite_calibration_on = 1;
+    g_leo_wonder_appetite_policy_on = 1;
+    g_leo_wonder_appetite_admission_on = 1;
+
+    leo_init(leo);
+    test_prepare_appetite_transport(leo);
+    test_add_appetite_checkpoint_pattern(
+        leo, TEST_APPETITE_CHECKPOINT_PROVISIONAL);
+    LeoWonderAppetiteCheckpointLane *lane =
+        &leo->wonder_appetite_checkpoints.lanes[0];
+    const LeoWonderAppetiteCheckpoint *first =
+        leo_wonder_appetite_checkpoint_at(lane, 0);
+    CHECK(first && lane->n == 1 &&
+          lane->active.status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY &&
+          first->attempts ==
+              LEO_WONDER_APPETITE_CHECKPOINT_BUDGET &&
+          first->epochs[0].attempts == 16 &&
+          first->epochs[1].attempts == 16 &&
+          first->status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_PROVISIONAL &&
+          first->seen_proposed_turn[0] >
+              first->after_proposed_turn &&
+          first->seen_proposed_turn[31] ==
+              first->through_proposed_turn &&
+          leo_wonder_appetite_checkpoints_valid(leo),
+          "wonder-appetite-checkpoint: one raw 32-life budget closes with exact proposal identity");
+
+    LeoWonderAppetiteCheckpointSequence sequence;
+    leo_wonder_appetite_checkpoint_sequence(leo, &sequence);
+    CHECK(sequence.one == 1 &&
+          sequence.cells[0].status ==
+              LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_ONE,
+          "wonder-appetite-checkpoint: one life remains one observation, not a regime");
+
+    uint64_t first_through =
+        first ? first->through_proposed_turn : 0;
+    test_add_appetite_checkpoint_pattern(
+        leo, TEST_APPETITE_CHECKPOINT_PROVISIONAL);
+    first = leo_wonder_appetite_checkpoint_at(lane, 0);
+    const LeoWonderAppetiteCheckpoint *second =
+        leo_wonder_appetite_checkpoint_at(lane, 1);
+    leo_wonder_appetite_checkpoint_sequence(leo, &sequence);
+    CHECK(first && second && lane->n == 2 &&
+          first->through_proposed_turn == first_through &&
+          second->after_proposed_turn == first_through &&
+          second->seen_proposed_turn[0] > first_through &&
+          first->seen_proposed_turn[31] <
+              second->seen_proposed_turn[0] &&
+          sequence.stable_provisional == 1 &&
+          sequence.cells[0].same_signature &&
+          sequence.cells[0].status ==
+              LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_STABLE_PROVISIONAL &&
+          leo_wonder_appetite_checkpoints_valid(leo),
+          "wonder-appetite-checkpoint: a second life begins strictly after the first and alone earns stable provisionality");
+
+    LeoWonderAppetiteCheckpointLane lane_before = *lane;
+    lane->history[0].seen_proposed_turn[1] =
+        lane->history[0].seen_proposed_turn[0];
+    CHECK(!leo_wonder_appetite_checkpoints_valid(leo),
+          "wonder-appetite-checkpoint: duplicate proposal identity invalidates the ledger");
+    *lane = lane_before;
+    lane->history[0].status =
+        LEO_WONDER_APPETITE_CHRONOLOGY_AGGREGATE_SHIFTED;
+    CHECK(!leo_wonder_appetite_checkpoints_valid(leo),
+          "wonder-appetite-checkpoint: a stored verdict cannot disagree with its raw counts");
+    *lane = lane_before;
+    lane->history[1].after_proposed_turn =
+        lane->history[0].through_proposed_turn - 4;
+    CHECK(!leo_wonder_appetite_checkpoints_valid(leo),
+          "wonder-appetite-checkpoint: overlapping lives cannot share evidence");
+    *lane = lane_before;
+    lane->history[1].through_proposed_turn =
+        (uint64_t)leo->school.turn_clock + 4;
+    lane->history[1].seen_proposed_turn[31] =
+        lane->history[1].through_proposed_turn;
+    lane->history[1].epochs[1].last_proposed_turn =
+        lane->history[1].through_proposed_turn;
+    lane->next_after_proposed_turn =
+        lane->history[1].through_proposed_turn;
+    CHECK(!leo_wonder_appetite_checkpoints_valid(leo),
+          "wonder-appetite-checkpoint: internally coherent evidence from a future turn is still impossible");
+    *lane = lane_before;
+
+    test_build_appetite_checkpoint_pair(
+        leo, TEST_APPETITE_CHECKPOINT_PROVISIONAL,
+        TEST_APPETITE_CHECKPOINT_EARLY_SHIFT);
+    leo_wonder_appetite_checkpoint_sequence(leo, &sequence);
+    CHECK(sequence.emerging_shift == 1 &&
+          sequence.cells[0].status ==
+              LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_EMERGING_SHIFT,
+          "wonder-appetite-checkpoint: one changed life is an emerging shift, not a new law");
+
+    leo_free(leo);
+    test_build_appetite_checkpoint_pair(
+        leo, TEST_APPETITE_CHECKPOINT_EARLY_SHIFT,
+        TEST_APPETITE_CHECKPOINT_RECENT_SHIFT);
+    leo_wonder_appetite_checkpoint_sequence(leo, &sequence);
+    CHECK(sequence.persistent_shift == 1 &&
+          !sequence.cells[0].same_signature &&
+          sequence.cells[0].status ==
+              LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_PERSISTENT_SHIFT,
+          "wonder-appetite-checkpoint: two shifted lives persist even when their local debt changes face");
+
+    leo_free(leo);
+    test_build_appetite_checkpoint_pair(
+        leo, TEST_APPETITE_CHECKPOINT_EARLY_SHIFT,
+        TEST_APPETITE_CHECKPOINT_PROVISIONAL);
+    leo_wonder_appetite_checkpoint_sequence(leo, &sequence);
+    CHECK(sequence.recovered == 1 &&
+          sequence.cells[0].status ==
+              LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_RECOVERED,
+          "wonder-appetite-checkpoint: a bounded life after a shift is visible as recovery");
+
+    leo_free(leo);
+    test_build_appetite_checkpoint_pair(
+        leo, TEST_APPETITE_CHECKPOINT_PROVISIONAL,
+        TEST_APPETITE_CHECKPOINT_COVERAGE_STARVED);
+    leo_wonder_appetite_checkpoint_sequence(leo, &sequence);
+    CHECK(sequence.insufficient == 1 &&
+          sequence.cells[0].status ==
+              LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INSUFFICIENT,
+          "wonder-appetite-checkpoint: an arm-starved life cannot vote for stability or change");
+
+    leo_free(leo);
+    leo_init(leo);
+    test_prepare_appetite_transport(leo);
+    test_add_appetite_checkpoint_pattern(
+        leo, TEST_APPETITE_CHECKPOINT_PENDING);
+    lane = &leo->wonder_appetite_checkpoints.lanes[0];
+    CHECK(lane->n == 0 &&
+          lane->active.status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_PENDING &&
+          lane->active.attempts == 31 &&
+          lane->active.epochs[0].attempts == 16 &&
+          lane->active.epochs[1].attempts == 15 &&
+          leo_wonder_appetite_checkpoints_valid(leo),
+          "wonder-appetite-checkpoint: thirty-one settled attempts persist as an unfinished life");
+
+    const char *state =
+        "/tmp/leo_appetite_checkpoint_v25.state";
+    const char *v24 =
+        "/tmp/leo_appetite_checkpoint_v24.state";
+    const char *cut =
+        "/tmp/leo_appetite_checkpoint_v25_cut.state";
+    const char *bad =
+        "/tmp/leo_appetite_checkpoint_v25_bad.state";
+    int saved = leo_save_state(leo, state);
+    leo_init(woke);
+    CHECK(saved && leo_load_state(woke, state) &&
+          !memcmp(&woke->wonder_appetite_checkpoints,
+                  &leo->wonder_appetite_checkpoints,
+                  sizeof leo->wonder_appetite_checkpoints),
+          "wonder-appetite-checkpoint: an unfinished raw life survives v25 sleep exactly");
+
+    int built_v24 = 0, built_cut = 0, built_bad = 0;
+    FILE *fi = fopen(state, "rb");
+    if (fi) {
+        fseek(fi, 0, SEEK_END);
+        long size = ftell(fi);
+        fseek(fi, 0, SEEK_SET);
+        unsigned char *bytes =
+            malloc(size > 0 ? (size_t)size : 1);
+        long checkpoint_tail =
+            (long)sizeof(LeoWonderAppetiteCheckpoints);
+        if (bytes && size > checkpoint_tail &&
+            (long)fread(bytes, 1, (size_t)size, fi) == size) {
+            uint32_t twenty_four = 24;
+            memcpy(bytes + sizeof(uint32_t), &twenty_four,
+                   sizeof twenty_four);
+            FILE *fo = fopen(v24, "wb");
+            if (fo) {
+                built_v24 =
+                    (long)fwrite(
+                        bytes, 1,
+                        (size_t)(size - checkpoint_tail), fo) ==
+                    size - checkpoint_tail;
+                fclose(fo);
+            }
+
+            uint32_t twenty_five = 25;
+            memcpy(bytes + sizeof(uint32_t), &twenty_five,
+                   sizeof twenty_five);
+            fo = fopen(cut, "wb");
+            if (fo) {
+                built_cut =
+                    (long)fwrite(
+                        bytes, 1, (size_t)(size - 1), fo) ==
+                    size - 1;
+                fclose(fo);
+            }
+
+            LeoWonderAppetiteCheckpoints corrupted;
+            memcpy(&corrupted,
+                   bytes + size - checkpoint_tail,
+                   sizeof corrupted);
+            corrupted.lanes[0].active.seen_proposed_turn[1] =
+                corrupted.lanes[0].active.seen_proposed_turn[0];
+            memcpy(bytes + size - checkpoint_tail,
+                   &corrupted, sizeof corrupted);
+            fo = fopen(bad, "wb");
+            if (fo) {
+                built_bad =
+                    (long)fwrite(
+                        bytes, 1, (size_t)size, fo) == size;
+                fclose(fo);
+            }
+        }
+        free(bytes);
+        fclose(fi);
+    }
+
+    leo_init(old);
+    CHECK(built_v24 && leo_load_state(old, v24) &&
+          old->wonder_appetite_checkpoints.lanes[0].n == 0 &&
+          old->wonder_appetite_checkpoints.lanes[0].active.status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY &&
+          old->wonder_appetite_checkpoints.lanes[0].
+              next_after_proposed_turn ==
+                  leo->wonder_appetite_calibration.receipts[30].
+                      proposed_turn,
+          "wonder-appetite-checkpoint: v24 migration starts after existing history instead of inventing a checkpoint");
+
+    leo_init(damaged);
+    CHECK(built_cut && leo_load_state(damaged, cut) &&
+          !memcmp(&damaged->wonder_appetite_holdouts,
+                  &leo->wonder_appetite_holdouts,
+                  sizeof leo->wonder_appetite_holdouts) &&
+          !memcmp(&damaged->wonder_appetite_admissions,
+                  &leo->wonder_appetite_admissions,
+                  sizeof leo->wonder_appetite_admissions) &&
+          damaged->wonder_appetite_checkpoints.lanes[0].n == 0 &&
+          damaged->wonder_appetite_checkpoints.lanes[0].
+              next_after_proposed_turn ==
+                  leo->wonder_appetite_calibration.receipts[30].
+                      proposed_turn,
+          "wonder-appetite-checkpoint: a truncated v25 ledger loses no body, trial, or admission");
+
+    leo_free(damaged);
+    leo_init(damaged);
+    CHECK(built_bad && leo_load_state(damaged, bad) &&
+          !memcmp(&damaged->wonder_appetite_holdouts,
+                  &leo->wonder_appetite_holdouts,
+                  sizeof leo->wonder_appetite_holdouts) &&
+          damaged->wonder_appetite_checkpoints.lanes[0].n == 0 &&
+          damaged->wonder_appetite_checkpoints.lanes[0].
+              next_after_proposed_turn ==
+                  leo->wonder_appetite_calibration.receipts[30].
+                      proposed_turn,
+          "wonder-appetite-checkpoint: corrupt proposal identity fails soft and cannot be replayed");
+    remove(state);
+    remove(v24);
+    remove(cut);
+    remove(bad);
+
+    leo_free(leo);
+    leo_init(leo);
+    test_prepare_appetite_transport(leo);
+    test_add_appetite_checkpoint_pattern(
+        leo, TEST_APPETITE_CHECKPOINT_MIXED);
+    lane = &leo->wonder_appetite_checkpoints.lanes[0];
+    first = leo_wonder_appetite_checkpoint_at(lane, 0);
+    CHECK(first &&
+          first->epochs[0].attempts == 16 &&
+          first->epochs[0].exact == 8 &&
+          first->epochs[0].confounded == 4 &&
+          first->epochs[0].other == 4 &&
+          first->epochs[1].attempts == 16 &&
+          first->epochs[1].exact == 8 &&
+          first->epochs[1].confounded == 4 &&
+          first->epochs[1].other == 4,
+          "wonder-appetite-checkpoint: confounds and other strata spend fixed time without impersonating either arm");
+
+    leo_free(leo);
+    leo_init(leo);
+    test_prepare_appetite_transport(leo);
+    test_add_appetite_checkpoint_pattern(
+        leo, TEST_APPETITE_CHECKPOINT_INCOMPATIBLE);
+    lane = &leo->wonder_appetite_checkpoints.lanes[0];
+    LeoWonderAppetiteCheckpointLane incompatible_before = *lane;
+    test_add_appetite_checkpoint_pattern(
+        leo, TEST_APPETITE_CHECKPOINT_PROVISIONAL);
+    leo_wonder_appetite_checkpoint_sequence(leo, &sequence);
+    CHECK(lane->blocked && lane->n == 1 &&
+          !memcmp(&incompatible_before, lane,
+                  sizeof incompatible_before) &&
+          sequence.incompatible == 1 &&
+          sequence.cells[0].status ==
+              LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INCOMPATIBLE,
+          "wonder-appetite-checkpoint: changed policy language closes the lane instead of translating later evidence");
+
+    leo_free(leo);
+    leo_init(leo);
+    test_prepare_appetite_transport(leo);
+    g_leo_wonder_appetite_checkpoint_on = 0;
+    test_add_appetite_checkpoint_pattern(
+        leo, TEST_APPETITE_CHECKPOINT_PROVISIONAL);
+    CHECK(!memcmp(&leo->wonder_appetite_checkpoints,
+                  &(LeoWonderAppetiteCheckpoints){0},
+                  sizeof leo->wonder_appetite_checkpoints),
+          "wonder-appetite-checkpoint: ablation prevents the ledger rather than hiding a reader");
+
+    g_leo_wonder_appetite_checkpoint_on = previous_checkpoint;
+    g_leo_wonder_appetite_holdout_on = previous_holdout;
+    g_leo_wonder_appetite_calibration_on =
+        previous_calibration;
+    g_leo_wonder_appetite_policy_on = previous_policy;
+    g_leo_wonder_appetite_admission_on =
+        previous_admission;
+    leo_free(leo);
+    leo_free(woke);
+    leo_free(old);
+    leo_free(damaged);
+    free(leo);
+    free(woke);
+    free(old);
+    free(damaged);
 }
 
 int main(void) {
@@ -3895,7 +4342,8 @@ int main(void) {
                     if (fo) {
                         long post_v22_tail =
                             (long)(sizeof(LeoWonderAppetiteHoldouts) +
-                                   sizeof(LeoWonderAppetiteAdmissions));
+                                   sizeof(LeoWonderAppetiteAdmissions) +
+                                   sizeof(LeoWonderAppetiteCheckpoints));
                         built_cut =
                             (long)fwrite(
                                 bytes, 1,
@@ -4337,6 +4785,7 @@ int main(void) {
     test_wonder_appetite_holdout_trial();
     test_wonder_appetite_transport_witness();
     test_wonder_appetite_transport_chronology();
+    test_wonder_appetite_transport_checkpoints();
 
     /* A.5 I2: School grows a word→glyph map. The answer's dominant glyph is the
      * concept-slot; a taught word then returns that glyph (no longer -1); the

--- a/tests/wonder_appetite_holdout_fixture.c
+++ b/tests/wonder_appetite_holdout_fixture.c
@@ -172,6 +172,19 @@ static int chronology_scenario(const char *scenario) {
         !strcmp(scenario, "chronology-incompatible");
 }
 
+static int checkpoint_scenario(const char *scenario) {
+    return
+        !strcmp(scenario, "checkpoint-one") ||
+        !strcmp(scenario, "checkpoint-stable") ||
+        !strcmp(scenario, "checkpoint-emerging") ||
+        !strcmp(scenario, "checkpoint-persistent") ||
+        !strcmp(scenario, "checkpoint-recovered") ||
+        !strcmp(scenario, "checkpoint-insufficient") ||
+        !strcmp(scenario, "checkpoint-incompatible") ||
+        !strcmp(scenario, "checkpoint-pending") ||
+        !strcmp(scenario, "checkpoint-ablated");
+}
+
 static int transport_scenario(const char *scenario) {
     return
         !strcmp(scenario, "transport-provisional") ||
@@ -330,15 +343,92 @@ static int add_chronology_present(
     return 0;
 }
 
+static int add_checkpoint_life(
+        Leo *leo, const char *chronology) {
+    LeoWonderAppetiteHoldoutTrial *trial =
+        &leo->wonder_appetite_holdouts.trials[0];
+    LeoWonderAppetiteCheckpointLane *lane =
+        &leo->wonder_appetite_checkpoints.lanes[0];
+    uint64_t boundary =
+        lane->next_after_proposed_turn ?
+            lane->next_after_proposed_turn :
+            leo_wonder_appetite_holdout_terminal_boundary(trial);
+    memset(&leo->wonder_appetite_calibration, 0,
+           sizeof leo->wonder_appetite_calibration);
+    proposed_base = boundary + 4;
+    int ok = add_chronology_present(leo, chronology);
+    if (ok) leo_wonder_appetite_checkpoint_update(leo);
+    return ok;
+}
+
+static int build_checkpoint_scenario(
+        Leo *leo, const char *scenario) {
+    if (!strcmp(scenario, "checkpoint-one"))
+        return add_checkpoint_life(
+            leo, "chronology-provisional");
+    if (!strcmp(scenario, "checkpoint-stable"))
+        return
+            add_checkpoint_life(
+                leo, "chronology-provisional") &&
+            add_checkpoint_life(
+                leo, "chronology-provisional");
+    if (!strcmp(scenario, "checkpoint-emerging"))
+        return
+            add_checkpoint_life(
+                leo, "chronology-provisional") &&
+            add_checkpoint_life(
+                leo, "chronology-early-shift");
+    if (!strcmp(scenario, "checkpoint-persistent"))
+        return
+            add_checkpoint_life(
+                leo, "chronology-early-shift") &&
+            add_checkpoint_life(
+                leo, "chronology-recent-shift");
+    if (!strcmp(scenario, "checkpoint-recovered"))
+        return
+            add_checkpoint_life(
+                leo, "chronology-early-shift") &&
+            add_checkpoint_life(
+                leo, "chronology-provisional");
+    if (!strcmp(scenario, "checkpoint-insufficient"))
+        return
+            add_checkpoint_life(
+                leo, "chronology-provisional") &&
+            add_checkpoint_life(
+                leo, "chronology-coverage-starved");
+    if (!strcmp(scenario, "checkpoint-incompatible"))
+        return add_checkpoint_life(
+            leo, "chronology-incompatible");
+    if (!strcmp(scenario, "checkpoint-pending"))
+        return add_checkpoint_life(
+            leo, "chronology-observing");
+    if (!strcmp(scenario, "checkpoint-ablated")) {
+        int previous = g_leo_wonder_appetite_checkpoint_on;
+        g_leo_wonder_appetite_checkpoint_on = 0;
+        int ok = add_checkpoint_life(
+            leo, "chronology-provisional");
+        g_leo_wonder_appetite_checkpoint_on = previous;
+        return ok;
+    }
+    return 0;
+}
+
 int main(int argc, char **argv) {
     if (argc == 2 && !strcmp(argv[1], "--tail-size")) {
         printf("%zu\n",
                sizeof(LeoWonderAppetiteHoldouts) +
-               sizeof(LeoWonderAppetiteAdmissions));
+               sizeof(LeoWonderAppetiteAdmissions) +
+               sizeof(LeoWonderAppetiteCheckpoints));
         return 0;
     }
     if (argc == 2 && !strcmp(argv[1], "--admission-tail-size")) {
-        printf("%zu\n", sizeof(LeoWonderAppetiteAdmissions));
+        printf("%zu\n",
+               sizeof(LeoWonderAppetiteAdmissions) +
+               sizeof(LeoWonderAppetiteCheckpoints));
+        return 0;
+    }
+    if (argc == 2 && !strcmp(argv[1], "--checkpoint-tail-size")) {
+        printf("%zu\n", sizeof(LeoWonderAppetiteCheckpoints));
         return 0;
     }
     if (argc != 3 ||
@@ -348,9 +438,10 @@ int main(int argc, char **argv) {
          strcmp(argv[2], "restraint-failed") &&
          strcmp(argv[2], "both-failed") &&
          strcmp(argv[2], "coverage-starved") &&
+         !checkpoint_scenario(argv[2]) &&
          !transport_scenario(argv[2]))) {
         fprintf(stderr,
-                "usage: %s STATE arm|confirmed|motion-failed|restraint-failed|both-failed|coverage-starved|transport-*|chronology-*\n",
+                "usage: %s STATE arm|confirmed|motion-failed|restraint-failed|both-failed|coverage-starved|transport-*|chronology-*|checkpoint-*\n",
                 argv[0]);
         return 2;
     }
@@ -363,7 +454,13 @@ int main(int argc, char **argv) {
         "Leo hears the night and asks what the sea remembers. "
         "The child watches light move across the room.");
     int ok = add_candidate(&leo);
-    if (ok && transport_scenario(argv[2])) {
+    if (ok && checkpoint_scenario(argv[2])) {
+        leo_wonder_appetite_holdout_update(&leo);
+        ok = add_future(&leo, "confirmed");
+        if (ok) leo_wonder_appetite_holdout_update(&leo);
+        if (ok) ok = build_checkpoint_scenario(
+            &leo, argv[2]);
+    } else if (ok && transport_scenario(argv[2])) {
         leo_wonder_appetite_holdout_update(&leo);
         ok = add_future(&leo, "confirmed");
         if (ok) leo_wonder_appetite_holdout_update(&leo);


### PR DESCRIPTION
Persist raw v25 transport checkpoints, recompute their verdicts, and classify two-life sequences without adding a speech reader. Add future-only migration, corruption guards, diagnostics, process matrices, and A.55 records.

Quote: "Continuity begins where evidence can no longer be spent twice." - Sol

Method: The Arianna Method gives each lived interval its own evidence before naming persistence.