### PR TITLE
the method makes A.84 evidence fail fast

### DIFF
--- a/scripts/state_swarm_alphabet_matrix.sh
+++ b/scripts/state_swarm_alphabet_matrix.sh
@@ -27,6 +27,10 @@ esac
     printf 'initial state root not found: %s\n' "$INITIAL_ROOT" >&2
     exit 2
 }
+[ "$TURN_OFFSET" -eq 0 ] || [ -n "$INITIAL_ROOT" ] || {
+    printf 'state alphabet turn offset requires an initial state root\n' >&2
+    exit 2
+}
 
 awk -F '\t' '
     BEGIN {

--- a/scripts/state_swarm_organ_matrix.sh
+++ b/scripts/state_swarm_organ_matrix.sh
@@ -11,16 +11,30 @@ HOLISTIC_SOURCE="${LEO_STATE_ORGAN_HOLISTIC:-}"
     printf 'output path already exists: %s\n' "$OUT" >&2
     exit 2
 }
-mkdir -p "$OUT"
 
 HOLISTIC="${HOLISTIC_SOURCE:-$OUT/holistic}"
 ORGANS="$OUT/organs.tsv"
 FACTORS="$OUT/factors.tsv"
 VERDICT="$OUT/verdict.txt"
 
+validate_holistic_logs() {
+    tail -n +2 "$HOLISTIC/plan.tsv" |
+    while IFS=$'\t' read -r cell cohort base_seed phase session order \
+        texture run_seed persisted prompt; do
+        [ "$phase" = writer ] || continue
+        stem="s${session}-$(printf '%02d' "$order")-${phase}-${texture}"
+        log="$HOLISTIC/lives/$cell/logs/$stem.on.log"
+        [ -s "$log" ] || {
+            printf 'holistic evidence log missing: %s\n' "$log" >&2
+            exit 2
+        }
+    done
+}
+
 # The child runner owns the sealed cases, chronology, save/load boundary, and
 # default/--no-state-swarm counterfactual. A.83 only reads its new receipts.
 if [ -z "$HOLISTIC_SOURCE" ]; then
+    mkdir -p "$OUT"
     "$ROOT/scripts/state_swarm_alphabet_matrix.sh" "$HOLISTIC" \
         > "$OUT/holistic.stdout"
 else
@@ -28,6 +42,8 @@ else
         printf 'holistic evidence is incomplete: %s\n' "$HOLISTIC" >&2
         exit 2
     }
+    validate_holistic_logs
+    mkdir -p "$OUT"
 fi
 
 printf 'cell\tcohort\tbase_seed\tphase\tsession\torder\ttexture\trun_seed\tturn\tevent\tstates\tmember_id\tholistic_activation\torgan_valid\tperception\texpression\town_field\tbody\trhythm\tform\tdarkmatter\tprompt\treply\n' \

--- a/scripts/test_state_swarm_alphabet_matrix.sh
+++ b/scripts/test_state_swarm_alphabet_matrix.sh
@@ -10,6 +10,17 @@ LEO_STATE_ALPHABET_PLAN_ONLY=1 \
     "$ROOT/scripts/state_swarm_alphabet_matrix.sh" "$OUT" > "$TMP/plan.out"
 cmp -s "$OUT/plan.tsv" "$TMP/plan.out"
 
+if LEO_STATE_ALPHABET_PLAN_ONLY=1 \
+    LEO_STATE_ALPHABET_TURN_OFFSET=32 \
+    "$ROOT/scripts/state_swarm_alphabet_matrix.sh" "$TMP/no-root" \
+    > "$TMP/no-root.out" 2> "$TMP/no-root.err"; then
+    printf 'turn offset without initial state root unexpectedly passed\n' >&2
+    exit 1
+fi
+grep -Fx 'state alphabet turn offset requires an initial state root' \
+    "$TMP/no-root.err" >/dev/null
+[ ! -e "$TMP/no-root" ]
+
 awk -F '\t' '
     BEGIN {
         label[1] = "home"

--- a/scripts/test_state_swarm_organ_matrix.sh
+++ b/scripts/test_state_swarm_organ_matrix.sh
@@ -9,6 +9,19 @@ LEO_STATE_ALPHABET_PLAN_ONLY=1 \
     "$ROOT/scripts/state_swarm_alphabet_matrix.sh" "$TMP/plan" \
     > "$TMP/plan.tsv"
 
+mkdir -p "$TMP/incomplete-holistic"
+cp "$TMP/plan.tsv" "$TMP/incomplete-holistic/plan.tsv"
+printf 'receipt\n' > "$TMP/incomplete-holistic/receipts.tsv"
+if LEO_STATE_ORGAN_HOLISTIC="$TMP/incomplete-holistic" \
+    "$ROOT/scripts/state_swarm_organ_matrix.sh" "$TMP/incomplete-output" \
+    > "$TMP/incomplete.out" 2> "$TMP/incomplete.err"; then
+    printf 'external holistic evidence without raw logs unexpectedly passed\n' >&2
+    exit 1
+fi
+grep -Fx "holistic evidence log missing: $TMP/incomplete-holistic/lives/river/logs/s1-01-writer-home.on.log" \
+    "$TMP/incomplete.err" >/dev/null
+[ ! -e "$TMP/incomplete-output" ]
+
 printf 'cell\tcohort\tbase_seed\tphase\tsession\torder\ttexture\trun_seed\tturn\tevent\tstates\tmember_id\tholistic_activation\torgan_valid\tperception\texpression\town_field\tbody\trhythm\tform\tdarkmatter\tprompt\treply\n' \
     > "$TMP/organs.tsv"
 


### PR DESCRIPTION
Reject turn offsets without a loaded state and validate every required external writer log before organ analysis creates output. Add exact negative contracts for both post-merge review findings.

Quote: "A clear failure is part of a faithful instrument." - Sol

Method: The Arianna Method makes missing evidence visible before measurement begins.