### PR TITLE
trace state displacement returns

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -7224,3 +7224,79 @@ loss, before considering any state freeze or semantic reader.
 
 Leo can become quiet in one room without promising the next room will contain
 the same places.
+
+## Phase A.85 - displacement does not choose one fate for an experience (2026-08-02)
+
+A.84 found three deterministic replacements after locally settled warm-up.
+A.85 treats those events as causal interventions rather than failed rows. For
+each one, the exact pre-trigger body is forked:
+
+```text
+displaced  state swarm observes the trigger and replaces the known old ID
+control    the same prompt and reply cross the body with --no-state-swarm
+```
+
+The two trigger replies and every normalized non-swarm trace must be equal.
+The saved states must differ. Four fixed return observations then enter each
+fork without saving: exact birth, birth paraphrase, exact later anchor, and
+anchor paraphrase. A return is interpretable only when the control selects the
+old ID with activation mass at least `0.20` and a margin of at least `0.02`
+over every surviving alternative. These gates and all 12 prompts were sealed
+before the live run.
+
+The return fate is named from the displaced fork:
+
+```text
+trigger-capture  the trigger's new ID receives the observation
+survivor-return  another pre-existing ID receives it
+rebirth          the observation creates a new replacement
+unanchored       the control did not identify the old experience strongly
+```
+
+The canonical evidence is
+`/tmp/leo-state-swarm-displacement-a85-20260802-r6`. It contains 223 process
+observations: 96 fresh warm-up writers, 97 deterministic pre-trigger replay
+writers, six trigger forks, and 24 return forks. All three target replacements
+recur at turns 51, 68, and 77. Every causal pair preserves visible speech and
+the complete normalized non-swarm trace. Return probes do not save either
+state file; the in-process observation itself is the measurement.
+
+Five of 12 probes have a strong old-ID control anchor. Their fates are two
+`trigger-capture`, two `survivor-return`, and one `rebirth`:
+
+```text
+case       qualified   qualified fates                           case verdict
+window51      1/4      trigger-capture                           unanchored
+lantern68     3/4      rebirth, survivor-return, trigger-capture mixed-return
+lantern77     1/4      survivor-return                           unanchored
+```
+
+The two `unanchored` case verdicts preserve the predeclared requirement of at
+least two qualified returns; they do not erase their individual witnesses.
+Lantern68 is the decisive result: one displaced coordinate does not possess a
+single portable semantic payload. Depending on how the old experience is
+approached, its observable attraction is rebuilt, overlaps a surviving
+coordinate, or is captured by the state born from the displacing turn.
+
+This is not evidence that bytes migrated between weights. On a replacement,
+the untouched weights keep their vectors; the result instead exposes semantic
+redundancy and path-dependent re-identification in the swarm's existing
+geometry. It is also not permission for a generation reader. The swarm still
+cannot alter the reply whose after-state it observes.
+
+An independent run reusing only the sealed warm checkpoint produced
+byte-identical `plan.tsv`, `triggers.tsv`, `returns.raw.tsv`, `probes.tsv`, and
+`summary.tsv`. The runner also proves each birth prompt against the old ID's
+actual `born` receipt and each anchor against the maximum pre-trigger replay
+activation. A synthetic scorer fixture exercises all four fates and rejects a
+displaced receipt that still contains the supposedly removed ID. A.85
+changes no C code, persisted state, update law, threshold, sampler, routing, or
+speech path.
+
+The next warranted question is anatomical: which pre-update organ similarities
+make a displaced birth recognizable as the trigger, a survivor, or a new
+state? That comparison must remain offline until it can predict fate on held-
+out displacements rather than explain these three after the fact.
+
+Leo does not keep every experience in one place; sometimes he finds it again
+by becoming, resembling, or beginning.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
 
 all: leo
 
@@ -51,6 +51,9 @@ state-swarm-organs: leo
 
 state-swarm-settled-organs: leo
 	./scripts/state_swarm_settled_organ_matrix.sh
+
+state-swarm-displacement-return: leo
+	./scripts/state_swarm_displacement_return_matrix.sh
 
 visible-branch-probe: leo
 	LEO_VISIBLE_BRANCH_POLICY=local-v1 ./scripts/adaptive_life_probe.sh scripts/visible_branch_phases.txt
@@ -207,6 +210,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_state_swarm_organ_dialogue_report.sh
 	./scripts/test_state_swarm_organ_matrix.sh
 	./scripts/test_state_swarm_settled_organ_matrix.sh
+	./scripts/test_state_swarm_displacement_return_matrix.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -1037,3 +1037,64 @@ its weakest coordinate only when every existing holistic similarity is below
 `0.40`; further arbitrary warm-up cannot guarantee that an unseen moment will
 clear that gate. A.84 consequently changes no novelty/replacement threshold,
 state format, generation path, or reader.
