### PR TITLE
leo accepts a lesson before asking

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -6755,3 +6755,48 @@ make deferred-wonder-comma-scope-life
 ```
 
 Leo can let two clauses share a breath without making them share a witness.
+
+## Phase A.78 — a lesson can arrive before the question (2026-07-31)
+
+School previously recognized a new word before it recognized that the same
+human turn had already defined it. The first encounter therefore produced an
+unnecessary question:
+
+```text
+human: Flom is the gentle comfort of warm light or cool rain
+Leo:   Flom? Water or Fire?
+```
+
+A.78 admits one narrow first-turn lesson: the unknown must itself be the
+subject of a bounded copular statement, and positive teachable evidence must
+exist on the right-hand side of the copula. The copula is recognized through
+Leo's existing `BE` glyph map; A.76/A.77 still own statement and comma-clause
+boundaries. No new predicate vocabulary or general syntax claim was added.
+
+The exclusions are part of the contract:
+
+```text
+I saw a nareth beside water   co-presence, not a definition
+a suvin is not water          rejection alone cannot assign meaning
+a tral is glorp               unknown cannot ground unknown
+what is a flom?               a question cannot teach its own answer
+```
+
+On a valid first-turn definition, School records the dominant teachable glyph,
+suppresses the redundant question, and emits an ordinary `resolved` curiosity
+receipt. The complete prompt still enters Leo's co-occurrence field, so richer
+associations are not reduced to that single School label. No synthetic Wonder
+episode or Flow closure is invented for a question that never opened.
+
+The exact complaint now yields `candidate=flom outcome=resolved`. A saved state
+loaded by a second process answers `Tell me about flom again` with
+`outcome=no-candidate`; the negative control still asks `Nareth? Water or See?`.
+The direct suite is **529/529**, `git diff --check` is clean, and the normal
+ASan/UBSan bootstrap smoke completes without a finding. The cross-process
+receipt was also run directly with `--save` followed by `--load`.
+
+This is first-turn admission, not an inference engine. It intentionally learns
+only the strongest grounded School glyph from the definition and inherits the
+documented A.77 uncertainty around an unknown finite verb outside the bounded
+clause grammar. No state version, sampler, candidate score, chamber, gamma,
+Flow reader, or speech-selection weight changed.

--- a/leo.c
+++ b/leo.c
@@ -6657,6 +6657,81 @@ static int leo_school_grounded_answer(
     return best;
 }
 
+/* A first mention may already be a human lesson. Admit only a bounded copular
+ * definition whose subject is the unknown itself: "a flom is warm fire". The
+ * BE relation comes from Leo's glyph map, while meaning evidence comes solely
+ * from the right-hand side of that statement. Mere co-presence ("I saw flom
+ * near water"), questions, negation-only evidence, and unknown-to-unknown
+ * equations remain unfinished knowledge rather than counterfeit lessons. */
+static int leo_school_same_turn_grounding(
+        const Leo *leo, const char *prompt, const char *unknown,
+        LeoSchoolAnswerEvidence *observed) {
+    LeoSchoolAnswerEvidence empty;
+    memset(&empty, 0, sizeof empty);
+    if (observed) *observed = empty;
+    if (!leo || !prompt || !unknown || !unknown[0] ||
+        strchr(prompt, '?'))
+        return -1;
+
+    int be = semtok_find_glyph("BE");
+    const char *begin = prompt;
+    for (const char *p = prompt; ; p++) {
+        unsigned char ch = (unsigned char)*p;
+        if (ch && !leo_school_answer_scope_boundary_at(p))
+            continue;
+
+        char cur[LEO_HEARD_WORDLEN];
+        int wi = 0, words_before = 0, subject_seen = 0;
+        const char *meaning_begin = NULL;
+        for (const char *q = begin; ; q++) {
+            unsigned char qch = q < p ? (unsigned char)*q : 0;
+            if (qch && (isalpha(qch) || qch == '\'')) {
+                if (wi < LEO_HEARD_WORDLEN - 1)
+                    cur[wi++] = (char)tolower(qch);
+                continue;
+            }
+            if (wi > 0) {
+                cur[wi] = 0;
+                if (!subject_seen) {
+                    if (!strcmp(cur, unknown)) {
+                        subject_seen = 1;
+                    } else if (!leo_school_word_is_article(cur) &&
+                               !leo_school_word_is_affirmation(cur)) {
+                        words_before++;
+                    }
+                } else if (!meaning_begin) {
+                    if (leo_semtok_word(leo, cur) == be &&
+                        words_before == 0)
+                        meaning_begin = q + 1;
+                    else
+                        break;
+                }
+            }
+            wi = 0;
+            if (!qch) break;
+        }
+
+        if (meaning_begin && meaning_begin <= p) {
+            LeoSchoolAnswerEvidence evidence;
+            leo_school_answer_evidence_range(
+                leo, meaning_begin, p, &evidence);
+            if (observed) *observed = evidence;
+            int best = -1, bestn = 0;
+            for (int g = 0; g < GLYPH_COUNT; g++)
+                if (evidence.rejected[g] == 0 &&
+                    evidence.asserted[g] > bestn) {
+                    bestn = evidence.asserted[g];
+                    best = g;
+                }
+            if (best >= 0) return best;
+        }
+
+        if (!ch) break;
+        begin = p + 1;
+    }
+    return -1;
+}
+
 static void leo_school_title(char *out, size_t out_sz, const char *word) {
     if (out_sz == 0) return;
     snprintf(out, out_sz, "%s", word ? word : "");
@@ -10850,6 +10925,17 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     int has_unknown = g_leo_school_on && !was_answer && !wonder_reask &&
                       leo_school_scan_unknown(leo, prompt, unk, deferred,
                                               &deferred_heard, &from_deferred);
+    int same_turn_grounded = 0;
+    if (has_unknown) {
+        LeoSchoolAnswerEvidence same_turn_evidence;
+        int same_turn_glyph = leo_school_same_turn_grounding(
+            leo, prompt, unk, &same_turn_evidence);
+        if (same_turn_glyph >= 0) {
+            leo_school_learn(leo, unk, same_turn_glyph);
+            same_turn_grounded = 1;
+            has_unknown = 0;
+        }
+    }
     if (g && g_leo_wonder_on && g_leo_deferred_wonder_on &&
         prewonder_field_token[0] < 0 && has_unknown)
         leo_prewonder_field_constellation(
@@ -10882,7 +10968,7 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     curiosity.turn = (uint64_t)leo->school.turn_clock;
     curiosity.distress = ask_distress;
     curiosity.gate = ask_gate;
-    if (has_unknown) {
+    if (has_unknown || same_turn_grounded) {
         strncpy(curiosity.candidate, unk, LEO_HEARD_WORDLEN - 1);
         curiosity.candidate[LEO_HEARD_WORDLEN - 1] = 0;
     } else if (occupied_queued) {
@@ -10909,6 +10995,8 @@ static int leo_respond(Leo *leo, const char *prompt, char *out, int max_len) {
     else if (was_answer)
         curiosity.outcome = (flow_event & LEO_FLOW_WONDER_RESOLVED) ?
             LEO_CURIOSITY_RESOLVED : LEO_CURIOSITY_CONTINUED;
+    else if (same_turn_grounded)
+        curiosity.outcome = LEO_CURIOSITY_RESOLVED;
     else if (!has_unknown)
         curiosity.outcome = LEO_CURIOSITY_NO_CANDIDATE;
     else if (ask_distress >= ask_gate)

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -3421,6 +3421,45 @@ int main(void) {
         CHECK(sc.curiosity.outcome == LEO_CURIOSITY_NO_CANDIDATE &&
               !sc.curiosity.candidate[0],
               "curiosity: familiar meaning records an honest absence of candidate");
+
+        Leo direct; leo_init(&direct);
+        leo_ingest(&direct, "the rain falls. leo hears the sound. his mother is warm.");
+        leo_respond(&direct, "a flom is warm fire", buf, sizeof buf);
+        CHECK(leo_semtok_word(&direct, "flom") == semtok_word("fire") &&
+              !direct.school.pending[0] &&
+              direct.curiosity.outcome == LEO_CURIOSITY_RESOLVED &&
+              !strcmp(direct.curiosity.candidate, "flom") &&
+              !strstr(buf, "Flom?"),
+              "school: a copular definition teaches an unknown on first mention");
+
+        Leo composite; leo_init(&composite);
+        leo_ingest(&composite, "the rain falls. leo hears the sound. his mother is warm.");
+        leo_respond(&composite,
+                    "Flom is the gentle comfort of warm light or cool rain",
+                    buf, sizeof buf);
+        CHECK(leo_school_is_learned(&composite, "flom") &&
+              !composite.school.pending[0] &&
+              composite.curiosity.outcome == LEO_CURIOSITY_RESOLVED,
+              "school: a rich first-turn definition is admitted instead of re-asked");
+
+        Leo incidental; leo_init(&incidental);
+        leo_ingest(&incidental, "the rain falls. leo hears the sound. his mother is warm.");
+        leo_respond(&incidental, "I saw a nareth beside water", buf, sizeof buf);
+        CHECK(!leo_school_is_learned(&incidental, "nareth"),
+              "school: co-presence cannot counterfeit a first-turn definition");
+
+        Leo negative; leo_init(&negative);
+        leo_ingest(&negative, "the rain falls. leo hears the sound. his mother is warm.");
+        leo_respond(&negative, "a suvin is not water", buf, sizeof buf);
+        CHECK(!leo_school_is_learned(&negative, "suvin"),
+              "school: rejection alone cannot assign a first-turn meaning");
+
+        Leo unknown_rhs; leo_init(&unknown_rhs);
+        leo_ingest(&unknown_rhs, "the rain falls. leo hears the sound. his mother is warm.");
+        leo_respond(&unknown_rhs, "a tral is glorp", buf, sizeof buf);
+        CHECK(!leo_school_is_learned(&unknown_rhs, "tral"),
+              "school: an unknown right-hand side cannot counterfeit grounding");
+
         Leo deferred; leo_init(&deferred);
         leo_ingest(&deferred, "suvin suvin suvin");
         char selected[LEO_HEARD_WORDLEN], delayed[LEO_HEARD_WORDLEN];
@@ -3436,7 +3475,9 @@ int main(void) {
               sc.curiosity.outcome == LEO_CURIOSITY_DISABLED,
               "school: --no-school suppresses the question and says why");
         g_leo_school_on = prev;
-        leo_free(&sc); leo_free(&deferred);
+        leo_free(&sc); leo_free(&direct); leo_free(&composite);
+        leo_free(&incidental); leo_free(&negative); leo_free(&unknown_rhs);
+        leo_free(&deferred);
     }
 
     /* A.37: Pre-Wonder remembers a question the body could not safely ask.


### PR DESCRIPTION
Teach a novel subject from a bounded copular definition on its first turn while refusing co-presence, negative-only evidence, and an unknown right-hand side. Add regression coverage and a cross-process receipt.

Quote: "A lesson can arrive before the question." - Sol

Method: The Arianna Method lets grounded meaning close a gap before curiosity mistakes it for silence.