### PR TITLE
the method distinguishes recurrence from a world

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -4905,3 +4905,71 @@ writer reply equality   yes
 The on/off writer pair differed only in the fixed v25 checkpoint tail. With
 that tail preserved, both bodies spoke the same reply. Time is now durable
 without becoming a hidden voice.
+
+## Phase A.56 — one recurring question is not a world (2026-07-28)
+
+A prospective process run exposed a hole in A.55 that its constructed
+checkpoint matrix could not see. Starting from a confirmed and attested past,
+one real deferred question (`suvin`) lived through 145 separate
+save/exit/reload turns. Its semantic association returned every fourth turn.
+That one identity alone filled all 32 checkpoint attempts and closed a
+terminal life:
+
+```text
+sources          1
+max source      32
+early epoch     1 source / 16 attempts
+recent epoch    1 source / 16 attempts
+```
+
+The arm verdict was honestly `coverage-starved`, but the ledger had no way to
+say that the whole alleged life was one thought repeated. Attempt count is not
+source independence.
+
+A.56 persists a deterministic 64-bit identity of each calibration word beside
+its proposal identity. The hash is evidence-only: neither the word nor the
+hash is read by School, Flow, scheduling, routing, sampling, or generation.
+Every complete checkpoint now requires:
+
+```text
+whole life       at least 4 distinct Wonder sources
+each epoch       at least 2 distinct sources
+each epoch       no source may occupy more than 8 of 16 attempts
+```
+
+Failure is named `source-starved`, separate from policy-arm
+`coverage-starved`. Both are insufficient for a checkpoint sequence, but they
+preserve different debts. Debug receipts expose total and per-epoch source
+counts for the active checkpoint as well as both terminal histories.
+
+State moved from v25 to v26. A v25 checkpoint cannot be given source identity
+after the fact, so migration preserves the organism, calibration, holdout, and
+admission, then anchors a new source-aware checkpoint after the newest
+surviving receipt. A malformed v26 source vector fails soft in the same narrow
+way. Zero identities in used slots and nonzero identities in unused slots are
+invalid; verdicts are regraded from the persisted raw vector on load.
+
+Four direct contracts raised the suite from **469/469** to **473/473**. The
+expanded real-process fixture matrix is **9/9** for chronology, reply equality,
+and complete on/off state equality. Its new constructed cell records
+`source-starved: 1/32`; ordinary cells retain `32/1`.
+
+The prospective natural-life receipt is independently reproducible with:
+
+```sh
+make deferred-wonder-appetite-checkpoint-life
+```
+
+Across 145 on/off process turns, all 145 visible replies were identical and
+the complete state prefix before the fixed checkpoint tail was identical.
+Only the readerless tail differed. The former false life now ends explicitly:
+
+```text
+one-wonder-cycle  source-starved  sources=1  max=32
+epochs            1/16 | 1/16
+sequence          insufficient
+```
+
+This closes the reproduced pseudo-replication. It does not yet prove that an
+ordinary unscripted long life supplies four source-distinct Wonders; that
+remains a prospective observation rather than a manufactured success.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life
 
 all: leo
 
@@ -100,6 +100,9 @@ deferred-wonder-appetite-transport-chronology: leo
 deferred-wonder-appetite-checkpoint: leo
 	./scripts/deferred_wonder_appetite_checkpoint_matrix.sh
 
+deferred-wonder-appetite-checkpoint-life: leo
+	./scripts/deferred_wonder_appetite_checkpoint_life.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -138,6 +141,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_appetite_transport_matrix.sh
 	./scripts/test_deferred_wonder_appetite_transport_chronology_matrix.sh
 	./scripts/test_deferred_wonder_appetite_checkpoint_matrix.sh
+	./scripts/test_deferred_wonder_appetite_checkpoint_life.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -176,6 +176,17 @@ static uint32_t fnv1a(const void *data, int len) {
     return h;
 }
 