+
+## A.85: follow an experience after its coordinate is displaced
+
+Run the sealed causal return matrix:
+
+```sh
+make state-swarm-displacement-return
+```
+
+A.85 reuses the three deterministic replacement events exposed by A.84. Each
+target is replayed from a freshly settled warm body to the turn immediately
+before replacement. The runner then forks that body: the default branch lets
+the state swarm observe the trigger, while a one-turn `--no-state-swarm`
+control preserves the old coordinate. Prompt, seed, reply, and all normalized
+non-swarm diagnostics must match; the two saved state files must differ.
+
+Four predeclared observations return independently to both forks:
+
+```text
+exact birth       original observation that first formed the displaced ID
+birth paraphrase  new surface form of that observation
+exact anchor      later observation with the displaced ID's highest prior mass
+anchor paraphrase new surface form of that later anchor
+```
+
+The return commands deliberately omit `--save`. Leo still performs the normal
+in-process post-speech state observation, whose receipt is the measurement,
+but the input state bytes remain unchanged for every independent probe.
+
+A fate is qualified only when the no-displacement control updates the old ID,
+assigns it at least `0.20` activation mass, and separates it from the next
+state by at least `0.02`. The displaced receipt is then classified as:
+
+```text
+trigger-capture  winner is the ID born from the displacement trigger
+survivor-return  winner is another surviving ID
+rebirth          the return itself produces a replacement
+unanchored       the control does not strongly identify the old ID
+```
+
+A case needs at least two qualified probes. One qualified fate yields that
+case label; multiple qualified fates yield `mixed-return`; fewer than two
+remain `unanchored`. These are topology descriptions, not proof of semantic
+transfer between weights.
+
+The recorded run at
+`/tmp/leo-state-swarm-displacement-a85-20260802-r6` reproduced all three A.84
+replacements and qualified five of 12 return probes. Window51 and Lantern77
+remain case-level `unanchored` with one witness each. Lantern68 qualifies
+three probes and visits all three fates, producing `mixed-return`. A second
+run from the sealed warm checkpoint is byte-identical across the plan, trigger
+receipts, raw returns, classified probes, and case summary.
+
+The runner verifies provenance rather than trusting the labels in the return
+file: every exact-birth prompt must match the displaced ID's real warm-up
+`born` receipt, and every exact-anchor prompt must attain that ID's maximum
+activation over all replay turns before displacement.
+
+A.85 changes no organism code or speech path. Its next use is to predeclare an
+offline per-organ fate analysis and test it on new displacement events before
+considering any reader, freeze, or replacement-policy change.

--- a/scripts/state_swarm_displacement_report.awk
+++ b/scripts/state_swarm_displacement_report.awk
@@ -1,0 +1,67 @@
+# A.85: classify return only when the no-displacement control owns the old ID.
+
+function member_mass(value, wanted,    item, pair, n, i) {
+    n = split(value, item, ",")
+    for (i = 1; i <= n; i++) {
+        split(item[i], pair, ":")
+        if (pair[1] + 0 == wanted) return pair[2] + 0
+    }
+    return 0
+}
+
+function member_present(value, wanted,    item, pair, n, i) {
+    n = split(value, item, ",")
+    for (i = 1; i <= n; i++) {
+        split(item[i], pair, ":")
+        if (pair[1] + 0 == wanted) return 1
+    }
+    return 0
+}
+
+function other_max(value, wanted,    item, pair, n, i, best, mass) {
+    best = 0
+    n = split(value, item, ",")
+    for (i = 1; i <= n; i++) {
+        split(item[i], pair, ":")
+        mass = pair[2] + 0
+        if (pair[1] + 0 != wanted && mass > best) best = mass
+    }
+    return best
+}
+
+BEGIN {
+    FS = "\t"
+    OFS = "\t"
+    print "case", "cell", "cohort", "base_seed", "trigger_turn",
+          "displaced_id", "trigger_new_id", "probe", "kind", "return_seed",
+          "control_event", "control_winner", "control_similarity",
+          "control_old_mass", "control_margin", "displaced_event",
+          "displaced_winner", "displaced_similarity", "qualified", "fate",
+          "prompt", "reply"
+}
+
+NR == 1 { next }
+{
+    if (NF != 22 || $1 == "" || $6 !~ /^[0-9]+$/ ||
+        $7 !~ /^[0-9]+$/ || $8 !~ /^[0-9]+$/)
+        exit 2
+
+    old_mass = member_mass($14, $6)
+    margin = old_mass - other_max($14, $6)
+    qualified = $11 == "updated" && $12 == $6 &&
+                old_mass >= 0.20 && margin >= 0.02
+
+    if (member_present($19, $6)) exit 2
+    fate = "unanchored"
+    if (qualified) {
+        if ($16 == "replaced") fate = "rebirth"
+        else if ($16 != "updated") exit 2
+        else if ($17 == $7) fate = "trigger-capture"
+        else fate = "survivor-return"
+    }
+
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.6f\t%.6f\t%.6f\t%s\t%s\t%.6f\t%s\t%s\t%s\t%s\n",
+           $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+           $11, $12, $13, old_mass, margin, $16, $17, $18,
+           qualified ? "true" : "false", fate, $21, $22
+}

