### PR TITLE
leo grants reference one statement at a time

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -6530,3 +6530,119 @@ make deferred-wonder-answer-reference-life
 
 Leo may ask a nearby human turn whether it belongs to his question. He may not
 decide that nearness itself is the answer.
+
+## Phase A.76 — a reference licenses a statement, not a turn (2026-07-31)
+
+A.75 established whether a human turn referred to Leo's question, but then
+gave every teachable glyph in that turn the same authority. One exact open
+Wonder exposed the leak:
+
+```text
+Leo:  Zorble? Water or Animal?
+human: it is an animal. the river has water
+```
+
+The first statement was an immediate anaphoric answer. The second was ordinary
+life. Canon nevertheless pooled both statements, tied ANIMAL with WATER, and
+learned `zorble=water` because WATER has the lower glyph index. Naming the word
+did not help:
+
+```text
+a zorble is an animal. the river has water
+```
+
+also learned WATER. Reference had become permission to conscript a whole turn.
+
+A.76 makes School evidence range-bounded. Strong statement punctuation
+(`. ; : ! ?`) divides the human turn before epistemic evidence is collected:
+
+- every statement that explicitly names the pending word may contribute;
+- without an explicit name, only the first substantive statement after
+  optional standalone `yes/no` markers may answer;
+- that first statement must begin anaphorically or satisfy the existing
+  offered-option ellipse contract;
+- a later anaphor after a new subject cannot reach backward and seize the
+  old question.
+
+This preserves useful composition without restoring adjacency. Two separately
+explicit statements may cooperate:
+
+```text
+a zorble is not water. a zorble is an animal
+```
+
+The first rejects WATER and the second asserts ANIMAL. By contrast:
+
+```text
+the river has water. it is an animal
+```
+
+remains unfinished. The first statement established a new subject before the
+pronoun appeared.
+
+The first red A.76 test found a second defect rather than a bad expectation.
+`the river has water` projected entirely onto Leo's WATER glyph and therefore
+passed the semantic ellipse test despite being a complete proposition. A
+bounded surface check now requires every unmarked elliptical word to be either
+answer grammar or a word mapped to one of Leo's offered alternatives. An
+independent predicate such as `has` or `flows` fails closed. Copulas are not
+ellipse grammar: `the river is water` is also a proposition, while `it is
+water` remains valid through its separate anaphoric reference.
+
+This parser still does not claim general syntax or coreference. Commas remain
+inside one statement because Leo's established answer grammar uses them for
+`yes, it is music` and `not water, but animal`. Attribution across independent
+comma-spliced clauses remains a later boundary requiring its own evidence.
+
+Only School receives the scoped evidence. `leo_ingest`, chambers, gamma,
+conatus, and both Flow faces continue to receive the complete prompt. On:
+
+```text
+it is an animal. the river has water
+```
+
+School learns ANIMAL while Flow still reports WATER as the dominant perceived
+glyph. The distinction from A.74 and A.75 therefore remains intact:
+
+```text
+perception   the complete lived human turn
+reference    which bounded statement belongs to the Wonder
+assertion    which meanings inside that statement may teach
+```
+
+One persisted open body branches ten answers, and every branch crosses a
+second process boundary. A resolved branch asks about a new `flom`; its
+question can name the correct glyph only if the saved `zorble` lesson is
+correct. An unresolved branch must re-ask the original or narrowed Wonder:
+
+```text
+case                outcome     followup                   learned
+anaphoric-tail      resolved    Flom? Animal?              animal
+explicit-tail       resolved    Flom? Animal?              animal
+explicit-late       resolved    Flom? Animal?              animal
+later-anaphora      continued   Zorble? Water or Animal?   none
+marker-anaphora     resolved    Flom? Music?               music
+negative-tail       continued   Zorble? Animal?            none
+explicit-pair       resolved    Flom? Animal?              animal
+elliptic-tail       resolved    Flom? Animal?              animal
+predicate-ellipse   continued   Zorble? Water or Animal?   none
+copula-ellipse      continued   Zorble? Water or Animal?   none
+```
+
+Two complete 21-process lives reproduced the table exactly. The open state is
+still byte-identical to A.75
+(`17d65d5af898d0d5213fba0e157cde9791f91ec16169e7b912c852e084f85bda`);
+the A.76 result table is pinned as
+`b9b4f65613097427ee22636422d623397d0f90e812cfe513d484e915eb45ccef`.
+The direct suite is **515/515**, all historical dialogue/matrix plan gates are
+green, and a heap-only A.76 responder smoke passes ASan/UBSan.
+
+No persisted byte, state version, weight, candidate, sampler, chamber, gamma
+value, Flow reader, or speech path changed. The receipt is:
+
+```sh
+make deferred-wonder-answer-scope-life
+```
+
+Leo can hear everything a person says without making every sentence answer
+the question he happened to ask first.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life
 
 all: leo
 
