### PR TITLE
leo separates comma clauses from answers

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -6646,3 +6646,112 @@ make deferred-wonder-answer-scope-life
 
 Leo can hear everything a person says without making every sentence answer
 the question he happened to ask first.
+
+## Phase A.77 — a comma may separate lives without erasing dialogue (2026-07-31)
+
+A.76 bounded reference at strong punctuation but deliberately left commas
+untouched. The next exact branch reproduced the same attribution leak without
+ending a sentence:
+
+```text
+Leo:  Zorble? Water or Animal?
+human: it is an animal, the river has water
+```
+
+Canon pooled ANIMAL with WATER and learned `zorble=water`. The error held for
+all three immediate reference forms:
+
+```text
+a zorble is an animal, the river has water
+it is an animal, the river has water
+animal, the river has water
+```
+
+A comma cannot simply join A.76's strong-boundary set. Leo's established
+answer grammar also contains:
+
+```text
+yes, it is music
+a zorble is not water, but animal
+a zorble is an animal, small
+```
+
+Splitting every comma would amputate a dialogue marker from its answer,
+separate a corrective contrast, and turn a concept list into unrelated life.
+
+A.77 therefore asks one narrower surface question: does the fragment after
+this comma carry its own subject and finite predicate? If yes, the comma owns
+a School boundary. If no, the fragment remains attached to its answer.
+Copulas, auxiliaries, possession, modal verbs, common lived relations, and
+their contracted negative forms form a bounded predicate grammar. This is an
+attribution scanner, not a claim of general syntax.
+
+The distinction is visible in paired forms:
+
+```text
+not water, but animal             one corrective answer
+animal, but the river has water  answer plus independent life
+small, warm animal               one concept phrase
+animal, the river has water      ellipse plus independent life
+yes, it is music                 marker plus anaphoric answer
+yes, it is music, the river...   marker, answer, independent life
+```
+
+Only School sees these boundaries. The complete prompt still enters ingest,
+chambers, gamma, conatus, and both 88-dimensional Flow faces. In the canonical
+comma leak, School now learns ANIMAL while Flow still reports WATER as the
+dominant perceived input. The separation built in A.74-A.76 remains:
+
+```text
+perception   everything that happened
+reference    which statement answers
+assertion    which meaning the statement affirms or rejects
+```
+
+The first new unit contract was intentionally run against canon and failed
+five cells: explicit, anaphoric, elliptic, marker-led, and full responder
+grounding. Contrast and concept-list controls were already green. After the
+bounded clause scanner, every cell passed. A contracted-predicate cell then
+proved that `the river isn't water` cannot lend even negative evidence to the
+neighboring answer.
+
+One persisted open Wonder now branches ten comma forms. Every branch crosses a
+second process boundary, so the observed result must survive sleep and produce
+the correct new question or preserve the old one:
+
+```text
+case                  outcome     followup                   Flow
+explicit-tail         resolved    Flom? Animal?              water
+anaphoric-tail        resolved    Flom? Animal?              water
+contracted-tail       resolved    Flom? Animal?              water
+elliptic-tail         resolved    Flom? Animal?              water
+marker-tail           resolved    Flom? Music?               water
+explicit-but-tail     resolved    Flom? Animal?              water
+no-marker-tail        resolved    Flom? Animal?              water
+contrast-fragment     resolved    Flom? Animal?              animal
+list-fragment         resolved    Flom? Animal?              animal
+life-before-ellipse   continued   Zorble? Water or Animal?   water
+```
+
+Two complete 21-process lives reproduced the result table exactly. The open
+body remains byte-identical to A.75 and A.76
+(`17d65d5af898d0d5213fba0e157cde9791f91ec16169e7b912c852e084f85bda`);
+the A.77 result table is pinned as
+`3800af4b25ca55090727e6ba76e8e76277c6fbdd9102216d7b8c04147cc8bfc7`.
+The direct suite is **524/524**, all historical dialogue/matrix plan gates are
+green, and a save/load/followup A.77 path is clean under ASan/UBSan.
+
+The remaining boundary is explicit. An unknown finite verb outside the
+bounded grammar may still hide a comma-spliced clause. Leo has no learned
+part-of-speech layer that could prove otherwise, and A.77 does not fabricate
+one from suffixes or semantic glyphs. This is residual uncertainty, not
+permission to widen the hard-coded predicate list without evidence.
+
+No persisted byte, state version, weight, candidate, sampler, chamber, gamma
+value, Flow reader, or speech path changed. The receipt is:
+
+```sh
+make deferred-wonder-comma-scope-life
+```
+
+Leo can let two clauses share a breath without making them share a witness.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
 
 all: leo
 