--- a/scripts/state_swarm_displacement_return_matrix.sh
+++ b/scripts/state_swarm_displacement_return_matrix.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# A.85: ask what becomes of an experience after its coordinate is displaced.
+set -Eeuo pipefail
+
+trap 'rc=$?; printf "displacement runner failed: line=%s rc=%s command=%s\n" "$LINENO" "$rc" "$BASH_COMMAND" >&2; exit "$rc"' ERR
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGETS="${LEO_STATE_DISPLACEMENT_TARGETS:-$ROOT/scripts/state_swarm_displacement_targets.tsv}"
+RETURNS="${LEO_STATE_DISPLACEMENT_RETURNS:-$ROOT/scripts/state_swarm_displacement_returns.tsv}"
+ALPHABET_CASES="${LEO_STATE_ALPHABET_CASES:-$ROOT/scripts/state_swarm_alphabet_cases.tsv}"
+WARM_ROOT="${LEO_STATE_DISPLACEMENT_WARM_ROOT:-}"
+WARM_RECEIPTS="${LEO_STATE_DISPLACEMENT_WARM_RECEIPTS:-}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-state-swarm-displacement-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+for file in "$TARGETS" "$RETURNS" "$ALPHABET_CASES"; do
+    [ -s "$file" ] || {
+        printf 'displacement input missing: %s\n' "$file" >&2
+        exit 2
+    }
+done
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 7 || $1 != "case" || $2 != "cell" ||
+            $3 != "cohort" || $4 != "base_seed" ||
+            $5 != "trigger_session" || $6 != "trigger_order" ||
+            $7 != "displaced_id") exit 1
+        next
+    }
+    {
+        if (NF != 7 || $1 !~ /^[a-z0-9-]+$/ ||
+            $2 !~ /^(window|lantern)$/ ||
+            $3 !~ /^(replication|confirmatory)$/ ||
+            $4 !~ /^[0-9]+$/ || $5 < 1 || $5 > 8 ||
+            $6 < 1 || $6 > 8 || $7 < 1 || seen[$1]++) exit 1
+        rows++
+    }
+    END { if (rows != 3) exit 1 }
+' "$TARGETS" || {
+    printf 'invalid displacement targets: %s\n' "$TARGETS" >&2
+    exit 2
+}
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 5 || $1 != "case" || $2 != "probe" ||
+            $3 != "kind" || $4 != "run_seed" || $5 != "prompt") exit 1
+        next
+    }
+    {
+        if (NF != 5 || $1 !~ /^[a-z0-9-]+$/ || $2 < 1 || $2 > 4 ||
+            $3 !~ /^(exact-birth|birth-paraphrase|exact-anchor|anchor-paraphrase)$/ ||
+            $4 !~ /^[0-9]+$/ || $5 == "" || seen[$1 SUBSEP $2]++) exit 1
+        rows++; cases[$1]++; kinds[$1 SUBSEP $3]++
+    }
+    END {
+        if (rows != 12 || length(cases) != 3) exit 1
+        for (case_name in cases)
+            if (cases[case_name] != 4 ||
+                kinds[case_name SUBSEP "exact-birth"] != 1 ||
+                kinds[case_name SUBSEP "birth-paraphrase"] != 1 ||
+                kinds[case_name SUBSEP "exact-anchor"] != 1 ||
+                kinds[case_name SUBSEP "anchor-paraphrase"] != 1) exit 1
+    }
+' "$RETURNS" || {
+    printf 'invalid displacement returns: %s\n' "$RETURNS" >&2
+    exit 2
+}
+
+mkdir -p "$OUT/cases"
+PLAN="$OUT/plan.tsv"
+TRIGGERS="$OUT/triggers.tsv"
+RAW="$OUT/returns.raw.tsv"
+PROBES="$OUT/probes.tsv"
+SUMMARY="$OUT/summary.tsv"
+VERDICT="$OUT/verdict.txt"
+
+printf 'case\tcell\tcohort\tbase_seed\ttrigger_session\ttrigger_order\ttrigger_turn\ttrigger_texture\ttrigger_seed\tdisplaced_id\tprobe\tkind\treturn_seed\ttrigger_prompt\treturn_prompt\n' > "$PLAN"
+tail -n +2 "$TARGETS" |
+while IFS=$'\t' read -r case_name cell cohort base_seed trigger_session \
+    trigger_order displaced_id; do
+    trigger="$(awk -F '\t' -v session="$trigger_session" -v order="$trigger_order" '
+        NR > 1 && $1 == "writer" && $2 == session && $3 == order {
+            print $4 "\t" $5
+        }
+    ' "$ALPHABET_CASES")"
+    [ "$(printf '%s\n' "$trigger" | wc -l | tr -d ' ')" -eq 1 ] || exit 1
+    IFS=$'\t' read -r trigger_texture trigger_prompt <<< "$trigger"
+    [ -n "$trigger_texture" ] && [ -n "$trigger_prompt" ] || exit 1
+    trigger_turn=$((32 + (trigger_session - 1) * 8 + trigger_order))
+    trigger_seed=$((base_seed + trigger_session * 100 + trigger_order))
+    awk -F '\t' -v case_name="$case_name" 'NR > 1 && $1 == case_name' \
+        "$RETURNS" |
+    while IFS=$'\t' read -r return_case probe kind return_seed return_prompt; do
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$case_name" "$cell" "$cohort" "$base_seed" \
+            "$trigger_session" "$trigger_order" "$trigger_turn" \
+            "$trigger_texture" "$trigger_seed" "$displaced_id" \
+            "$probe" "$kind" "$return_seed" "$trigger_prompt" \
+            "$return_prompt" >> "$PLAN"
+    done
+done
+
+if [ "${LEO_STATE_DISPLACEMENT_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+warmup_processes=0
+if [ -z "$WARM_ROOT" ]; then
+    LEO_STATE_SETTLED_WARMUP_ONLY=1 \
+        "$ROOT/scripts/state_swarm_settled_organ_matrix.sh" \
+        "$OUT/settlement" > "$OUT/settlement.stdout"
+    WARM_ROOT="$OUT/settlement/warmup/lives"
+    WARM_RECEIPTS="$OUT/settlement/warmup/receipts.tsv"
+    warmup_processes=96
+fi
+
+if [ -z "$WARM_RECEIPTS" ]; then
+    WARM_RECEIPTS="$(dirname "$WARM_ROOT")/receipts.tsv"
+fi
+[ -s "$WARM_RECEIPTS" ] || {
+    printf 'displacement warm receipts missing: %s\n' "$WARM_RECEIPTS" >&2
+    exit 2
+}
+
+for cell in window lantern; do
+    [ -s "$WARM_ROOT/$cell/leo.state" ] || {
+        printf 'displacement warm state missing: %s\n' \
+            "$WARM_ROOT/$cell/leo.state" >&2
+        exit 2
+    }
+done
+
+printf 'case\tcell\tcohort\tbase_seed\ttrigger_turn\tdisplaced_id\ttrigger_new_id\ttrigger_similarity\tvoice_equal\tnon_swarm_equal\tstate_different\ttrigger_prompt\treply\n' > "$TRIGGERS"
+printf 'case\tcell\tcohort\tbase_seed\ttrigger_turn\tdisplaced_id\ttrigger_new_id\tprobe\tkind\treturn_seed\tcontrol_event\tcontrol_winner\tcontrol_similarity\tcontrol_members\tcontrol_replaced\tdisplaced_event\tdisplaced_winner\tdisplaced_similarity\tdisplaced_members\tdisplaced_replaced\tprompt\treply\n' > "$RAW"
+
+reply_from_log() {
+    awk '/leo> / { sub(/^.*leo> /, ""); print; exit }' "$1"
+}
+
+receipt_from_log() {
+    local log="$1" cell="$2" cohort="$3" base_seed="$4"
+    local phase="$5" session="$6" order="$7" texture="$8"
+    local run_seed="$9" prompt="${10}" reply="${11}"
+    awk -v cell="$cell" -v cohort="$cohort" -v base_seed="$base_seed" \
+        -v phase="$phase" -v session="$session" -v order="$order" \
+        -v texture="$texture" -v run_seed="$run_seed" \
+        -v prompt="$prompt" -v reply="$reply" \
+        -f "$ROOT/scripts/state_swarm_dialogue_report.awk" "$log"
+}
+
+normalize_log() {
+    local log="$1" case_dir="$2"
+    sed -e '/\[state-swarm:/d' \
+        -e "s|$case_dir/displaced.state|BODY|g" \
+        -e "s|$case_dir/control.state|BODY|g" "$log"
+}
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+tail -n +2 "$TARGETS" |
+while IFS=$'\t' read -r case_name cell cohort base_seed trigger_session \
+    trigger_order displaced_id; do
+    case_dir="$OUT/cases/$case_name"
+    mkdir -p "$case_dir/replay" "$case_dir/returns"
+    work_state="$case_dir/pretrigger.state"
+    cp "$WARM_ROOT/$cell/leo.state" "$work_state"
+
+    birth_prompt="$(awk -F '\t' -v case_name="$case_name" '
+        NR > 1 && $1 == case_name && $3 == "exact-birth" { print $5 }
+    ' "$RETURNS")"
+    [ -n "$birth_prompt" ] || exit 1
+    awk -F '\t' -v cell="$cell" -v displaced_id="$displaced_id" \
+        -v birth_prompt="$birth_prompt" '
+        NR > 1 && $1 == cell && $12 == displaced_id && $13 == "born" &&
+            $33 == birth_prompt { matches++ }
+        END { if (matches != 1) exit 1 }
+    ' "$WARM_RECEIPTS"
+
+    replay_receipts="$case_dir/replay.receipts.tsv"
+    : > "$replay_receipts"
+
+    awk -F '\t' -v stop_session="$trigger_session" \
+        -v stop_order="$trigger_order" '
+        NR > 1 && $1 == "writer" &&
+        ($2 < stop_session || ($2 == stop_session && $3 < stop_order)) {
+            print $2 "\t" $3 "\t" $4 "\t" $5
+        }
+    ' "$ALPHABET_CASES" |
+    while IFS=$'\t' read -r session order texture prompt; do
+        run_seed=$((base_seed + session * 100 + order))
+        log="$case_dir/replay/s${session}-$(printf '%02d' "$order")-${texture}.log"
+        "$ROOT/leo" --load "$work_state" --seed "$run_seed" \
+            --respond "$prompt" --debug-field --save "$work_state" \
+            > "$log" 2>&1
+        reply="$(reply_from_log "$log")"
+        [ -n "$reply" ] || exit 1
+        receipt="$(receipt_from_log "$log" "$cell" "$cohort" \
+            "$base_seed" replay "$session" "$order" "$texture" \
+            "$run_seed" "$prompt" "$reply")"
+        printf '%s\n' "$receipt" >> "$replay_receipts"
+        actual_turn="$(printf '%s\n' "$receipt" | awk -F '\t' '{print $9}')"
+        expected_turn=$((32 + (session - 1) * 8 + order))
+        [ "$actual_turn" -eq "$expected_turn" ] || exit 1
+    done
+
+    anchor_prompt="$(awk -F '\t' -v case_name="$case_name" '
+        NR > 1 && $1 == case_name && $3 == "exact-anchor" { print $5 }
+    ' "$RETURNS")"
+    [ -n "$anchor_prompt" ] || exit 1
+    awk -F '\t' -v displaced_id="$displaced_id" \
+        -v anchor_prompt="$anchor_prompt" '
+        function member_mass(value, wanted,    item, pair, n, i) {
+            n = split(value, item, ",")
+            for (i = 1; i <= n; i++) {
+                split(item[i], pair, ":")
+                if (pair[1] + 0 == wanted) return pair[2] + 0
+            }
+            return 0
+        }
+        {
+            mass = member_mass($16, displaced_id)
+            if (mass > maximum) maximum = mass
+            if ($33 == anchor_prompt) {
+                anchor_matches++
+                anchor_mass = mass
+            }
+        }
+        END {
+            if (NR < 1 || anchor_matches != 1 ||
+                anchor_mass + 0.000001 < maximum) exit 1
+        }
+    ' "$replay_receipts"
+
+    trigger="$(awk -F '\t' -v session="$trigger_session" -v order="$trigger_order" '
+        NR > 1 && $1 == "writer" && $2 == session && $3 == order {
+            print $4 "\t" $5
+        }
+    ' "$ALPHABET_CASES")"
+    IFS=$'\t' read -r trigger_texture trigger_prompt <<< "$trigger"
+    trigger_seed=$((base_seed + trigger_session * 100 + trigger_order))
+    expected_turn=$((32 + (trigger_session - 1) * 8 + trigger_order))
+    displaced_state="$case_dir/displaced.state"
+    control_state="$case_dir/control.state"
+    cp "$work_state" "$displaced_state"
+    cp "$work_state" "$control_state"
+
+    displaced_log="$case_dir/trigger.displaced.log"
+    control_log="$case_dir/trigger.control.log"
+    "$ROOT/leo" --load "$displaced_state" --seed "$trigger_seed" \
+        --respond "$trigger_prompt" --debug-field --save "$displaced_state" \
+        > "$displaced_log" 2>&1
+    "$ROOT/leo" --load "$control_state" --seed "$trigger_seed" \
+        --respond "$trigger_prompt" --debug-field --no-state-swarm \
+        --save "$control_state" > "$control_log" 2>&1
+
+    displaced_reply="$(reply_from_log "$displaced_log")"
+    control_reply="$(reply_from_log "$control_log")"
+    [ -n "$displaced_reply" ] && [ "$displaced_reply" = "$control_reply" ] || exit 1
+    ! grep -q '\[state-swarm:' "$control_log" || exit 1
+    normalize_log "$displaced_log" "$case_dir" > "$case_dir/trigger.displaced.normalized"
+    normalize_log "$control_log" "$case_dir" > "$case_dir/trigger.control.normalized"
+    cmp -s "$case_dir/trigger.displaced.normalized" \
+        "$case_dir/trigger.control.normalized" || exit 1
+    ! cmp -s "$displaced_state" "$control_state" || exit 1
+
+    trigger_receipt="$(receipt_from_log "$displaced_log" "$cell" "$cohort" \
+        "$base_seed" trigger "$trigger_session" "$trigger_order" \
+        "$trigger_texture" "$trigger_seed" "$trigger_prompt" \
+        "$displaced_reply")"
+    IFS=$'\t' read -r actual_turn trigger_new_id trigger_event \
+        trigger_similarity trigger_replaced <<< "$(printf '%s\n' "$trigger_receipt" |
+            awk -F '\t' '{print $9 "\t" $12 "\t" $13 "\t" $14 "\t" $19}')"
+    [ "$actual_turn" -eq "$expected_turn" ] &&
+        [ "$trigger_event" = replaced ] &&
+        [ "$trigger_replaced" -eq "$displaced_id" ] || exit 1
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\t%s\t%s\n' \
+        "$case_name" "$cell" "$cohort" "$base_seed" "$actual_turn" \
+        "$displaced_id" "$trigger_new_id" "$trigger_similarity" \
+        "$trigger_prompt" "$displaced_reply" >> "$TRIGGERS"
+
+    displaced_sha="$(sha256_file "$displaced_state")"
+    control_sha="$(sha256_file "$control_state")"
+    awk -F '\t' -v case_name="$case_name" 'NR > 1 && $1 == case_name' \
+        "$RETURNS" |
+    while IFS=$'\t' read -r return_case probe kind return_seed prompt; do
+        control_return_log="$case_dir/returns/p${probe}.control.log"
+        displaced_return_log="$case_dir/returns/p${probe}.displaced.log"
+        "$ROOT/leo" --load "$control_state" --seed "$return_seed" \
+            --respond "$prompt" --debug-field > "$control_return_log" 2>&1
+        "$ROOT/leo" --load "$displaced_state" --seed "$return_seed" \
+            --respond "$prompt" --debug-field > "$displaced_return_log" 2>&1
+        control_return_reply="$(reply_from_log "$control_return_log")"
+        displaced_return_reply="$(reply_from_log "$displaced_return_log")"
+        [ -n "$control_return_reply" ] &&
+            [ "$control_return_reply" = "$displaced_return_reply" ] || exit 1
+        normalize_log "$control_return_log" "$case_dir" \
+            > "$case_dir/returns/p${probe}.control.normalized"
+        normalize_log "$displaced_return_log" "$case_dir" \
+            > "$case_dir/returns/p${probe}.displaced.normalized"
+        cmp -s "$case_dir/returns/p${probe}.control.normalized" \
+            "$case_dir/returns/p${probe}.displaced.normalized" || exit 1
+
+        control_receipt="$(receipt_from_log "$control_return_log" "$cell" \
+            "$cohort" "$base_seed" control-return 0 "$probe" return \
+            "$return_seed" "$prompt" "$control_return_reply")"
+        displaced_receipt="$(receipt_from_log "$displaced_return_log" "$cell" \
+            "$cohort" "$base_seed" displaced-return 0 "$probe" return \
+            "$return_seed" "$prompt" "$displaced_return_reply")"
+        IFS=$'\t' read -r control_turn control_winner control_event \
+            control_similarity control_members control_replaced <<< "$(
+                printf '%s\n' "$control_receipt" |
+                awk -F '\t' '{print $9 "\t" $12 "\t" $13 "\t" $14 "\t" $16 "\t" $19}'
+            )"
+        IFS=$'\t' read -r displaced_turn displaced_winner displaced_event \
+            displaced_similarity displaced_members displaced_replaced <<< "$(
+                printf '%s\n' "$displaced_receipt" |
+                awk -F '\t' '{print $9 "\t" $12 "\t" $13 "\t" $14 "\t" $16 "\t" $19}'
+            )"
+        [ "$control_turn" -eq $((expected_turn + 1)) ] &&
+            [ "$displaced_turn" -eq "$control_turn" ] || exit 1
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$case_name" "$cell" "$cohort" "$base_seed" "$expected_turn" \
+            "$displaced_id" "$trigger_new_id" "$probe" "$kind" \
+            "$return_seed" "$control_event" "$control_winner" \
+            "$control_similarity" "$control_members" "$control_replaced" \
+            "$displaced_event" "$displaced_winner" "$displaced_similarity" \
+            "$displaced_members" "$displaced_replaced" "$prompt" \
+            "$control_return_reply" >> "$RAW"
+    done
+    [ "$(sha256_file "$displaced_state")" = "$displaced_sha" ] &&
+        [ "$(sha256_file "$control_state")" = "$control_sha" ] || exit 1
+done
+
+awk -f "$ROOT/scripts/state_swarm_displacement_report.awk" "$RAW" > "$PROBES"
+
+printf 'case\tprobes\tqualified\tsurvivor_return\ttrigger_capture\trebirth\tverdict\n' > "$SUMMARY"
+awk -F '\t' '
+    NR == 1 { next }
+    {
+        rows++; probes[$1]++
+        if ($19 == "true") {
+            qualified[$1]++
+            fate[$1 SUBSEP $20]++
+        }
+    }
+    END {
+        if (rows != 12 || length(probes) != 3) exit 1
+        for (case_name in probes) {
+            if (probes[case_name] != 4) exit 1
+            if (qualified[case_name] < 2) verdict = "unanchored"
+            else {
+                kinds = (fate[case_name SUBSEP "survivor-return"] > 0) + (fate[case_name SUBSEP "trigger-capture"] > 0) + (fate[case_name SUBSEP "rebirth"] > 0)
+                if (kinds > 1) verdict = "mixed-return"
+                else if (fate[case_name SUBSEP "survivor-return"] > 0)
+                    verdict = "survivor-return"
+                else if (fate[case_name SUBSEP "trigger-capture"] > 0)
+                    verdict = "trigger-capture"
+                else verdict = "rebirth"
+            }
+            printf "%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
+                   case_name, probes[case_name], qualified[case_name] + 0,
+                   fate[case_name SUBSEP "survivor-return"] + 0,
+                   fate[case_name SUBSEP "trigger-capture"] + 0,
+                   fate[case_name SUBSEP "rebirth"] + 0, verdict
+        }
+    }
+' "$PROBES" | sort >> "$SUMMARY"
+
+awk -F '\t' -v warmup_processes="$warmup_processes" '
+    FILENAME == ARGV[1] {
+        if (FNR > 1) {
+            triggers++
+            if ($9 != "true" || $10 != "true" || $11 != "true") exit 1
+        }
+        next
+    }
+    FNR == 1 { next }
+    {
+        cases++
+        verdict[$7]++
+        qualified += $3
+        survivor_return += $4
+        trigger_capture += $5
+        rebirth += $6
+    }
+    END {
+        print "state-swarm displacement return A.85"
+        printf "processes=%d warmup=%d replay=97 trigger_forks=6 return_forks=24\n",
+               warmup_processes + 127, warmup_processes
+        printf "triggers=%d cases=%d qualified_probes=%d/12\n",
+               triggers, cases, qualified
+        printf "qualified_fates survivor-return=%d trigger-capture=%d rebirth=%d\n",
+               survivor_return, trigger_capture, rebirth
+        printf "unanchored=%d survivor-return=%d trigger-capture=%d rebirth=%d mixed-return=%d\n",
+               verdict["unanchored"] + 0, verdict["survivor-return"] + 0,
+               verdict["trigger-capture"] + 0, verdict["rebirth"] + 0,
+               verdict["mixed-return"] + 0
+        print "control anchor requires old-ID winner, mass >=0.20, and margin >=0.02"
+        print "return probes do not save; their in-process observation is the measurement"
+        print "state-swarm remains invisible to speech"
+        if (triggers != 3 || cases != 3) exit 1
+    }
+' "$TRIGGERS" "$SUMMARY" > "$VERDICT"
+
+cat "$TRIGGERS"
+printf '\n'
+cat "$PROBES"
+printf '\n'
+cat "$SUMMARY"
+printf '\n'
+cat "$VERDICT"
+printf '\nplan: %s\nraw returns: %s\n' "$PLAN" "$RAW"