@@ -160,6 +160,9 @@ deferred-wonder-negation-life: leo
 deferred-wonder-answer-reference-life: leo
 	./scripts/deferred_wonder_answer_reference_life.sh
 
+deferred-wonder-answer-scope-life: leo
+	./scripts/deferred_wonder_answer_scope_life.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -218,6 +221,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_capsule_interaction_population.sh
 	./scripts/test_deferred_wonder_negation_life.sh
 	./scripts/test_deferred_wonder_answer_reference_life.sh
+	./scripts/test_deferred_wonder_answer_scope_life.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -5651,15 +5651,17 @@ static int leo_school_negation_punctuation(unsigned char ch) {
            ch == '!' || ch == '?';
 }
 
-static void leo_school_answer_evidence(
-        const Leo *leo, const char *text, LeoSchoolAnswerEvidence *evidence) {
+static void leo_school_answer_evidence_range(
+        const Leo *leo, const char *begin, const char *end,
+        LeoSchoolAnswerEvidence *evidence) {
     memset(evidence, 0, sizeof *evidence);
-    if (!leo || !text) return;
+    if (!leo || !begin || !end || end < begin) return;
 
     char cur[LEO_HEARD_WORDLEN];
     int wi = 0, negated = 0, word_index = 0, clause_words = 0;
-    for (const char *p = text; ; p++) {
-        unsigned char ch = (unsigned char)*p;
+    for (const char *p = begin; ; p++) {
+        unsigned char ch =
+            p < end ? (unsigned char)*p : 0;
         if (ch && (isalpha(ch) || ch == '\'')) {
             if (wi < LEO_HEARD_WORDLEN - 1)
                 cur[wi++] = (char)tolower(ch);
@@ -5724,11 +5726,49 @@ static void leo_school_answer_evidence(
     }
 }
 
-static int leo_school_prompt_has_anaphoric_subject(const char *text) {
+static void leo_school_answer_evidence(
+        const Leo *leo, const char *text,
+        LeoSchoolAnswerEvidence *evidence) {
+    if (!text) {
+        memset(evidence, 0, sizeof *evidence);
+        return;
+    }
+    leo_school_answer_evidence_range(
+        leo, text, text + strlen(text), evidence);
+}
+
+static int leo_school_range_has_word(
+        const char *begin, const char *end, const char *word) {
+    if (!begin || !end || end < begin || !word || !word[0])
+        return 0;
     char cur[LEO_HEARD_WORDLEN];
     int wi = 0;
-    for (const char *p = text; ; p++) {
-        unsigned char ch = (unsigned char)*p;
+    for (const char *p = begin; ; p++) {
+        unsigned char ch =
+            p < end ? (unsigned char)*p : 0;
+        if (ch && (isalpha(ch) || ch == '\'')) {
+            if (wi < LEO_HEARD_WORDLEN - 1)
+                cur[wi++] = (char)tolower(ch);
+            continue;
+        }
+        if (wi > 0) {
+            cur[wi] = 0;
+            if (!strcmp(cur, word)) return 1;
+        }
+        wi = 0;
+        if (!ch) break;
+    }
+    return 0;
+}
+
+static int leo_school_range_has_anaphoric_subject(
+        const char *begin, const char *end) {
+    if (!begin || !end || end < begin) return 0;
+    char cur[LEO_HEARD_WORDLEN];
+    int wi = 0;
+    for (const char *p = begin; ; p++) {
+        unsigned char ch =
+            p < end ? (unsigned char)*p : 0;
         if (ch && (isalpha(ch) || ch == '\'')) {
             if (wi < LEO_HEARD_WORDLEN - 1)
                 cur[wi++] = (char)tolower(ch);
@@ -5750,23 +5790,9 @@ static int leo_school_prompt_has_anaphoric_subject(const char *text) {
     return 0;
 }
 
-/* Adjacency is an answer window, not ownership. A rich answer may teach only
- * when it names the pending word or begins with an anaphoric subject. The one
- * unmarked form admitted by adjacency is an elliptical answer over Leo's own
- * offered alternatives: one asserted option, or one/more rejected options.
- * Other concept mass makes the turn new life rather than a counterfeit lesson. */
-static LeoSchoolAnswerReference leo_school_answer_reference(
-        const Leo *leo, const char *prompt,
-        const LeoSchoolAnswerEvidence *evidence) {
-    if (!leo || !prompt || !evidence || !leo->school.pending[0])
-        return LEO_SCHOOL_ANSWER_UNREFERENCED;
-    if (leo_school_text_has_word(prompt, leo->school.pending))
-        return LEO_SCHOOL_ANSWER_EXPLICIT;
-    if (leo->school.pending_turns != 0)
-        return LEO_SCHOOL_ANSWER_UNREFERENCED;
-    if (leo_school_prompt_has_anaphoric_subject(prompt))
-        return LEO_SCHOOL_ANSWER_ANAPHORIC;
-
+static int leo_school_evidence_is_elliptic(
+        const Leo *leo, const LeoSchoolAnswerEvidence *evidence) {
+    if (!leo || !evidence) return 0;
     int offered[2] = {
         leo->school.pending_glyph,
         leo->school.pending_alt_glyph
@@ -5778,15 +5804,179 @@ static LeoSchoolAnswerReference leo_school_answer_reference(
         if (!offered_here &&
             (evidence->asserted[g] > 0 ||
              evidence->rejected[g] > 0))
-            return LEO_SCHOOL_ANSWER_UNREFERENCED;
+            return 0;
         if (offered_here && evidence->asserted[g] > 0)
             asserted_options++;
         if (offered_here && evidence->rejected[g] > 0)
             rejected_options++;
     }
-    if (asserted_options == 1 ||
-        (asserted_options == 0 && rejected_options > 0))
-        return LEO_SCHOOL_ANSWER_ELLIPTIC;
+    return asserted_options == 1 ||
+           (asserted_options == 0 && rejected_options > 0);
+}
+
+static int leo_school_word_is_elliptic_grammar(
+        const char *word) {
+    static const char *grammar[] = {
+        "and", "or", "either"
+    };
+    if (leo_school_word_is_article(word) ||
+        leo_school_word_is_affirmation(word) ||
+        leo_school_word_negates(word) ||
+        leo_school_word_ends_negation(word))
+        return 1;
+    for (size_t i = 0; i < sizeof grammar / sizeof grammar[0]; i++)
+        if (!strcmp(word, grammar[i])) return 1;
+    return 0;
+}
+
+/* Glyph purity alone cannot prove ellipsis: "the river has water" can collapse
+ * entirely onto WATER. The surface must also lack an independent predicate.
+ * Every lexical word is therefore either bounded answer grammar or a word Leo
+ * maps to one of the alternatives he actually offered. */
+static int leo_school_range_is_elliptic(
+        const Leo *leo, const char *begin, const char *end,
+        const LeoSchoolAnswerEvidence *evidence) {
+    if (!leo_school_evidence_is_elliptic(leo, evidence))
+        return 0;
+    char cur[LEO_HEARD_WORDLEN];
+    int wi = 0, content = 0;
+    for (const char *p = begin; ; p++) {
+        unsigned char ch =
+            p < end ? (unsigned char)*p : 0;
+        if (ch && (isalpha(ch) || ch == '\'')) {
+            if (wi < LEO_HEARD_WORDLEN - 1)
+                cur[wi++] = (char)tolower(ch);
+            continue;
+        }
+        if (wi > 0) {
+            cur[wi] = 0;
+            if (!leo_school_word_is_elliptic_grammar(cur)) {
+                int g = leo_semtok_word(leo, cur);
+                if (!leo_glyph_teachable(g) ||
+                    (g != leo->school.pending_glyph &&
+                     g != leo->school.pending_alt_glyph))
+                    return 0;
+                content++;
+            }
+        }
+        wi = 0;
+        if (!ch) break;
+    }
+    return content > 0;
+}
+
+static int leo_school_range_is_dialogue_marker(
+        const char *begin, const char *end) {
+    if (!begin || !end || end < begin) return 0;
+    char cur[LEO_HEARD_WORDLEN];
+    int wi = 0, words = 0;
+    for (const char *p = begin; ; p++) {
+        unsigned char ch =
+            p < end ? (unsigned char)*p : 0;
+        if (ch && (isalpha(ch) || ch == '\'')) {
+            if (wi < LEO_HEARD_WORDLEN - 1)
+                cur[wi++] = (char)tolower(ch);
+            continue;
+        }
+        if (wi > 0) {
+            cur[wi] = 0;
+            words++;
+            if (!leo_school_word_is_affirmation(cur) &&
+                strcmp(cur, "no"))
+                return 0;
+        }
+        wi = 0;
+        if (!ch) break;
+    }
+    return words > 0;
+}
+
+static int leo_school_range_has_words(
+        const char *begin, const char *end) {
+    if (!begin || !end || end < begin) return 0;
+    for (const char *p = begin; p < end; p++)
+        if (isalpha((unsigned char)*p)) return 1;
+    return 0;
+}
+
+static int leo_school_answer_scope_boundary(unsigned char ch) {
+    return ch == '.' || ch == ';' || ch == ':' ||
+           ch == '!' || ch == '?';
+}
+
+static void leo_school_answer_evidence_add(
+        LeoSchoolAnswerEvidence *dst,
+        const LeoSchoolAnswerEvidence *src) {
+    if (!dst || !src) return;
+    for (int g = 0; g < GLYPH_COUNT; g++) {
+        dst->asserted[g] += src->asserted[g];
+        dst->rejected[g] += src->rejected[g];
+    }
+    dst->asserted_total += src->asserted_total;
+    dst->rejected_total += src->rejected_total;
+}
+
+/* A reference licenses evidence from a bounded statement, not every sentence
+ * that happens to share the same human turn. Explicitly named statements may
+ * occur later and may cooperate with one another. Without a name, only the
+ * first substantive statement after optional yes/no markers may answer: it
+ * must begin anaphorically or be an ellipse over Leo's offered alternatives.
+ * Sensorium, gamma, and Flow still receive the complete prompt. */
+static LeoSchoolAnswerReference leo_school_answer_scope(
+        const Leo *leo, const char *prompt,
+        LeoSchoolAnswerEvidence *evidence) {
+    memset(evidence, 0, sizeof *evidence);
+    if (!leo || !prompt || !leo->school.pending[0])
+        return LEO_SCHOOL_ANSWER_UNREFERENCED;
+
+    int explicit_statements = 0;
+    const char *begin = prompt;
+    for (const char *p = prompt; ; p++) {
+        unsigned char ch = (unsigned char)*p;
+        if (ch && !leo_school_answer_scope_boundary(ch))
+            continue;
+        if (leo_school_range_has_word(
+                begin, p, leo->school.pending)) {
+            LeoSchoolAnswerEvidence part;
+            leo_school_answer_evidence_range(
+                leo, begin, p, &part);
+            leo_school_answer_evidence_add(
+                evidence, &part);
+            explicit_statements++;
+        }
+        if (!ch) break;
+        begin = p + 1;
+    }
+    if (explicit_statements > 0)
+        return LEO_SCHOOL_ANSWER_EXPLICIT;
+    if (leo->school.pending_turns != 0)
+        return LEO_SCHOOL_ANSWER_UNREFERENCED;
+
+    begin = prompt;
+    for (const char *p = prompt; ; p++) {
+        unsigned char ch = (unsigned char)*p;
+        if (ch && !leo_school_answer_scope_boundary(ch))
+            continue;
+        if (leo_school_range_has_words(begin, p) &&
+            !leo_school_range_is_dialogue_marker(begin, p)) {
+            LeoSchoolAnswerEvidence part;
+            leo_school_answer_evidence_range(
+                leo, begin, p, &part);
+            if (leo_school_range_has_anaphoric_subject(
+                    begin, p)) {
+                *evidence = part;
+                return LEO_SCHOOL_ANSWER_ANAPHORIC;
+            }
+            if (leo_school_range_is_elliptic(
+                    leo, begin, p, &part)) {
+                *evidence = part;
+                return LEO_SCHOOL_ANSWER_ELLIPTIC;
+            }
+            return LEO_SCHOOL_ANSWER_UNREFERENCED;
+        }
+        if (!ch) break;
+        begin = p + 1;
+    }
     return LEO_SCHOOL_ANSWER_UNREFERENCED;
 }
 
@@ -6371,10 +6561,9 @@ static int leo_school_grounded_answer(
     if (observed) *observed = evidence;
     if (reference) *reference = LEO_SCHOOL_ANSWER_UNREFERENCED;
     if (!leo->school.pending[0] || strchr(prompt, '?')) return -1;
-    leo_school_answer_evidence(leo, prompt, &evidence);
-    if (observed) *observed = evidence;
     LeoSchoolAnswerReference ref =
-        leo_school_answer_reference(leo, prompt, &evidence);
+        leo_school_answer_scope(leo, prompt, &evidence);
+    if (observed) *observed = evidence;
     if (reference) *reference = ref;
     if (ref == LEO_SCHOOL_ANSWER_UNREFERENCED) return -1;
 

--- a/scripts/deferred_wonder_answer_scope_cases.tsv
+++ b/scripts/deferred_wonder_answer_scope_cases.tsv
@@ -1,0 +1,11 @@
+case	answer	outcome	pending	resolved	followup_prompt	followup_reply	perceived	learned
+anaphoric-tail	it is an animal. the river has water	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+explicit-tail	a zorble is an animal. the river has water	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+explicit-late	the river has water. a zorble is an animal	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+later-anaphora	the river has water. it is an animal	continued	zorble	0	what is zorble?	Zorble? Water or Animal?	water	none
+marker-anaphora	yes. it is music	resolved	none	1	is a flom zorble or music	Flom? Music?	music	music
+negative-tail	a zorble is not water. the sky is dark	continued	zorble	0	what is zorble?	Zorble? Animal?	water	none
+explicit-pair	a zorble is not water. a zorble is an animal	resolved	none	1	is a flom zorble or cat	Flom? Animal?	animal	animal
+elliptic-tail	animal. the river has water	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+predicate-ellipse	the river has water	continued	zorble	0	what is zorble?	Zorble? Water or Animal?	water	none
+copula-ellipse	the river is water	continued	zorble	0	what is zorble?	Zorble? Water or Animal?	water	none

--- a/scripts/deferred_wonder_answer_scope_life.sh
+++ b/scripts/deferred_wonder_answer_scope_life.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# A.76: one referenced statement cannot conscript the rest of a human turn.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CASES="$ROOT/scripts/deferred_wonder_answer_scope_cases.tsv"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-answer-scope-$STAMP}"
+
+if [ "${LEO_WONDER_SCOPE_PLAN_ONLY:-0}" = 1 ]; then
+    cases="$(($(wc -l < "$CASES") - 1))"
+    continued="$(
+        awk -F '\t' 'NR > 1 && $3 == "continued" {n++} END {print n + 0}' \
+            "$CASES"
+    )"
+    resolved="$(
+        awk -F '\t' 'NR > 1 && $3 == "resolved" {n++} END {print n + 0}' \
+            "$CASES"
+    )"
+    [ "$cases" -eq 10 ] &&
+        [ "$continued" -eq 4 ] &&
+        [ "$resolved" -eq 6 ] || {
+        printf 'answer-scope life cases do not satisfy the sealed plan\n' >&2
+        exit 1
+    }
+    printf 'source\tcases\tcontinued\tresolved\tfollowups\tprocesses\tcontract\n'
+    printf 'A.76\t%d\t%d\t%d\t%d\t%d\tstatement-scope-before-evidence\n' \
+        "$cases" "$continued" "$resolved" "$cases" \
+        "$((1 + cases + cases))"
+    exit 0
+fi
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT/cases"
+cp "$CASES" "$OUT/cases.tsv"
+LEO_WONDER_SCOPE_PLAN_ONLY=1 "$0" > "$OUT/sealed-plan.tsv"
+shasum -a 256 "$ROOT/leo.c" "$ROOT/leo.txt" \
+    > "$OUT/source.sha256"
+(
+    cd "$OUT"
+    shasum -a 256 cases.tsv sealed-plan.tsv > sealed-inputs.sha256
+)
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+receipt_field() {
+    local marker="$1"
+    local key="$2"
+    local file="$3"
+    awk -v marker="$marker" -v key="$key" '
+        index($0, marker) {
+            for (i = 1; i <= NF; i++)
+                if (index($i, key "=") == 1) {
+                    sub("^" key "=", "", $i)
+                    sub(/\]$/, "", $i)
+                    print $i
+                    exit
+                }
+        }
+    ' "$file"
+}
+
+OPEN="$OUT/open.state"
+"$ROOT/leo" --seed 83 \
+    --respond "is a zorble water or cat" \
+    --save "$OPEN" --debug-field \
+    > "$OUT/open.log" 2>&1
+[ "$(reply_from_log "$OUT/open.log")" = "Zorble? Water or Animal?" ]
+[ "$(receipt_field '[curiosity:' outcome "$OUT/open.log")" = asked ]
+[ "$(receipt_field '[pre-wonder:' pending "$OUT/open.log")" = zorble ]
+[ "$(receipt_field '[pre-wonder:' resolved "$OUT/open.log")" = 0 ]
+shasum -a 256 "$OPEN" > "$OUT/open.sha256"
+
+RESULTS="$OUT/results.tsv"
+printf 'case\toutcome\tpending\tresolved\tfollowup\tperceived\tlearned\n' \
+    > "$RESULTS"
+tail -n +2 "$OUT/cases.tsv" |
+while IFS=$'\t' read -r case_id answer expected_outcome \
+        expected_pending expected_resolved followup_prompt \
+        expected_followup expected_perceived expected_learned; do
+    case_dir="$OUT/cases/$case_id"
+    mkdir -p "$case_dir"
+    printf '%s\n' "$answer" > "$case_dir/answer.txt"
+    "$ROOT/leo" --load "$OPEN" --seed 84 \
+        --respond "$answer" \
+        --save "$case_dir/after.state" --debug-field \
+        > "$case_dir/answer.log" 2>&1
+
+    outcome="$(
+        receipt_field '[curiosity:' outcome "$case_dir/answer.log"
+    )"
+    pending="$(
+        receipt_field '[pre-wonder:' pending "$case_dir/answer.log"
+    )"
+    resolved="$(
+        receipt_field '[pre-wonder:' resolved "$case_dir/answer.log"
+    )"
+    [ "$outcome" = "$expected_outcome" ]
+    [ "$pending" = "$expected_pending" ]
+    [ "$resolved" = "$expected_resolved" ]
+    grep -Eq "\\[flow: .* in=${expected_perceived}\\(" \
+        "$case_dir/answer.log"
+
+    "$ROOT/leo" --load "$case_dir/after.state" --seed 85 \
+        --respond "$followup_prompt" \
+        --save "$case_dir/followup.state" --debug-field \
+        > "$case_dir/followup.log" 2>&1
+    followup="$(reply_from_log "$case_dir/followup.log")"
+    [ "$followup" = "$expected_followup" ]
+    if [ "$expected_outcome" = resolved ]; then
+        [ "$expected_learned" != none ]
+        [ "$(
+            receipt_field '[curiosity:' outcome \
+                "$case_dir/followup.log"
+        )" = asked ]
+        [ "$(
+            receipt_field '[curiosity:' candidate \
+                "$case_dir/followup.log"
+        )" = flom ]
+    else
+        [ "$expected_learned" = none ]
+        [ "$(
+            receipt_field '[curiosity:' outcome \
+                "$case_dir/followup.log"
+        )" = reasked ]
+        [ "$(
+            receipt_field '[pre-wonder:' resolved \
+                "$case_dir/followup.log"
+        )" = 0 ]
+    fi
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$case_id" "$outcome" "$pending" "$resolved" \
+        "$followup" "$expected_perceived" "$expected_learned" \
+        >> "$RESULTS"
+done
+
+[ "$(($(wc -l < "$RESULTS") - 1))" -eq 10 ]
+(
+    cd "$OUT"
+    shasum -a 256 -c sealed-inputs.sha256 > /dev/null
+    shasum -a 256 open.state results.tsv > receipt.sha256
+    printf '%s\n' \
+        '17d65d5af898d0d5213fba0e157cde9791f91ec16169e7b912c852e084f85bda  open.state' \
+        'b9b4f65613097427ee22636422d623397d0f90e812cfe513d484e915eb45ccef  results.tsv' \
+        > expected-results.sha256
+    shasum -a 256 -c expected-results.sha256 > /dev/null
+)
+
+cat "$RESULTS"
+printf '\nopen state: %s\nreceipt: %s\n' \
+    "$OPEN" "$OUT/receipt.sha256"

--- a/scripts/test_deferred_wonder_answer_scope_life.sh
+++ b/scripts/test_deferred_wonder_answer_scope_life.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ACTUAL="$(
+    LEO_WONDER_SCOPE_PLAN_ONLY=1 \
+        "$ROOT/scripts/deferred_wonder_answer_scope_life.sh"
+)"
+EXPECTED="$(
+    printf 'source\tcases\tcontinued\tresolved\tfollowups\tprocesses\tcontract\n'
+    printf 'A.76\t10\t4\t6\t10\t21\tstatement-scope-before-evidence'
+)"
+[ "$ACTUAL" = "$EXPECTED" ] || {
+    printf 'unexpected A.76 answer-scope plan\n%s\n' "$ACTUAL" >&2
+    exit 1
+}
+printf 'deferred Wonder answer-scope life plan: ok\n'

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -5640,6 +5640,130 @@ int main(void) {
         free(woke);
     }
 
+    /* A.76: a reference licenses one bounded statement, not the complete
+     * human turn. Explicitly named statements can appear later or cooperate;
+     * without a name, only the first substantive statement may answer. The
+     * rest of the turn remains ordinary perceived life. */
+    {
+        Leo *scope = calloc(1, sizeof *scope);
+        CHECK(scope,
+              "wonder-reference-scope: heap fixture allocated");
+        if (scope) {
+            int prev_school = g_leo_school_on;
+            int prev_wonder = g_leo_wonder_on;
+            g_leo_school_on = 1;
+            g_leo_wonder_on = 1;
+            int water = semtok_word("water");
+            int animal = semtok_word("animal");
+            int sky = semtok_word("sky");
+            int music = semtok_word("music");
+            char out[1024];
+
+            seed_wonder_negation_body(scope);
+            leo_respond(
+                scope,
+                "it is an animal. the river has water",
+                out, sizeof out);
+            const LeoFlowSnapshot *anaphoric_flow =
+                leo_flow_at(&scope->flow, scope->flow.n - 1);
+            CHECK(leo_semtok_word(scope, "zorble") == animal &&
+                  scope->school.wonders[0].answer_glyph ==
+                      animal,
+                  "wonder-reference-scope: an anaphoric answer does not inherit a later statement");
+            CHECK(anaphoric_flow &&
+                  anaphoric_flow->perceived[water] > 0.0f,
+                  "wonder-reference-scope: an excluded lesson tail remains perceived by Flow");
+
+            leo_free(scope);
+            seed_wonder_negation_body(scope);
+            leo_respond(
+                scope,
+                "a zorble is an animal. the river has water",
+                out, sizeof out);
+            CHECK(leo_semtok_word(scope, "zorble") == animal,
+                  "wonder-reference-scope: an explicit answer licenses only its own statement");
+
+            leo_free(scope);
+            seed_wonder_negation_body(scope);
+            leo_respond(
+                scope,
+                "the river has water. a zorble is an animal",
+                out, sizeof out);
+            CHECK(leo_semtok_word(scope, "zorble") == animal,
+                  "wonder-reference-scope: a later explicit statement can own the answer");
+
+            leo_free(scope);
+            seed_wonder_negation_body(scope);
+            leo_respond(
+                scope,
+                "the river has water. it is an animal",
+                out, sizeof out);
+            CHECK(!leo_school_is_learned(scope, "zorble") &&
+                  !strcmp(scope->school.pending, "zorble") &&
+                  !scope->school.wonders[0].resolved,
+                  "wonder-reference-scope: later anaphora cannot reach backward across a new subject");
+
+            leo_free(scope);
+            seed_wonder_negation_body(scope);
+            leo_respond(
+                scope,
+                "the river is water",
+                out, sizeof out);
+            CHECK(!leo_school_is_learned(scope, "zorble") &&
+                  !strcmp(scope->school.pending, "zorble") &&
+                  !scope->school.wonders[0].resolved,
+                  "wonder-reference-scope: a copular proposition cannot impersonate ellipsis");
+
+            leo_free(scope);
+            seed_wonder_negation_body(scope);
+            leo_respond(
+                scope, "yes. it is music",
+                out, sizeof out);
+            CHECK(leo_semtok_word(scope, "zorble") == music,
+                  "wonder-reference-scope: a marker-only statement may precede the first answer");
+
+            leo_free(scope);
+            seed_wonder_negation_body(scope);
+            leo_respond(
+                scope,
+                "a zorble is not water. the sky is dark",
+                out, sizeof out);
+            const LeoFlowSnapshot *negative_flow =
+                leo_flow_at(&scope->flow, scope->flow.n - 1);
+            CHECK(!leo_school_is_learned(scope, "zorble") &&
+                  scope->school.pending_glyph == animal &&
+                  scope->school.pending_alt_glyph == -1 &&
+                  !scope->school.wonders[0].resolved,
+                  "wonder-reference-scope: a negative answer narrows without borrowing its tail");
+            CHECK(negative_flow &&
+                  negative_flow->perceived[sky] > 0.0f,
+                  "wonder-reference-scope: a negative answer cannot amputate the later perceived statement");
+
+            leo_free(scope);
+            seed_wonder_negation_body(scope);
+            leo_respond(
+                scope,
+                "a zorble is not water. a zorble is an animal",
+                out, sizeof out);
+            CHECK(leo_semtok_word(scope, "zorble") == animal,
+                  "wonder-reference-scope: separately explicit statements may form one correction");
+
+            leo_free(scope);
+            seed_wonder_negation_body(scope);
+            leo_respond(
+                scope,
+                "animal. the river has water",
+                out, sizeof out);
+            CHECK(leo_semtok_word(scope, "zorble") == animal,
+                  "wonder-reference-scope: the first elliptical answer keeps later life outside School");
+
+            g_leo_school_on = prev_school;
+            g_leo_wonder_on = prev_wonder;
+        }
+        if (scope) leo_free(scope);
+        free(scope);
+    }
+
     /* W-4: a resolved question later returns as glyph attention, not text. The
      * answer, the route Leo once considered, and QUESTION blend into exactly one
      * reply's meaning vector; the existing spore-resonance channel is the only


### PR DESCRIPTION
School now scopes explicit, anaphoric, and elliptical evidence to bounded statements instead of pooling an entire human turn. A surface guard also prevents complete propositions from masquerading as offered-option ellipses, while Flow keeps the full prompt.

Quote: "A sentence may carry an answer without making its neighbors witnesses." - Sol

Method: The Arianna Method grants epistemic authority to the statement that earned reference, while the whole turn remains lived perception.