+static uint64_t fnv1a64_ascii_lower(const char *data, size_t len) {
+    uint64_t h = UINT64_C(14695981039346656037);
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)data[i];
+        if (c >= 'A' && c <= 'Z') c = (unsigned char)(c + 'a' - 'A');
+        h ^= c;
+        h *= UINT64_C(1099511628211);
+    }
+    return h;
+}
+
 __attribute__((unused))  /* used by the smoke main; absent in the test TU */
 static double leo_ns(void) {
     struct timespec ts;
@@ -2165,6 +2176,7 @@ enum {
     LEO_WONDER_APPETITE_CHRONOLOGY_INCOMPATIBLE,
     LEO_WONDER_APPETITE_CHRONOLOGY_OBSERVING,
     LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED,
+    LEO_WONDER_APPETITE_CHRONOLOGY_SOURCE_STARVED,
     LEO_WONDER_APPETITE_CHRONOLOGY_AGGREGATE_SHIFTED,
     LEO_WONDER_APPETITE_CHRONOLOGY_EARLY_SHIFTED,
     LEO_WONDER_APPETITE_CHRONOLOGY_RECENT_SHIFTED,
@@ -2226,12 +2238,15 @@ typedef struct {
     int provisional;
 } LeoWonderAppetiteTransportChronology;
 
-/* A.55: transport evidence advances through fixed, non-overlapping lives.
- * Checkpoints persist raw proposal identities and outcome counts; all rates
- * and sequence claims are recomputed. Two terminal checkpoints are enough to
- * distinguish one transition from a repeated regime without authorizing it. */
+/* A.55/A.56: transport evidence advances through fixed, non-overlapping
+ * lives. Proposal and source identities prevent evidence reuse and a single
+ * recurring Wonder from impersonating a whole semantic ecology. All rates
+ * and sequence claims are recomputed; none of this grants a speech reader. */
 #define LEO_WONDER_APPETITE_CHECKPOINT_BUDGET 32
 #define LEO_WONDER_APPETITE_CHECKPOINT_HISTORY 2
+#define LEO_WONDER_APPETITE_CHECKPOINT_MIN_SOURCES 4
+#define LEO_WONDER_APPETITE_CHECKPOINT_EPOCH_MIN_SOURCES 2
+#define LEO_WONDER_APPETITE_CHECKPOINT_EPOCH_MAX_SOURCE 8
 typedef struct {
     uint64_t first_proposed_turn;
     uint64_t last_proposed_turn;
@@ -2252,6 +2267,8 @@ typedef struct {
     uint64_t after_proposed_turn;
     uint64_t through_proposed_turn;
     uint64_t seen_proposed_turn[
+        LEO_WONDER_APPETITE_CHECKPOINT_BUDGET];
+    uint64_t seen_source_id[
         LEO_WONDER_APPETITE_CHECKPOINT_BUDGET];
     uint8_t spoken;
     uint8_t bin;
@@ -2480,8 +2497,8 @@ typedef struct {
     /* A.52/state v24: immutable proof of the A.50 geometry that admitted each
      * trial. Separate so v23 trials migrate visibly unattested, never invented. */
     LeoWonderAppetiteAdmissions wonder_appetite_admissions;
-    /* A.55/state v25: raw fixed-budget transport checkpoints. They persist
-     * evidence chronology, but no cognition or generation path reads them. */
+    /* A.56/state v26: source-aware fixed-budget transport checkpoints. They
+     * persist evidence chronology, but cognition and generation never read it. */
     LeoWonderAppetiteCheckpoints wonder_appetite_checkpoints;
     /* A.42/A.43: pre-grounding address witness. Semantic conflict can only
      * guard; an exact waiting name may redirect without assigning meaning. */
@@ -8168,8 +8185,9 @@ static const char *leo_wonder_appetite_transport_chronology_status_name(
         *names[LEO_WONDER_APPETITE_CHRONOLOGY_STATUS_COUNT] = {
             "empty", "unattested", "pending", "refuted",
             "incompatible", "observing", "coverage-starved",
-            "aggregate-shifted", "early-shifted", "recent-shifted",
-            "both-shifted", "ecology-shifted", "provisional"
+            "source-starved", "aggregate-shifted", "early-shifted",
+            "recent-shifted", "both-shifted", "ecology-shifted",
+            "provisional"
         };
     return status >= 0 &&
            status < LEO_WONDER_APPETITE_CHRONOLOGY_STATUS_COUNT ?
@@ -8195,6 +8213,75 @@ static int leo_interval_overlaps(
         float a_lower, float a_upper,
         float b_lower, float b_upper) {
     return a_lower <= b_upper && b_lower <= a_upper;
+}
+
+typedef struct {
+    int distinct;
+    int max_attempts;
+    int epoch_distinct[LEO_WONDER_APPETITE_TRANSPORT_EPOCHS];
+    int epoch_max_attempts[LEO_WONDER_APPETITE_TRANSPORT_EPOCHS];
+} LeoWonderAppetiteCheckpointSources;
+
+static uint64_t leo_wonder_appetite_source_id(
+        const LeoWonderAppetiteCalibrationReceipt *receipt) {
+    if (!receipt || !receipt->word[0]) return 0;
+    uint64_t id =
+        fnv1a64_ascii_lower(receipt->word, strlen(receipt->word));
+    return id ? id : 1;
+}
+
+static void leo_wonder_appetite_checkpoint_sources(
+        const LeoWonderAppetiteCheckpoint *checkpoint,
+        LeoWonderAppetiteCheckpointSources *sources) {
+    if (!sources) return;
+    memset(sources, 0, sizeof *sources);
+    if (!checkpoint) return;
+    for (int i = 0; i < checkpoint->attempts; i++) {
+        uint64_t id = checkpoint->seen_source_id[i];
+        int total = 0, first = 1;
+        for (int j = 0; j < checkpoint->attempts; j++) {
+            if (checkpoint->seen_source_id[j] != id) continue;
+            total++;
+            if (j < i) first = 0;
+        }
+        if (first) sources->distinct++;
+        if (total > sources->max_attempts)
+            sources->max_attempts = total;
+
+        int epoch =
+            i / LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS;
+        int begin =
+            epoch * LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS;
+        int end = begin +
+            LEO_WONDER_APPETITE_TRANSPORT_EPOCH_ATTEMPTS;
+        if (end > checkpoint->attempts) end = checkpoint->attempts;
+        int epoch_total = 0, epoch_first = 1;
+        for (int j = begin; j < end; j++) {
+            if (checkpoint->seen_source_id[j] != id) continue;
+            epoch_total++;
+            if (j < i) epoch_first = 0;
+        }
+        if (epoch_first) sources->epoch_distinct[epoch]++;
+        if (epoch_total > sources->epoch_max_attempts[epoch])
+            sources->epoch_max_attempts[epoch] = epoch_total;
+    }
+}
+
+static int leo_wonder_appetite_checkpoint_sources_sufficient(
+        const LeoWonderAppetiteCheckpoint *checkpoint) {
+    LeoWonderAppetiteCheckpointSources sources;
+    leo_wonder_appetite_checkpoint_sources(checkpoint, &sources);
+    if (sources.distinct <
+        LEO_WONDER_APPETITE_CHECKPOINT_MIN_SOURCES)
+        return 0;
+    for (int i = 0;
+         i < LEO_WONDER_APPETITE_TRANSPORT_EPOCHS; i++)
+        if (sources.epoch_distinct[i] <
+                LEO_WONDER_APPETITE_CHECKPOINT_EPOCH_MIN_SOURCES ||
+            sources.epoch_max_attempts[i] >
+                LEO_WONDER_APPETITE_CHECKPOINT_EPOCH_MAX_SOURCE)
+            return 0;
+    return 1;
 }
 
 static void leo_wonder_appetite_transport_chronology_count(
@@ -8523,6 +8610,9 @@ static int leo_wonder_appetite_checkpoint_grade(
     if (checkpoint->attempts <
         LEO_WONDER_APPETITE_CHECKPOINT_BUDGET)
         return LEO_WONDER_APPETITE_CHRONOLOGY_PENDING;
+    if (!leo_wonder_appetite_checkpoint_sources_sufficient(
+            checkpoint))
+        return LEO_WONDER_APPETITE_CHRONOLOGY_SOURCE_STARVED;
     if (early_raw->eligible <
             LEO_WONDER_APPETITE_TRANSPORT_EPOCH_MIN_ARM_N ||
         early_raw->abstained <
@@ -8750,6 +8840,8 @@ static void leo_wonder_appetite_checkpoint_update(Leo *leo) {
                 &checkpoint->epochs[epoch_index];
             checkpoint->seen_proposed_turn[attempt] =
                 receipt->proposed_turn;
+            checkpoint->seen_source_id[attempt] =
+                leo_wonder_appetite_source_id(receipt);
             checkpoint->through_proposed_turn =
                 receipt->proposed_turn;
             checkpoint->attempts++;
@@ -8880,8 +8972,11 @@ static void leo_wonder_appetite_checkpoint_sequence(
                 cell->status =
                     LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INCOMPATIBLE;
                 sequence->incompatible++;
-            } else if (cell->recent_status ==
-                LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED) {
+            } else if (
+                cell->recent_status ==
+                    LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED ||
+                cell->recent_status ==
+                    LEO_WONDER_APPETITE_CHRONOLOGY_SOURCE_STARVED) {
                 cell->status =
                     LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INSUFFICIENT;
                 sequence->insufficient++;
@@ -8909,8 +9004,12 @@ static void leo_wonder_appetite_checkpoint_sequence(
         } else if (
             cell->previous_status ==
                     LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED ||
+            cell->previous_status ==
+                    LEO_WONDER_APPETITE_CHRONOLOGY_SOURCE_STARVED ||
             cell->recent_status ==
-                    LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED) {
+                    LEO_WONDER_APPETITE_CHRONOLOGY_COVERAGE_STARVED ||
+            cell->recent_status ==
+                    LEO_WONDER_APPETITE_CHRONOLOGY_SOURCE_STARVED) {
             cell->status =
                 LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INSUFFICIENT;
             sequence->insufficient++;
@@ -9012,6 +9111,11 @@ static int leo_wonder_appetite_checkpoint_record_valid(
         } else if (proposed != 0) {
             return 0;
         }
+        uint64_t source =
+            checkpoint->seen_source_id[i];
+        if ((i < checkpoint->attempts && source == 0) ||
+            (i >= checkpoint->attempts && source != 0))
+            return 0;
     }
     if (checkpoint->through_proposed_turn != previous)
         return 0;
@@ -10336,9 +10440,10 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
  *   v23      : fixed-budget out-of-sample trials over readiness candidates
  *   v24      : immutable A.50 admission receipts for those trials
  *   v25      : non-overlapping raw transport checkpoints and their sequence
+ *   v26      : source identities and ecology for transport checkpoints
  * ======================================================================== */
 #define LEO_STATE_MAGIC   0x5300454C   /* "LE\0S" — little-endian LEOS */
-#define LEO_STATE_VERSION 25  /* A.55 carries transport lives; v5..v24 soft-migrate */
+#define LEO_STATE_VERSION 26  /* A.56 carries checkpoint source ecology; v5..v25 soft-migrate */
 
 static int st_w32(FILE *f, int32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
 static int st_wu(FILE *f, uint32_t v)  { return fwrite(&v, sizeof v, 1, f) == 1; }
@@ -10575,8 +10680,8 @@ static int leo_save_state(const Leo *leo, const char *path) {
     fwrite(&leo->wonder_appetite_admissions,
            sizeof leo->wonder_appetite_admissions, 1, f);
 
-    /* A.55 (v25): each checkpoint owns its proposal identities and raw counts.
-     * Derived verdicts are checked again on load; no speech path reads this. */
+    /* A.56 (v26): checkpoints also own source identities, so recurrence by one
+     * Wonder cannot impersonate semantic transport. No speech path reads this. */
     fwrite(&leo->wonder_appetite_checkpoints,
            sizeof leo->wonder_appetite_checkpoints, 1, f);
 
@@ -11361,16 +11466,16 @@ static int leo_load_state_inner(Leo *leo, const char *path) {
         }
     }
 
-    /* A.55 transport lives (v25). Older bodies begin after every receipt they
-     * already carry: migration may observe the future, never retrofit a past
-     * checkpoint. A malformed v25 tail loses only this readerless ledger. */
-    if (version >= 25) {
+    /* A.56 source-aware transport lives (v26). A v25 ledger cannot prove
+     * source diversity, so it is not promoted: both older bodies and damaged
+     * v26 bodies restart observation after every receipt they already carry. */
+    if (version >= 26) {
         int checkpoint_ok =
             fread(&leo->wonder_appetite_checkpoints,
                   sizeof leo->wonder_appetite_checkpoints, 1, f) == 1 &&
             leo_wonder_appetite_checkpoints_valid(leo);
         if (!checkpoint_ok) {
-            fprintf(stderr, "[leo] WARNING: v25 transport-checkpoint tail truncated/corrupt — organism lives without checkpoints.\n");
+            fprintf(stderr, "[leo] WARNING: v26 transport-checkpoint tail truncated/corrupt — organism lives without checkpoints.\n");
             memset(&leo->wonder_appetite_checkpoints, 0,
                    sizeof leo->wonder_appetite_checkpoints);
         }
@@ -12325,14 +12430,21 @@ static void print_wonder_appetite_checkpoint_record(
     if (!checkpoint ||
         checkpoint->status ==
             LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY) {
-        printf("/0/0/empty/0/0/0/0/0/0/0/0/0/0");
+        printf("/0/0/empty/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0/0");
         return;
     }
-    printf("/%llu/%llu/%s",
+    LeoWonderAppetiteCheckpointSources sources;
+    leo_wonder_appetite_checkpoint_sources(checkpoint, &sources);
+    printf("/%llu/%llu/%s/%d/%d/%d/%d/%d/%d",
            (unsigned long long)checkpoint->after_proposed_turn,
            (unsigned long long)checkpoint->through_proposed_turn,
            leo_wonder_appetite_transport_chronology_status_name(
-               checkpoint->status));
+               checkpoint->status),
+           sources.distinct, sources.max_attempts,
+           sources.epoch_distinct[0],
+           sources.epoch_max_attempts[0],
+           sources.epoch_distinct[1],
+           sources.epoch_max_attempts[1]);
     for (int i = 0;
          i < LEO_WONDER_APPETITE_TRANSPORT_EPOCHS; i++) {
         const LeoWonderAppetiteCheckpointEpoch *epoch =
@@ -12386,7 +12498,10 @@ static void print_wonder_appetite_checkpoint_stats(const Leo *leo) {
             continue;
         int bin =
             i % LEO_WONDER_APPETITE_RELIABILITY_BINS;
-        printf("%s%c%d-%d:%llu/%u/%llu/%llu/%u/%s/%u",
+        LeoWonderAppetiteCheckpointSources active_sources;
+        leo_wonder_appetite_checkpoint_sources(
+            &lane->active, &active_sources);
+        printf("%s%c%d-%d:%llu/%u/%llu/%llu/%u/%s/%d/%d/%d/%d/%d/%d/%u",
                separator,
                i / LEO_WONDER_APPETITE_RELIABILITY_BINS ?
                    's' : 'u',
@@ -12401,6 +12516,12 @@ static void print_wonder_appetite_checkpoint_stats(const Leo *leo) {
                (unsigned)lane->active.attempts,
                leo_wonder_appetite_transport_chronology_status_name(
                    lane->active.status),
+               active_sources.distinct,
+               active_sources.max_attempts,
+               active_sources.epoch_distinct[0],
+               active_sources.epoch_max_attempts[0],
+               active_sources.epoch_distinct[1],
+               active_sources.epoch_max_attempts[1],
                (unsigned)lane->n);
         for (int j = 0;
              j < LEO_WONDER_APPETITE_CHECKPOINT_HISTORY; j++)

--- a/scripts/deferred_wonder_appetite_checkpoint_life.sh
+++ b/scripts/deferred_wonder_appetite_checkpoint_life.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# A.56: prove one naturally recurring Wonder cannot become a transport life.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-appetite-checkpoint-life-$STAMP}"
+TARGET=suvin
+TURNS=145
+
+if [ "${LEO_APPETITE_CHECKPOINT_LIFE_PLAN_ONLY:-0}" = 1 ]; then
+    printf 'case\ttarget\tturns\texpected_status\texpected_sources\texpected_max_source\n'
+    printf 'one-wonder-cycle\t%s\t%d\tsource-starved\t1\t32\n' \
+        "$TARGET" "$TURNS"
+    exit 0
+fi
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT/on" "$OUT/off"
+
+make -C "$ROOT" leo >/dev/null
+"${CC:-cc}" -O2 -Wall -Wextra -Wno-unused-function \
+    "$ROOT/tests/wonder_appetite_holdout_fixture.c" -lm \
+    -o "$OUT/holdout-fixture"
+"$OUT/holdout-fixture" "$OUT/base.state" confirmed
+cp "$OUT/base.state" "$OUT/on/state"
+cp "$OUT/base.state" "$OUT/off/state"
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+report_from_log() {
+    awk -v scenario=one-wonder-cycle -v seed=9101 \
+        -f "$ROOT/scripts/wonder_appetite_checkpoint_dialogue_report.awk" \
+        "$1"
+}
+
+cell_values() {
+    local cells="$1"
+    printf '%s\n' "$cells" |
+        awk '
+            {
+                n = split($0, items, /\|/)
+                for (i = 1; i <= n; i++) {
+                    split(items[i], pair, /:/)
+                    if (pair[1] != "u62-70") continue
+                    split(pair[2], values, /\//)
+                    for (j = 1; j <= 51; j++)
+                        printf "%s%s", (j == 1 ? "" : "\t"), values[j]
+                    printf "\n"
+                    exit
+                }
+            }
+        '
+}
+
+reply_equal=0
+for turn in $(seq 1 "$TURNS"); do
+    if [ "$turn" -eq 1 ]; then
+        prompt="Does $TARGET feel like bright sun or cold winter?"
+    elif [ $(( (turn - 2) % 4 )) -eq 0 ]; then
+        prompt="Bright sun. Cold winter."
+    else
+        prompt="I do not know."
+    fi
+    seed=$((9100 + turn))
+    "$ROOT/leo" --load "$OUT/on/state" --seed "$seed" \
+        --respond "$prompt" --debug-field --save "$OUT/on/state" \
+        > "$OUT/on/turn-$turn.log" 2>&1
+    "$ROOT/leo" --load "$OUT/off/state" --seed "$seed" \
+        --respond "$prompt" --debug-field \
+        --no-wonder-appetite-checkpoint --save "$OUT/off/state" \
+        > "$OUT/off/turn-$turn.log" 2>&1
+    [ "$(reply_from_log "$OUT/on/turn-$turn.log")" = \
+      "$(reply_from_log "$OUT/off/turn-$turn.log")" ] || {
+        printf 'checkpoint writer changed Leo reply at turn %d\n' \
+            "$turn" >&2
+        exit 1
+    }
+    reply_equal=$((reply_equal + 1))
+done
+
+report="$(report_from_log "$OUT/on/turn-$TURNS.log")"
+[ -n "$report" ] || {
+    printf 'natural life emitted no checkpoint receipt\n' >&2
+    exit 1
+}
+[ -z "$(report_from_log "$OUT/off/turn-$TURNS.log")" ] || {
+    printf 'checkpoint receipt survived writer ablation\n' >&2
+    exit 1
+}
+IFS=$'\t' read -r _ _ budget epochs history active terminal blocked \
+    checkpoint_cells one stable emerging persistent recovered \
+    insufficient incompatible sequence_cells <<< "$report"
+cell="$(cell_values "$checkpoint_cells")"
+[ -n "$cell" ] || {
+    printf 'natural life lost its u62-70 lane\n' >&2
+    exit 1
+}
+IFS=$'\t' read -r next_after blocked_cell active_after active_through \
+    active_attempts active_status active_sources active_max \
+    active_early_sources active_early_max active_recent_sources \
+    active_recent_max n first_after first_through first_status \
+    first_sources first_max first_early_sources first_early_max \
+    first_recent_sources first_recent_max \
+    _ _ _ _ _ _ _ _ _ _ \
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ extra <<< "$cell"
+
+sequence_status="$(
+    printf '%s\n' "$sequence_cells" |
+        awk -F '[:/]' '$1 == "u62-70" { print $6 }'
+)"
+checkpoint_tail="$("$OUT/holdout-fixture" --checkpoint-tail-size)"
+state_size="$(wc -c < "$OUT/on/state" | tr -d ' ')"
+prefix_size=$((state_size - checkpoint_tail))
+prefix_equal=0
+[ "$prefix_size" -gt 0 ] &&
+    cmp -s -n "$prefix_size" "$OUT/on/state" "$OUT/off/state" &&
+    prefix_equal=1
+state_distinct=0
+cmp -s "$OUT/on/state" "$OUT/off/state" ||
+    state_distinct=1
+
+[ -z "${extra:-}" ] &&
+[ "$budget" = 32 ] && [ "$epochs" = 2 ] && [ "$history" = 2 ] &&
+[ "$terminal" = 1 ] && [ "$blocked" = 0 ] &&
+[ "$blocked_cell" = 0 ] && [ "$n" = 1 ] &&
+[ "$first_status" = source-starved ] &&
+[ "$first_sources" = 1 ] && [ "$first_max" = 32 ] &&
+[ "$first_early_sources" = 1 ] && [ "$first_early_max" = 16 ] &&
+[ "$first_recent_sources" = 1 ] && [ "$first_recent_max" = 16 ] &&
+[ "$insufficient" = 1 ] && [ "$sequence_status" = insufficient ] &&
+[ "$reply_equal" = "$TURNS" ] && [ "$prefix_equal" = 1 ] &&
+[ "$state_distinct" = 1 ] || {
+    printf 'natural checkpoint contract failed: terminal=%s n=%s status=%s sources=%s/%s epochs=%s/%s|%s/%s sequence=%s replies=%s prefix=%s distinct=%s\n' \
+        "$terminal" "$n" "$first_status" "$first_sources" \
+        "$first_max" "$first_early_sources" "$first_early_max" \
+        "$first_recent_sources" "$first_recent_max" "$sequence_status" \
+        "$reply_equal" "$prefix_equal" "$state_distinct" >&2
+    exit 1
+}
+
+MATRIX="$OUT/matrix.tsv"
+printf 'case\ttarget\tturns\tterminal\tstatus\tsources\tmax_source\tearly_sources\tearly_max_source\trecent_sources\trecent_max_source\treply_equal\tbody_prefix_equal\tcheckpoint_tail_distinct\n' > "$MATRIX"
+printf 'one-wonder-cycle\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$TARGET" "$TURNS" "$terminal" "$first_status" \
+    "$first_sources" "$first_max" "$first_early_sources" \
+    "$first_early_max" "$first_recent_sources" "$first_recent_max" \
+    "$reply_equal" "$prefix_equal" "$state_distinct" >> "$MATRIX"
+
+cat "$MATRIX"
+printf '\nfinal receipt: %s/on/turn-%d.log\n' "$OUT" "$TURNS"

--- a/scripts/deferred_wonder_appetite_checkpoint_matrix.sh
+++ b/scripts/deferred_wonder_appetite_checkpoint_matrix.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# A.55: persist non-overlapping transport lives and classify their sequence.
+# A.56: persist non-overlapping, source-aware transport lives.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -20,6 +20,7 @@ printf 'checkpoint-emerging\t2\tearly-shifted\temerging-shift\n' >> "$PLAN"
 printf 'checkpoint-persistent\t2\trecent-shifted\tpersistent-shift\n' >> "$PLAN"
 printf 'checkpoint-recovered\t2\tprovisional\trecovered\n' >> "$PLAN"
 printf 'checkpoint-insufficient\t2\tcoverage-starved\tinsufficient\n' >> "$PLAN"
+printf 'checkpoint-source-starved\t1\tsource-starved\tinsufficient\n' >> "$PLAN"
 printf 'checkpoint-incompatible\t1\tincompatible\tincompatible\n' >> "$PLAN"
 printf 'checkpoint-pending\t0\tpending\tempty\n' >> "$PLAN"
 
@@ -60,7 +61,7 @@ cell_values() {
                     split(items[i], pair, /:/)
                     if (pair[1] != wanted) continue
                     split(pair[2], values, /\//)
-                    for (j = 1; j <= 33; j++)
+                    for (j = 1; j <= 51; j++)
                         printf "%s%s", (j == 1 ? "" : "\t"), values[j]
                     printf "\n"
                     exit
@@ -92,7 +93,7 @@ sequence_status() {
 }
 
 # Writer isolation: identical evidence with the organ on/off may differ only
-# in the fixed v25 tail, and the distinct states must still speak identically.
+# in the fixed v26 tail, and the distinct states must still speak identically.
 "$OUT/holdout-fixture" "$OUT/writer-on.state" checkpoint-one
 "$OUT/holdout-fixture" "$OUT/writer-off.state" checkpoint-ablated
 checkpoint_tail="$("$OUT/holdout-fixture" --checkpoint-tail-size)"
@@ -102,7 +103,7 @@ writer_prefix=$((writer_size - checkpoint_tail))
     cmp -s -n "$writer_prefix" \
         "$OUT/writer-on.state" "$OUT/writer-off.state" &&
     ! cmp -s "$OUT/writer-on.state" "$OUT/writer-off.state" || {
-        printf 'checkpoint writer escaped its v25 tail\n' >&2
+        printf 'checkpoint writer escaped its v26 tail\n' >&2
         exit 1
     }
 for side in on off; do
@@ -123,7 +124,7 @@ writer_reply_equal=0
 }
 
 MATRIX="$OUT/matrix.tsv"
-printf 'case\tn\tactive_attempts\trecent\tsequence\tchronological\treply_equal\tstate_equal\n' > "$MATRIX"
+printf 'case\tn\tactive_attempts\trecent\tsequence\tsources\tmax_source\tearly_sources\tearly_max_source\trecent_sources\trecent_max_source\tchronological\treply_equal\tstate_equal\n' > "$MATRIX"
 
 tail -n +2 "$PLAN" |
 while IFS=$'\t' read -r case_name expected_n \
@@ -148,7 +149,7 @@ while IFS=$'\t' read -r case_name expected_n \
 
     report="$(report_from_log "$case_dir/on.log" "$case_name" "$seed")"
     [ -n "$report" ] || {
-        printf '%s emitted no A.55 checkpoint witness\n' \
+        printf '%s emitted no A.56 checkpoint witness\n' \
             "$case_name" >&2
         exit 1
     }
@@ -168,18 +169,42 @@ while IFS=$'\t' read -r case_name expected_n \
         exit 1
     }
     IFS=$'\t' read -r next_after blocked_cell active_after \
-        active_through active_attempts active_status n \
+        active_through active_attempts active_status \
+        active_sources active_max active_early_sources active_early_max \
+        active_recent_sources active_recent_max n \
         first_after first_through first_status \
+        first_sources first_max first_early_sources first_early_max \
+        first_recent_sources first_recent_max \
         _ _ _ _ _ _ _ _ _ _ \
         second_after second_through second_status \
+        second_sources second_max second_early_sources second_early_max \
+        second_recent_sources second_recent_max \
         _ _ _ _ _ _ _ _ _ _ extra <<< "$cell"
 
     if [ "$n" = 0 ]; then
         recent="$active_status"
+        sources="$active_sources"
+        max_source="$active_max"
+        early_sources="$active_early_sources"
+        early_max="$active_early_max"
+        recent_sources="$active_recent_sources"
+        recent_max="$active_recent_max"
     elif [ "$n" = 1 ]; then
         recent="$first_status"
+        sources="$first_sources"
+        max_source="$first_max"
+        early_sources="$first_early_sources"
+        early_max="$first_early_max"
+        recent_sources="$first_recent_sources"
+        recent_max="$first_recent_max"
     else
         recent="$second_status"
+        sources="$second_sources"
+        max_source="$second_max"
+        early_sources="$second_early_sources"
+        early_max="$second_early_max"
+        recent_sources="$second_recent_sources"
+        recent_max="$second_recent_max"
     fi
     actual_sequence="$(
         sequence_status "$sequence_cells" u62-70
@@ -208,6 +233,28 @@ while IFS=$'\t' read -r case_name expected_n \
     if [ "$case_name" = checkpoint-incompatible ]; then
         expected_blocked=1
     fi
+    expected_sources=32
+    expected_max=1
+    expected_early_sources=16
+    expected_early_max=1
+    expected_recent_sources=16
+    expected_recent_max=1
+    if [ "$case_name" = checkpoint-pending ]; then
+        expected_sources=31
+        expected_recent_sources=15
+    elif [ "$case_name" = checkpoint-incompatible ]; then
+        expected_sources=1
+        expected_early_sources=1
+        expected_recent_sources=0
+        expected_recent_max=0
+    elif [ "$case_name" = checkpoint-source-starved ]; then
+        expected_sources=1
+        expected_max=32
+        expected_early_sources=1
+        expected_early_max=16
+        expected_recent_sources=1
+        expected_recent_max=16
+    fi
 
     [ -z "${extra:-}" ] &&
     [ "$budget" = 32 ] && [ "$epochs" = 2 ] &&
@@ -219,6 +266,12 @@ while IFS=$'\t' read -r case_name expected_n \
     [ "$n" = "$expected_n" ] &&
     [ "$recent" = "$expected_recent" ] &&
     [ "$actual_sequence" = "$expected_sequence" ] &&
+    [ "$sources" = "$expected_sources" ] &&
+    [ "$max_source" = "$expected_max" ] &&
+    [ "$early_sources" = "$expected_early_sources" ] &&
+    [ "$early_max" = "$expected_early_max" ] &&
+    [ "$recent_sources" = "$expected_recent_sources" ] &&
+    [ "$recent_max" = "$expected_recent_max" ] &&
     [ "$chronological" = 1 ] &&
     [ "$reply_equal" = 1 ] && [ "$state_equal" = 1 ] || {
         printf '%s checkpoint contract failed: n=%s active=%s/%s recent=%s sequence=%s chronological=%s reply=%s state=%s\n' \
@@ -228,25 +281,26 @@ while IFS=$'\t' read -r case_name expected_n \
         exit 1
     }
 
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
         "$case_name" "$n" "$active_attempts" "$recent" \
-        "$actual_sequence" "$chronological" \
-        "$reply_equal" "$state_equal" >> "$MATRIX"
+        "$actual_sequence" "$sources" "$max_source" \
+        "$early_sources" "$early_max" "$recent_sources" "$recent_max" \
+        "$chronological" "$reply_equal" "$state_equal" >> "$MATRIX"
 done
 
 awk -F '\t' -v writer_reply_equal="$writer_reply_equal" '
     NR > 1 {
         rows++
-        chronology += $6
-        replies += $7
-        states += $8
+        chronology += $12
+        replies += $13
+        states += $14
     }
     END {
         print "cases\tchronological\treply_equal\tstate_equal\twriter_prefix_equal\twriter_reply_equal"
         print rows "\t" chronology "\t" replies "\t" states \
               "\t1\t" writer_reply_equal
-        if (rows != 8 || chronology != 8 ||
-            replies != 8 || states != 8 ||
+        if (rows != 9 || chronology != 9 ||
+            replies != 9 || states != 9 ||
             writer_reply_equal != 1)
             exit 1
     }

--- a/scripts/test_deferred_wonder_appetite_checkpoint_life.sh
+++ b/scripts/test_deferred_wonder_appetite_checkpoint_life.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+got="$(
+    LEO_APPETITE_CHECKPOINT_LIFE_PLAN_ONLY=1 \
+        "$ROOT/scripts/deferred_wonder_appetite_checkpoint_life.sh"
+)"
+expected=$'case\ttarget\tturns\texpected_status\texpected_sources\texpected_max_source\none-wonder-cycle\tsuvin\t145\tsource-starved\t1\t32'
+
+[ "$got" = "$expected" ] || {
+    printf 'invalid natural checkpoint life plan:\n%s\n' "$got" >&2
+    exit 1
+}
+printf 'deferred Wonder appetite natural checkpoint life plan: ok\n'

--- a/scripts/test_deferred_wonder_appetite_checkpoint_matrix.sh
+++ b/scripts/test_deferred_wonder_appetite_checkpoint_matrix.sh
@@ -25,6 +25,7 @@ awk -F '\t' '
         expected["checkpoint-persistent"] = "2/recent-shifted/persistent-shift"
         expected["checkpoint-recovered"] = "2/provisional/recovered"
         expected["checkpoint-insufficient"] = "2/coverage-starved/insufficient"
+        expected["checkpoint-source-starved"] = "1/source-starved/insufficient"
         expected["checkpoint-incompatible"] = "1/incompatible/incompatible"
         expected["checkpoint-pending"] = "0/pending/empty"
         if (($2 "/" $3 "/" $4) != expected[$1])
@@ -32,7 +33,7 @@ awk -F '\t' '
         rows++
     }
     END {
-        if (rows != 8)
+        if (rows != 9)
             exit 1
     }
 ' "$OUT/plan.tsv" || {

--- a/scripts/test_wonder_appetite_checkpoint_dialogue_report.sh
+++ b/scripts/test_wonder_appetite_checkpoint_dialogue_report.sh
@@ -6,7 +6,7 @@ TMP="$(mktemp)"
 trap 'rm -f "$TMP"' EXIT
 
 cat > "$TMP" <<'EOF'
-     [wonder-appetite-checkpoint: budget=32 epochs=2 history=2 active=0 terminal=2 blocked=0 cells=u62-70:390/0/0/0/0/empty/2/134/262/provisional/16/8/8/1/1/16/8/8/1/1/262/390/provisional/16/8/8/1/1/16/8/8/1/1]
+     [wonder-appetite-checkpoint: budget=32 epochs=2 history=2 active=0 terminal=2 blocked=0 cells=u62-70:390/0/0/0/0/empty/0/0/0/0/0/0/2/134/262/provisional/32/1/16/1/16/1/16/8/8/1/1/16/8/8/1/1/262/390/provisional/32/1/16/1/16/1/16/8/8/1/1/16/8/8/1/1]
      [wonder-appetite-checkpoint-sequence: one=0 stable-provisional=1 emerging-shift=0 persistent-shift=0 recovered=0 insufficient=0 incompatible=0 cells=u62-70:2/provisional/provisional/1/stable-provisional]
 EOF
 
@@ -15,7 +15,7 @@ got="$(
         -f "$ROOT/scripts/wonder_appetite_checkpoint_dialogue_report.awk" \
         "$TMP"
 )"
-expected=$'checkpoint-stable\t5501\t32\t2\t2\t0\t2\t0\tu62-70:390/0/0/0/0/empty/2/134/262/provisional/16/8/8/1/1/16/8/8/1/1/262/390/provisional/16/8/8/1/1/16/8/8/1/1\t0\t1\t0\t0\t0\t0\t0\tu62-70:2/provisional/provisional/1/stable-provisional'
+expected=$'checkpoint-stable\t5501\t32\t2\t2\t0\t2\t0\tu62-70:390/0/0/0/0/empty/0/0/0/0/0/0/2/134/262/provisional/32/1/16/1/16/1/16/8/8/1/1/16/8/8/1/1/262/390/provisional/32/1/16/1/16/1/16/8/8/1/1/16/8/8/1/1\t0\t1\t0\t0\t0\t0\t0\tu62-70:2/provisional/provisional/1/stable-provisional'
 
 if [ "$got" != "$expected" ]; then
     printf 'unexpected Wonder appetite checkpoint parser output:\n%s\n' \

--- a/scripts/wonder_appetite_checkpoint_dialogue_report.awk
+++ b/scripts/wonder_appetite_checkpoint_dialogue_report.awk
@@ -1,4 +1,4 @@
-# Extract the A.55 raw checkpoint and two-life sequence from a Leo debug log.
+# Extract the A.56 source-aware checkpoint and sequence from a Leo debug log.
 
 function clean(value) {
     gsub(/\t/, "\\t", value)

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -735,7 +735,7 @@ static void test_wonder_appetite_regret_surface(void) {
                   sizeof *school_before) &&
           !memcmp(flow_before, &leo->flow,
                   sizeof *flow_before) &&
-          LEO_STATE_VERSION == 25,
+          LEO_STATE_VERSION == 26,
           "wonder-appetite-regret: observing cost rewrites no evidence, body, or state format");
     free(school_before);
     free(flow_before);
@@ -864,7 +864,7 @@ static void test_wonder_appetite_readiness_frontier(void) {
                   sizeof *school_before) &&
           !memcmp(flow_before, &leo->flow,
                   sizeof *flow_before) &&
-          LEO_STATE_VERSION == 25,
+          LEO_STATE_VERSION == 26,
           "wonder-appetite-readiness: candidacy rewrites no evidence, body, or state format");
     free(school_before);
     free(flow_before);
@@ -929,6 +929,14 @@ static void test_wonder_appetite_holdout_trial(void) {
     g_leo_wonder_appetite_calibration_on = 1;
     g_leo_wonder_appetite_policy_on = 1;
     g_leo_wonder_appetite_admission_on = 1;
+
+    LeoWonderAppetiteCalibrationReceipt upper_source = {0};
+    LeoWonderAppetiteCalibrationReceipt lower_source = {0};
+    snprintf(upper_source.word, sizeof upper_source.word, "Suvin");
+    snprintf(lower_source.word, sizeof lower_source.word, "suvin");
+    CHECK(leo_wonder_appetite_source_id(&upper_source) ==
+              leo_wonder_appetite_source_id(&lower_source),
+          "wonder-appetite-checkpoint: spelling case cannot counterfeit a second source");
 
     leo_init(leo);
     LeoWonderAppetiteHoldoutTrial *trial =
@@ -1457,7 +1465,7 @@ static void test_wonder_appetite_transport_witness(void) {
               LEO_WONDER_APPETITE_TRANSPORT_PROVISIONAL,
           "wonder-appetite-transport: a confirmed result remains applicable only on a new bounded life");
     CHECK(!memcmp(before, leo, sizeof *leo) &&
-          LEO_STATE_VERSION == 25,
+          LEO_STATE_VERSION == 26,
           "wonder-appetite-transport: reading applicability rewrites no body, evidence, or state format");
 
     leo_free(leo);
@@ -1697,7 +1705,7 @@ static void test_wonder_appetite_transport_chronology(void) {
               LEO_WONDER_APPETITE_CHRONOLOGY_PROVISIONAL,
           "wonder-appetite-transport-chronology: two bounded adjacent eras preserve only provisional continuity");
     CHECK(!memcmp(before, leo, sizeof *leo) &&
-          LEO_STATE_VERSION == 25,
+          LEO_STATE_VERSION == 26,
           "wonder-appetite-transport-chronology: reading eras rewrites no body, evidence, or state format");
 
     leo_free(leo);
@@ -1879,6 +1887,7 @@ enum {
     TEST_APPETITE_CHECKPOINT_EARLY_SHIFT,
     TEST_APPETITE_CHECKPOINT_RECENT_SHIFT,
     TEST_APPETITE_CHECKPOINT_COVERAGE_STARVED,
+    TEST_APPETITE_CHECKPOINT_SOURCE_STARVED,
     TEST_APPETITE_CHECKPOINT_PENDING,
     TEST_APPETITE_CHECKPOINT_MIXED,
     TEST_APPETITE_CHECKPOINT_INCOMPATIBLE
@@ -1898,7 +1907,8 @@ static void test_add_appetite_checkpoint_pattern(
     uint64_t proposed = boundary + 4;
     test_reset_appetite_policy_outcomes(leo);
 
-    if (pattern == TEST_APPETITE_CHECKPOINT_PROVISIONAL) {
+    if (pattern == TEST_APPETITE_CHECKPOINT_PROVISIONAL ||
+        pattern == TEST_APPETITE_CHECKPOINT_SOURCE_STARVED) {
         proposed = test_add_appetite_transport_epoch(
             leo, proposed, 0.65f, 0, 7, 1, 1, 7);
         test_add_appetite_transport_epoch(
@@ -1952,6 +1962,13 @@ static void test_add_appetite_checkpoint_pattern(
             LEO_WONDER_APPETITE_POLICY_LEGACY,
             LEO_WONDER_APPETITE_CALIB_SUSTAINED);
     }
+    if (pattern == TEST_APPETITE_CHECKPOINT_SOURCE_STARVED)
+        for (int i = 0;
+             i < leo->wonder_appetite_calibration.n; i++)
+            snprintf(
+                leo->wonder_appetite_calibration.receipts[i].word,
+                sizeof leo->wonder_appetite_calibration.receipts[i].word,
+                "monowonder");
     leo_wonder_appetite_checkpoint_update(leo);
 }
 
@@ -2119,6 +2136,35 @@ static void test_wonder_appetite_transport_checkpoints(void) {
     leo_init(leo);
     test_prepare_appetite_transport(leo);
     test_add_appetite_checkpoint_pattern(
+        leo, TEST_APPETITE_CHECKPOINT_SOURCE_STARVED);
+    lane = &leo->wonder_appetite_checkpoints.lanes[0];
+    first = leo_wonder_appetite_checkpoint_at(lane, 0);
+    LeoWonderAppetiteCheckpointSources sources;
+    leo_wonder_appetite_checkpoint_sources(first, &sources);
+    leo_wonder_appetite_checkpoint_sequence(leo, &sequence);
+    CHECK(first &&
+          first->status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_SOURCE_STARVED &&
+          sources.distinct == 1 &&
+          sources.max_attempts == 32 &&
+          sources.epoch_distinct[0] == 1 &&
+          sources.epoch_distinct[1] == 1 &&
+          sources.epoch_max_attempts[0] == 16 &&
+          sources.epoch_max_attempts[1] == 16 &&
+          sequence.insufficient == 1 &&
+          sequence.cells[0].status ==
+              LEO_WONDER_APPETITE_CHECKPOINT_SEQUENCE_INSUFFICIENT,
+          "wonder-appetite-checkpoint: one recurring Wonder cannot impersonate a transport life");
+    LeoWonderAppetiteCheckpointLane source_before = *lane;
+    lane->history[0].seen_source_id[0] = 0;
+    CHECK(!leo_wonder_appetite_checkpoints_valid(leo),
+          "wonder-appetite-checkpoint: a used attempt cannot lose its source identity");
+    *lane = source_before;
+
+    leo_free(leo);
+    leo_init(leo);
+    test_prepare_appetite_transport(leo);
+    test_add_appetite_checkpoint_pattern(
         leo, TEST_APPETITE_CHECKPOINT_PENDING);
     lane = &leo->wonder_appetite_checkpoints.lanes[0];
     CHECK(lane->n == 0 &&
@@ -2131,22 +2177,25 @@ static void test_wonder_appetite_transport_checkpoints(void) {
           "wonder-appetite-checkpoint: thirty-one settled attempts persist as an unfinished life");
 
     const char *state =
+        "/tmp/leo_appetite_checkpoint_v26.state";
+    const char *v25 =
         "/tmp/leo_appetite_checkpoint_v25.state";
     const char *v24 =
         "/tmp/leo_appetite_checkpoint_v24.state";
     const char *cut =
-        "/tmp/leo_appetite_checkpoint_v25_cut.state";
+        "/tmp/leo_appetite_checkpoint_v26_cut.state";
     const char *bad =
-        "/tmp/leo_appetite_checkpoint_v25_bad.state";
+        "/tmp/leo_appetite_checkpoint_v26_bad.state";
     int saved = leo_save_state(leo, state);
     leo_init(woke);
     CHECK(saved && leo_load_state(woke, state) &&
           !memcmp(&woke->wonder_appetite_checkpoints,
                   &leo->wonder_appetite_checkpoints,
                   sizeof leo->wonder_appetite_checkpoints),
-          "wonder-appetite-checkpoint: an unfinished raw life survives v25 sleep exactly");
+          "wonder-appetite-checkpoint: an unfinished source-aware life survives v26 sleep exactly");
 
-    int built_v24 = 0, built_cut = 0, built_bad = 0;
+    int built_v25 = 0, built_v24 = 0;
+    int built_cut = 0, built_bad = 0;
     FILE *fi = fopen(state, "rb");
     if (fi) {
         fseek(fi, 0, SEEK_END);
@@ -2174,6 +2223,19 @@ static void test_wonder_appetite_transport_checkpoints(void) {
             uint32_t twenty_five = 25;
             memcpy(bytes + sizeof(uint32_t), &twenty_five,
                    sizeof twenty_five);
+            fo = fopen(v25, "wb");
+            if (fo) {
+                built_v25 =
+                    (long)fwrite(
+                        bytes, 1,
+                        (size_t)(size - checkpoint_tail), fo) ==
+                    size - checkpoint_tail;
+                fclose(fo);
+            }
+
+            uint32_t twenty_six = 26;
+            memcpy(bytes + sizeof(uint32_t), &twenty_six,
+                   sizeof twenty_six);
             fo = fopen(cut, "wb");
             if (fo) {
                 built_cut =
@@ -2187,8 +2249,7 @@ static void test_wonder_appetite_transport_checkpoints(void) {
             memcpy(&corrupted,
                    bytes + size - checkpoint_tail,
                    sizeof corrupted);
-            corrupted.lanes[0].active.seen_proposed_turn[1] =
-                corrupted.lanes[0].active.seen_proposed_turn[0];
+            corrupted.lanes[0].active.seen_source_id[0] = 0;
             memcpy(bytes + size - checkpoint_tail,
                    &corrupted, sizeof corrupted);
             fo = fopen(bad, "wb");
@@ -2214,6 +2275,18 @@ static void test_wonder_appetite_transport_checkpoints(void) {
                       proposed_turn,
           "wonder-appetite-checkpoint: v24 migration starts after existing history instead of inventing a checkpoint");
 
+    leo_free(old);
+    leo_init(old);
+    CHECK(built_v25 && leo_load_state(old, v25) &&
+          old->wonder_appetite_checkpoints.lanes[0].n == 0 &&
+          old->wonder_appetite_checkpoints.lanes[0].active.status ==
+              LEO_WONDER_APPETITE_CHRONOLOGY_EMPTY &&
+          old->wonder_appetite_checkpoints.lanes[0].
+              next_after_proposed_turn ==
+                  leo->wonder_appetite_calibration.receipts[30].
+                      proposed_turn,
+          "wonder-appetite-checkpoint: v25 evidence restarts after history instead of inventing source identity");
+
     leo_init(damaged);
     CHECK(built_cut && leo_load_state(damaged, cut) &&
           !memcmp(&damaged->wonder_appetite_holdouts,
@@ -2227,7 +2300,7 @@ static void test_wonder_appetite_transport_checkpoints(void) {
               next_after_proposed_turn ==
                   leo->wonder_appetite_calibration.receipts[30].
                       proposed_turn,
-          "wonder-appetite-checkpoint: a truncated v25 ledger loses no body, trial, or admission");
+          "wonder-appetite-checkpoint: a truncated v26 ledger loses no body, trial, or admission");
 
     leo_free(damaged);
     leo_init(damaged);
@@ -2240,8 +2313,9 @@ static void test_wonder_appetite_transport_checkpoints(void) {
               next_after_proposed_turn ==
                   leo->wonder_appetite_calibration.receipts[30].
                       proposed_turn,
-          "wonder-appetite-checkpoint: corrupt proposal identity fails soft and cannot be replayed");
+          "wonder-appetite-checkpoint: corrupt source identity fails soft and cannot be replayed");
     remove(state);
+    remove(v25);
     remove(v24);
     remove(cut);
     remove(bad);

--- a/tests/wonder_appetite_holdout_fixture.c
+++ b/tests/wonder_appetite_holdout_fixture.c
@@ -180,6 +180,7 @@ static int checkpoint_scenario(const char *scenario) {
         !strcmp(scenario, "checkpoint-persistent") ||
         !strcmp(scenario, "checkpoint-recovered") ||
         !strcmp(scenario, "checkpoint-insufficient") ||
+        !strcmp(scenario, "checkpoint-source-starved") ||
         !strcmp(scenario, "checkpoint-incompatible") ||
         !strcmp(scenario, "checkpoint-pending") ||
         !strcmp(scenario, "checkpoint-ablated");
@@ -356,7 +357,19 @@ static int add_checkpoint_life(
     memset(&leo->wonder_appetite_calibration, 0,
            sizeof leo->wonder_appetite_calibration);
     proposed_base = boundary + 4;
-    int ok = add_chronology_present(leo, chronology);
+    const char *evidence =
+        !strcmp(chronology, "chronology-source-starved") ?
+            "chronology-provisional" : chronology;
+    int ok = add_chronology_present(leo, evidence);
+    if (ok &&
+        !strcmp(chronology, "chronology-source-starved"))
+        for (int i = 0;
+             i < leo->wonder_appetite_calibration.n; i++)
+            snprintf(
+                leo->wonder_appetite_calibration.receipts[i].word,
+                sizeof
+                    leo->wonder_appetite_calibration.receipts[i].word,
+                "monowonder");
     if (ok) leo_wonder_appetite_checkpoint_update(leo);
     return ok;
 }
@@ -396,6 +409,9 @@ static int build_checkpoint_scenario(
                 leo, "chronology-provisional") &&
             add_checkpoint_life(
                 leo, "chronology-coverage-starved");
+    if (!strcmp(scenario, "checkpoint-source-starved"))
+        return add_checkpoint_life(
+            leo, "chronology-source-starved");
     if (!strcmp(scenario, "checkpoint-incompatible"))
         return add_checkpoint_life(
             leo, "chronology-incompatible");


### PR DESCRIPTION
Persist source identity beside checkpoint proposal identity, reject source-starved lives, and reproduce the original false life across 145 real process turns.

Quote: "A repeated question is one witness, however long it echoes." - Sol

Method: The Arianna Method counts distinct sources before recurrence may testify about a world.