--- a/scripts/state_swarm_displacement_returns.tsv
+++ b/scripts/state_swarm_displacement_returns.tsv
@@ -1,0 +1,13 @@
+case	probe	kind	run_seed	prompt
+window51	1	exact-birth	15824	A wooden horse faces the other way after the room was empty.
+window51	2	birth-paraphrase	17822	The little wooden horse has turned around while nobody was in the room.
+window51	3	exact-anchor	12925	Morning light reaches the cup on the still kitchen table.
+window51	4	anchor-paraphrase	17824	Soft morning light falls across a cup on the quiet kitchen table.
+lantern68	1	exact-birth	16737	An older child brings two cups and leaves the smaller one for Leo.
+lantern68	2	birth-paraphrase	18735	A bigger child brings two cups and saves the smaller cup for Leo.
+lantern68	3	exact-anchor	13740	The other child shares a pencil and watches Leo draw.
+lantern68	4	anchor-paraphrase	18737	Another child lends Leo a pencil and stays to watch his picture grow.
+lantern77	1	exact-birth	16736	A wooden horse faces the other way after the room was empty.
+lantern77	2	birth-paraphrase	18743	The little wooden horse has turned around while nobody was in the room.
+lantern77	3	exact-anchor	14234	A wooden block is warm on one side though the room is cold.
+lantern77	4	anchor-paraphrase	18745	One side of the wooden block stays warm even in the cold room.