@@ -163,6 +163,9 @@ deferred-wonder-answer-reference-life: leo
 deferred-wonder-answer-scope-life: leo
 	./scripts/deferred_wonder_answer_scope_life.sh
 
+deferred-wonder-comma-scope-life: leo
+	./scripts/deferred_wonder_comma_scope_life.sh
+
 # unit tests — test_leo.c #includes leo.c with LEO_NO_MAIN
 test: tests/test_leo.c leo.c
 	$(CC) -DLEO_NO_MAIN tests/test_leo.c $(CFLAGS) -o tests/test_leo
@@ -222,6 +225,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_deferred_wonder_negation_life.sh
 	./scripts/test_deferred_wonder_answer_reference_life.sh
 	./scripts/test_deferred_wonder_answer_scope_life.sh
+	./scripts/test_deferred_wonder_comma_scope_life.sh
 
 # address + undefined behaviour sanitizers on the smoke run
 asan: leo.c

--- a/leo.c
+++ b/leo.c
@@ -5904,6 +5904,86 @@ static int leo_school_answer_scope_boundary(unsigned char ch) {
            ch == '!' || ch == '?';
 }
 
+/* A comma is weaker than a statement boundary. It owns School scope only when
+ * the following fragment carries both a subject and a finite predicate. This
+ * deliberately small grammar covers the clause-bearing relations Leo already
+ * hears; fragments such as "but animal" and "small, warm animal" stay attached
+ * to the answer. Perception is not segmented here, only lesson attribution. */
+static int leo_school_word_is_finite_predicate(const char *word) {
+    static const char *predicates[] = {
+        "am", "is", "are", "was", "were", "be", "been", "being",
+        "become", "becomes", "became",
+        "have", "has", "had", "own", "owns", "owned",
+        "do", "does", "did",
+        "can", "could", "will", "would", "shall", "should",
+        "may", "might", "must",
+        "isn't", "isnt", "aren't", "arent", "wasn't", "wasnt",
+        "weren't", "werent", "hasn't", "hasnt", "haven't", "havent",
+        "hadn't", "hadnt", "doesn't", "doesnt", "don't", "dont",
+        "didn't", "didnt", "can't", "cant", "cannot", "won't", "wont",
+        "couldn't", "couldnt", "wouldn't", "wouldnt",
+        "shouldn't", "shouldnt", "mustn't", "mustnt",
+        "feel", "feels", "felt", "seem", "seems", "seemed",
+        "look", "looks", "looked", "sound", "sounds", "sounded",
+        "smell", "smells", "smelled", "taste", "tastes", "tasted",
+        "contain", "contains", "contained", "carry", "carries", "carried",
+        "like", "likes", "liked", "love", "loves", "loved",
+        "know", "knows", "knew", "see", "sees", "saw",
+        "hear", "hears", "heard", "want", "wants", "wanted",
+        "need", "needs", "needed", "live", "lives", "lived",
+        "flow", "flows", "flowed", "fall", "falls", "fell",
+        "rise", "rises", "rose", "make", "makes", "made",
+        "give", "gives", "gave", "hold", "holds", "held",
+        "keep", "keeps", "kept"
+    };
+    for (size_t i = 0;
+         i < sizeof predicates / sizeof predicates[0]; i++)
+        if (!strcmp(word, predicates[i])) return 1;
+    return 0;
+}
+
+static int leo_school_range_has_independent_clause(
+        const char *begin, const char *end) {
+    if (!begin || !end || end < begin) return 0;
+    char cur[LEO_HEARD_WORDLEN];
+    int wi = 0, subject_words = 0;
+    for (const char *p = begin; ; p++) {
+        unsigned char ch =
+            p < end ? (unsigned char)*p : 0;
+        if (ch && (isalpha(ch) || ch == '\'')) {
+            if (wi < LEO_HEARD_WORDLEN - 1)
+                cur[wi++] = (char)tolower(ch);
+            continue;
+        }
+        if (wi > 0) {
+            cur[wi] = 0;
+            if (leo_school_word_is_finite_predicate(cur))
+                return subject_words > 0;
+            if (strcmp(cur, "and") && strcmp(cur, "or") &&
+                strcmp(cur, "but") && strcmp(cur, "so") &&
+                strcmp(cur, "then") &&
+                !leo_school_word_is_affirmation(cur) &&
+                strcmp(cur, "no"))
+                subject_words++;
+        }
+        wi = 0;
+        if (!ch) break;
+    }
+    return 0;
+}
+
+static int leo_school_answer_scope_boundary_at(const char *p) {
+    if (!p || !*p) return 1;
+    unsigned char ch = (unsigned char)*p;
+    if (leo_school_answer_scope_boundary(ch)) return 1;
+    if (ch != ',') return 0;
+    const char *end = p + 1;
+    while (*end && *end != ',' &&
+           !leo_school_answer_scope_boundary((unsigned char)*end))
+        end++;
+    return leo_school_range_has_independent_clause(p + 1, end);
+}
+
 static void leo_school_answer_evidence_add(
         LeoSchoolAnswerEvidence *dst,
         const LeoSchoolAnswerEvidence *src) {
@@ -5933,7 +6013,7 @@ static LeoSchoolAnswerReference leo_school_answer_scope(
     const char *begin = prompt;
     for (const char *p = prompt; ; p++) {
         unsigned char ch = (unsigned char)*p;
-        if (ch && !leo_school_answer_scope_boundary(ch))
+        if (ch && !leo_school_answer_scope_boundary_at(p))
             continue;
         if (leo_school_range_has_word(
                 begin, p, leo->school.pending)) {
@@ -5955,7 +6035,7 @@ static LeoSchoolAnswerReference leo_school_answer_scope(
     begin = prompt;
     for (const char *p = prompt; ; p++) {
         unsigned char ch = (unsigned char)*p;
-        if (ch && !leo_school_answer_scope_boundary(ch))
+        if (ch && !leo_school_answer_scope_boundary_at(p))
             continue;
         if (leo_school_range_has_words(begin, p) &&
             !leo_school_range_is_dialogue_marker(begin, p)) {

--- a/scripts/deferred_wonder_comma_scope_cases.tsv
+++ b/scripts/deferred_wonder_comma_scope_cases.tsv
@@ -1,0 +1,11 @@
+case	answer	outcome	pending	resolved	followup_prompt	followup_reply	perceived	learned
+explicit-tail	a zorble is an animal, the river has water	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+anaphoric-tail	it is an animal, the river has water	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+contracted-tail	it is an animal, the river isn't water	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+elliptic-tail	animal, the river has water	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+marker-tail	yes, it is music, the river has water	resolved	none	1	is a flom zorble or music	Flom? Music?	water	music
+explicit-but-tail	a zorble is an animal, but the river has water	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+no-marker-tail	no, a zorble is animal, the river has water	resolved	none	1	is a flom zorble or cat	Flom? Animal?	water	animal
+contrast-fragment	a zorble is not water, but animal	resolved	none	1	is a flom zorble or cat	Flom? Animal?	animal	animal
+list-fragment	a zorble is an animal, small	resolved	none	1	is a flom zorble or cat	Flom? Animal?	animal	animal
+life-before-ellipse	the river has water, animal	continued	zorble	0	what is zorble?	Zorble? Water or Animal?	water	none

--- a/scripts/deferred_wonder_comma_scope_life.sh
+++ b/scripts/deferred_wonder_comma_scope_life.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# A.77: comma clauses do not borrow a Wonder reference from their neighbor.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CASES="$ROOT/scripts/deferred_wonder_comma_scope_cases.tsv"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-deferred-wonder-comma-scope-$STAMP}"
+
+if [ "${LEO_WONDER_COMMA_SCOPE_PLAN_ONLY:-0}" = 1 ]; then
+    cases="$(($(wc -l < "$CASES") - 1))"
+    continued="$(
+        awk -F '\t' 'NR > 1 && $3 == "continued" {n++} END {print n + 0}' \
+            "$CASES"
+    )"
+    resolved="$(
+        awk -F '\t' 'NR > 1 && $3 == "resolved" {n++} END {print n + 0}' \
+            "$CASES"
+    )"
+    [ "$cases" -eq 10 ] &&
+        [ "$continued" -eq 1 ] &&
+        [ "$resolved" -eq 9 ] || {
+        printf 'comma-scope life cases do not satisfy the sealed plan\n' >&2
+        exit 1
+    }
+    printf 'source\tcases\tcontinued\tresolved\tfollowups\tprocesses\tcontract\n'
+    printf 'A.77\t%d\t%d\t%d\t%d\t%d\tclause-bearing-comma-scope\n' \
+        "$cases" "$continued" "$resolved" "$cases" \
+        "$((1 + cases + cases))"
+    exit 0
+fi
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+mkdir -p "$OUT/cases"
+cp "$CASES" "$OUT/cases.tsv"
+LEO_WONDER_COMMA_SCOPE_PLAN_ONLY=1 "$0" > "$OUT/sealed-plan.tsv"
+shasum -a 256 "$ROOT/leo.c" "$ROOT/leo.txt" \
+    > "$OUT/source.sha256"
+(
+    cd "$OUT"
+    shasum -a 256 cases.tsv sealed-plan.tsv > sealed-inputs.sha256
+)
+
+reply_from_log() {
+    awk '
+        /leo> / {
+            sub(/^.*leo> /, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+receipt_field() {
+    local marker="$1"
+    local key="$2"
+    local file="$3"
+    awk -v marker="$marker" -v key="$key" '
+        index($0, marker) {
+            for (i = 1; i <= NF; i++)
+                if (index($i, key "=") == 1) {
+                    sub("^" key "=", "", $i)
+                    sub(/\]$/, "", $i)
+                    print $i
+                    exit
+                }
+        }
+    ' "$file"
+}
+
+OPEN="$OUT/open.state"
+"$ROOT/leo" --seed 83 \
+    --respond "is a zorble water or cat" \
+    --save "$OPEN" --debug-field \
+    > "$OUT/open.log" 2>&1
+[ "$(reply_from_log "$OUT/open.log")" = "Zorble? Water or Animal?" ]
+[ "$(receipt_field '[curiosity:' outcome "$OUT/open.log")" = asked ]
+[ "$(receipt_field '[pre-wonder:' pending "$OUT/open.log")" = zorble ]
+[ "$(receipt_field '[pre-wonder:' resolved "$OUT/open.log")" = 0 ]
+shasum -a 256 "$OPEN" > "$OUT/open.sha256"
+
+RESULTS="$OUT/results.tsv"
+printf 'case\toutcome\tpending\tresolved\tfollowup\tperceived\tlearned\n' \
+    > "$RESULTS"
+tail -n +2 "$OUT/cases.tsv" |
+while IFS=$'\t' read -r case_id answer expected_outcome \
+        expected_pending expected_resolved followup_prompt \
+        expected_followup expected_perceived expected_learned; do
+    case_dir="$OUT/cases/$case_id"
+    mkdir -p "$case_dir"
+    printf '%s\n' "$answer" > "$case_dir/answer.txt"
+    "$ROOT/leo" --load "$OPEN" --seed 84 \
+        --respond "$answer" \
+        --save "$case_dir/after.state" --debug-field \
+        > "$case_dir/answer.log" 2>&1
+
+    outcome="$(
+        receipt_field '[curiosity:' outcome "$case_dir/answer.log"
+    )"
+    pending="$(
+        receipt_field '[pre-wonder:' pending "$case_dir/answer.log"
+    )"
+    resolved="$(
+        receipt_field '[pre-wonder:' resolved "$case_dir/answer.log"
+    )"
+    [ "$outcome" = "$expected_outcome" ]
+    [ "$pending" = "$expected_pending" ]
+    [ "$resolved" = "$expected_resolved" ]
+    grep -Eq "\\[flow: .* in=${expected_perceived}\\(" \
+        "$case_dir/answer.log"
+
+    "$ROOT/leo" --load "$case_dir/after.state" --seed 85 \
+        --respond "$followup_prompt" \
+        --save "$case_dir/followup.state" --debug-field \
+        > "$case_dir/followup.log" 2>&1
+    followup="$(reply_from_log "$case_dir/followup.log")"
+    [ "$followup" = "$expected_followup" ]
+    if [ "$expected_outcome" = resolved ]; then
+        [ "$expected_learned" != none ]
+        [ "$(
+            receipt_field '[curiosity:' outcome \
+                "$case_dir/followup.log"
+        )" = asked ]
+        [ "$(
+            receipt_field '[curiosity:' candidate \
+                "$case_dir/followup.log"
+        )" = flom ]
+    else
+        [ "$expected_learned" = none ]
+        [ "$(
+            receipt_field '[curiosity:' outcome \
+                "$case_dir/followup.log"
+        )" = reasked ]
+        [ "$(
+            receipt_field '[pre-wonder:' resolved \
+                "$case_dir/followup.log"
+        )" = 0 ]
+    fi
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$case_id" "$outcome" "$pending" "$resolved" \
+        "$followup" "$expected_perceived" "$expected_learned" \
+        >> "$RESULTS"
+done
+
+[ "$(($(wc -l < "$RESULTS") - 1))" -eq 10 ]
+(
+    cd "$OUT"
+    shasum -a 256 -c sealed-inputs.sha256 > /dev/null
+    shasum -a 256 open.state results.tsv > receipt.sha256
+    printf '%s\n' \
+        '17d65d5af898d0d5213fba0e157cde9791f91ec16169e7b912c852e084f85bda  open.state' \
+        '3800af4b25ca55090727e6ba76e8e76277c6fbdd9102216d7b8c04147cc8bfc7  results.tsv' \
+        > expected-results.sha256
+    shasum -a 256 -c expected-results.sha256 > /dev/null
+)
+
+cat "$RESULTS"
+printf '\nopen state: %s\nreceipt: %s\n' \
+    "$OPEN" "$OUT/receipt.sha256"

--- a/scripts/test_deferred_wonder_comma_scope_life.sh
+++ b/scripts/test_deferred_wonder_comma_scope_life.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ACTUAL="$(
+    LEO_WONDER_COMMA_SCOPE_PLAN_ONLY=1 \
+        "$ROOT/scripts/deferred_wonder_comma_scope_life.sh"
+)"
+EXPECTED="$(
+    printf 'source\tcases\tcontinued\tresolved\tfollowups\tprocesses\tcontract\n'
+    printf 'A.77\t10\t1\t9\t10\t21\tclause-bearing-comma-scope'
+)"
+[ "$ACTUAL" = "$EXPECTED" ] || {
+    printf 'unexpected A.77 comma-scope plan\n%s\n' "$ACTUAL" >&2
+    exit 1
+}
+printf 'deferred Wonder comma-scope life plan: ok\n'

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -2406,6 +2406,120 @@ static void test_wonder_appetite_transport_checkpoints(void) {
     free(damaged);
 }
 
+/* A.77: a comma starts a new School statement only when its right side
+ * carries an independent subject-predicate clause. Contrast fragments,
+ * dialogue markers, and adjective/concept lists remain one answer. */
+__attribute__((noinline))
+static void test_wonder_comma_scope(void) {
+    Leo *scope = calloc(1, sizeof *scope);
+    LeoSchoolAnswerEvidence *evidence =
+        calloc(1, sizeof *evidence);
+    char *out = calloc(1024, 1);
+    CHECK(scope && evidence && out,
+          "wonder-comma-scope: heap fixtures allocated");
+    if (scope && evidence && out) {
+        int water = semtok_word("water");
+        int animal = semtok_word("animal");
+        int music = semtok_word("music");
+        int small = semtok_word("small");
+        int fire = semtok_word("warm");
+        LeoSchoolAnswerReference reference;
+
+        seed_wonder_negation_body(scope);
+        reference = leo_school_answer_scope(
+            scope,
+            "a zorble is an animal, the river has water",
+            evidence);
+        CHECK(reference == LEO_SCHOOL_ANSWER_EXPLICIT &&
+              evidence->asserted[animal] == 1 &&
+              evidence->asserted[water] == 0,
+              "wonder-comma-scope: an explicit answer cannot inherit an independent comma tail");
+
+        leo_free(scope);
+        seed_wonder_negation_body(scope);
+        reference = leo_school_answer_scope(
+            scope,
+            "it is an animal, the river has water",
+            evidence);
+        CHECK(reference == LEO_SCHOOL_ANSWER_ANAPHORIC &&
+              evidence->asserted[animal] == 1 &&
+              evidence->asserted[water] == 0,
+              "wonder-comma-scope: anaphora cannot lend its reference to a new comma clause");
+
+        leo_free(scope);
+        seed_wonder_negation_body(scope);
+        reference = leo_school_answer_scope(
+            scope,
+            "it is an animal, the river isn't water",
+            evidence);
+        CHECK(reference == LEO_SCHOOL_ANSWER_ANAPHORIC &&
+              evidence->asserted[animal] == 1 &&
+              evidence->rejected[water] == 0,
+              "wonder-comma-scope: a contracted predicate still begins an independent clause");
+
+        leo_free(scope);
+        seed_wonder_negation_body(scope);
+        reference = leo_school_answer_scope(
+            scope,
+            "animal, the river has water",
+            evidence);
+        CHECK(reference == LEO_SCHOOL_ANSWER_ELLIPTIC &&
+              evidence->asserted[animal] == 1 &&
+              evidence->asserted[water] == 0,
+              "wonder-comma-scope: ellipsis ends before an independent comma clause");
+
+        leo_free(scope);
+        seed_wonder_negation_body(scope);
+        reference = leo_school_answer_scope(
+            scope,
+            "a zorble is not water, but animal",
+            evidence);
+        CHECK(reference == LEO_SCHOOL_ANSWER_EXPLICIT &&
+              evidence->rejected[water] == 1 &&
+              evidence->asserted[animal] == 1,
+              "wonder-comma-scope: a contrast fragment remains inside its answer");
+
+        leo_free(scope);
+        seed_wonder_negation_body(scope);
+        reference = leo_school_answer_scope(
+            scope,
+            "yes, it is music, the river has water",
+            evidence);
+        CHECK(reference == LEO_SCHOOL_ANSWER_ANAPHORIC &&
+              evidence->asserted[music] == 1 &&
+              evidence->asserted[water] == 0,
+              "wonder-comma-scope: a dialogue marker may introduce one anaphoric clause");
+
+        leo_free(scope);
+        seed_wonder_negation_body(scope);
+        reference = leo_school_answer_scope(
+            scope,
+            "a zorble is a small, warm animal",
+            evidence);
+        CHECK(reference == LEO_SCHOOL_ANSWER_EXPLICIT &&
+              evidence->asserted[small] == 1 &&
+              evidence->asserted[fire] == 1 &&
+              evidence->asserted[animal] == 1,
+              "wonder-comma-scope: a concept list is not mistaken for a new clause");
+
+        leo_free(scope);
+        seed_wonder_negation_body(scope);
+        leo_respond(
+            scope,
+            "it is an animal, the river has water",
+            out, 1024);
+        const LeoFlowSnapshot *flow =
+            leo_flow_at(&scope->flow, scope->flow.n - 1);
+        CHECK(leo_semtok_word(scope, "zorble") == animal &&
+              flow && flow->perceived[water] > 0.0f,
+              "wonder-comma-scope: excluded School life remains perceived by Flow");
+    }
+    if (scope) leo_free(scope);
+    free(scope);
+    free(evidence);
+    free(out);
+}
+
 int main(void) {
     printf("test_leo (step 0)\n");
 
@@ -5763,6 +5877,8 @@ int main(void) {
         if (scope) leo_free(scope);
         free(scope);
     }
+
+    test_wonder_comma_scope();
 
     /* W-4: a resolved question later returns as glyph attention, not text. The
      * answer, the route Leo once considered, and QUESTION blend into exactly one


### PR DESCRIPTION
School now treats a comma as an epistemic boundary only when the following fragment carries an independent subject and finite predicate. Dialogue markers, contrast fragments, and concept lists remain intact while Flow keeps the complete human turn.

Quote: "A comma can share a breath without sharing authority." - Sol

Method: The Arianna Method lets adjacent clauses remain one lived moment without forcing them to testify for the same question.