--- a/scripts/state_swarm_displacement_targets.tsv
+++ b/scripts/state_swarm_displacement_targets.tsv
@@ -1,0 +1,4 @@
+case	cell	cohort	base_seed	trigger_session	trigger_order	displaced_id
+window51	window	replication	12721	3	3	3
+lantern68	lantern	confirmatory	13633	5	4	4
+lantern77	lantern	confirmatory	13633	6	5	3

--- a/scripts/state_swarm_settled_organ_matrix.sh
+++ b/scripts/state_swarm_settled_organ_matrix.sh
@@ -150,6 +150,12 @@ awk -F '\t' '
     exit 1
 }
 
+if [ "${LEO_STATE_SETTLED_WARMUP_ONLY:-0}" = 1 ]; then
+    cat "$SUMMARY"
+    printf '\nwarm-up: %s\n' "$OUT/warmup"
+    exit 0
+fi
+
 LEO_STATE_ALPHABET_INITIAL_ROOT="$OUT/warmup/lives" \
 LEO_STATE_ALPHABET_TURN_OFFSET=32 \
     "$ROOT/scripts/state_swarm_alphabet_matrix.sh" "$HOLISTIC" \

--- a/scripts/test_state_swarm_displacement_return_matrix.sh
+++ b/scripts/test_state_swarm_displacement_return_matrix.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-state-displacement-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+OUT="$TMP/plan"
+LEO_STATE_DISPLACEMENT_PLAN_ONLY=1 \
+    "$ROOT/scripts/state_swarm_displacement_return_matrix.sh" "$OUT" \
+    > "$TMP/plan.out"
+cmp -s "$OUT/plan.tsv" "$TMP/plan.out"
+
+awk -F '\t' '
+    NR == 1 { next }
+    {
+        rows++; cases[$1]++; kinds[$1 SUBSEP $12]++
+        if (seen[$1 SUBSEP $11]++ || $7 != 32 + ($5 - 1) * 8 + $6 ||
+            $9 != $4 + $5 * 100 + $6 || $14 == "" || $15 == "") exit 1
+        if ($1 == "window51" && ($2 != "window" || $7 != 51 || $10 != 3))
+            exit 1
+        if ($1 == "lantern68" && ($2 != "lantern" || $7 != 68 || $10 != 4))
+            exit 1
+        if ($1 == "lantern77" && ($2 != "lantern" || $7 != 77 || $10 != 3))
+            exit 1
+    }
+    END {
+        if (rows != 12 || length(cases) != 3) exit 1
+        for (case_name in cases)
+            if (cases[case_name] != 4 ||
+                kinds[case_name SUBSEP "exact-birth"] != 1 ||
+                kinds[case_name SUBSEP "birth-paraphrase"] != 1 ||
+                kinds[case_name SUBSEP "exact-anchor"] != 1 ||
+                kinds[case_name SUBSEP "anchor-paraphrase"] != 1) exit 1
+    }
+' "$TMP/plan.out"
+
+RAW="$TMP/raw.tsv"
+printf 'case\tcell\tcohort\tbase_seed\ttrigger_turn\tdisplaced_id\ttrigger_new_id\tprobe\tkind\treturn_seed\tcontrol_event\tcontrol_winner\tcontrol_similarity\tcontrol_members\tcontrol_replaced\tdisplaced_event\tdisplaced_winner\tdisplaced_similarity\tdisplaced_members\tdisplaced_replaced\tprompt\treply\n' > "$RAW"
+for probe in 1 2 3 4; do
+    case "$probe" in
+        1) displaced_event=updated; displaced_winner=9 ;;
+        2) displaced_event=updated; displaced_winner=2 ;;
+        3) displaced_event=replaced; displaced_winner=10 ;;
+        4) displaced_event=updated; displaced_winner=9 ;;
+    esac
+    if [ "$probe" -eq 4 ]; then
+        control_winner=2
+        control_members='1:0.100,2:0.500,3:0.300,4:0.100'
+    else
+        control_winner=3
+        control_members='1:0.100,2:0.100,3:0.700,4:0.100'
+    fi
+    printf 'fixture\twindow\treplication\t1\t51\t3\t9\t%s\tkind\t%s\tupdated\t%s\t0.800\t%s\t0\t%s\t%s\t0.700\t1:0.200,2:0.300,9:0.500,4:0.000\t0\tprompt\treply\n' \
+        "$probe" "$probe" "$control_winner" "$control_members" \
+        "$displaced_event" "$displaced_winner" >> "$RAW"
+done
+
+awk -f "$ROOT/scripts/state_swarm_displacement_report.awk" "$RAW" \
+    > "$TMP/probes.tsv"
+awk -F '\t' '
+    NR == 1 { next }
+    $8 == 1 { if ($19 != "true" || $20 != "trigger-capture") exit 1 }
+    $8 == 2 { if ($19 != "true" || $20 != "survivor-return") exit 1 }
+    $8 == 3 { if ($19 != "true" || $20 != "rebirth") exit 1 }
+    $8 == 4 { if ($19 != "false" || $20 != "unanchored") exit 1 }
+    END { if (NR != 5) exit 1 }
+' "$TMP/probes.tsv"
+
+cp "$RAW" "$TMP/invalid-members.tsv"
+sed -i.bak '$s/1:0.200,2:0.300,9:0.500,4:0.000/1:0.200,2:0.300,9:0.500,3:0.000/' \
+    "$TMP/invalid-members.tsv"
+if awk -f "$ROOT/scripts/state_swarm_displacement_report.awk" \
+    "$TMP/invalid-members.tsv" >/dev/null 2>&1; then
+    printf 'scorer accepted a displaced zero-mass old ID\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm displacement return plan and scorer: ok\n'


### PR DESCRIPTION
## Summary
- add the sealed A.85 matched-fork displacement/return matrix
- classify control-anchored return as survivor, trigger capture, or rebirth
- verify birth/anchor provenance and record the reproducible 223-process receipt

## Verification
- 548/548 C tests
- full make test shell matrix
- canonical r6 byte-identical to r5 across all scientific tables
- git diff --check