### PR TITLE
the method maps displacement anatomy

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -7300,3 +7300,85 @@ out displacements rather than explain these three after the fact.
 
 Leo does not keep every experience in one place; sometimes he finds it again
 by becoming, resembling, or beginning.
+
+## Phase A.86 - anatomy cannot be inferred from events that did not happen (2026-08-02)
+
+A.85 exposed three deterministic displacements and three different return
+fates. A.86 predeclares how to ask whether those fates depend on one similarity
+organ or on their distributed geometry, then tests that question only on new
+lives.
+
+The runtime receipt now preserves two pre-update witnesses that previously
+disappeared at mutation time: the seven-organ similarity vector of the nearest
+existing coordinate and, on replacement, the seven-organ vector of the removed
+coordinate. They live outside the persisted v27 body. Unit tests reconstruct
+the unchanged holistic similarity and prove that replacement captures the old
+vector before clearing its slot.
+
+Eight fixed holdout seeds each receive the same 32-turn unscored settlement
+crossing and 64 unseen writer observations. All post-settlement replacements
+must be retained. For each one, the runner automatically recovers the removed
+ID's exact birth and strongest prior updated anchor from that life's receipts;
+there is no authored return list. The no-displacement control must update the
+old ID with mass at least `0.20` and margin at least `0.02`.
+
+Seven offline leave-one-organ-out projections renormalize the original weights
+after omitting perception, expression, own-field, body, rhythm, form, or
+darkmatter. A projection within `0.002` of the `0.40` replacement gate is
+reported as `boundary`. A return is robust only when at least six of seven
+projections preserve its observed fate. Population interpretation requires at
+least eight qualified returns across four events and four lives.
+
+The canonical run is
+`/tmp/leo-state-swarm-displacement-anatomy-a86-20260802-r4`. All eight lives
+reach eight states and have no birth or replacement in warm-up session four.
+Across all 512 post-settlement writer observations, however, there are zero
+replacements:
+
+```text
+life  minimum writer similarity  turn
+h01           0.412               77
+h02           0.424               43
+h03           0.411               68
+h04           0.412               51
+h05           0.457               53
+h06           0.409               53
+h07           0.411               49
+h08           0.436               53
+```
+
+The result is therefore `insufficient`, not `distributed`, `organ-sensitive`,
+or evidence against A.85. Seven lives approach the replacement gate within
+`0.036`, but none crosses it. The three A.85 events remain reproducible on
+their own trajectories; A.86 instead shows that replacement incidence itself
+is trajectory-sensitive enough that organ anatomy cannot yet be estimated
+from a small new population.
+
+An independent run at
+`/tmp/leo-state-swarm-displacement-anatomy-a86-20260802-r5` is byte-identical
+for all 768 receipts, eight final state bodies, life summaries, anatomy table,
+and verdict. Three earlier attempts are retained as harness receipts: a BSD
+awk line-break failure, a real diffuse receipt rejected by the old parser, and
+a reserved awk identifier in final reporting. No seed or threshold changed.
+The diffuse case revealed that `active=0` is legal when no soft activation
+crosses the active gate even though a winner still exists; the shared parser
+and its regression fixture now preserve that state.
+
+Because the new population produced no event, the complete fork path was also
+executed as a technical replay on the two known A.85 seed trajectories. It
+recovered all three old replacements, derived six birth/anchor returns, and
+qualified four. Three qualified fates are stable under all seven omissions.
+The old Lantern68 exact-birth rebirth is the only non-robust witness: omitting
+perception, expression, or own-field changes its offline fate to
+`trigger-capture`, while omitting body, rhythm, form, or darkmatter preserves
+rebirth. This is a useful implementation witness, not confirmatory evidence:
+it reuses discovery trajectories, spans only three events and two lives, and
+remains below the declared population floor.
+
+A.86 adds no persisted field, update reader, threshold change, sampler,
+routing, or speech influence. Its instrumentation and scorer remain ready for
+future events, but the experiment is closed. A separate incidence study may
+map replacement probability and near-gate distance across a larger sealed
+population before anatomy is reopened.
+
+An absent displacement has no organs to dissect.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
 
 all: leo
 
@@ -54,6 +54,9 @@ state-swarm-settled-organs: leo
 
 state-swarm-displacement-return: leo
 	./scripts/state_swarm_displacement_return_matrix.sh
+
+state-swarm-displacement-anatomy: leo
+	./scripts/state_swarm_displacement_anatomy_matrix.sh
 
 visible-branch-probe: leo
 	LEO_VISIBLE_BRANCH_POLICY=local-v1 ./scripts/adaptive_life_probe.sh scripts/visible_branch_phases.txt
@@ -211,6 +214,9 @@ test: tests/test_leo.c leo.c
 	./scripts/test_state_swarm_organ_matrix.sh
 	./scripts/test_state_swarm_settled_organ_matrix.sh
 	./scripts/test_state_swarm_displacement_return_matrix.sh
+	./scripts/test_state_swarm_displacement_anatomy_log.sh
+	./scripts/test_state_swarm_displacement_anatomy_report.sh
+	./scripts/test_state_swarm_displacement_anatomy_matrix.sh
 	./scripts/test_deferred_wonder_recovery_matrix.sh
 	./scripts/test_deferred_wonder_ecology_matrix.sh
 	./scripts/test_deferred_wonder_constellation_matrix.sh

--- a/leo.c
+++ b/leo.c
@@ -1672,6 +1672,7 @@ typedef struct {
     uint64_t winner_id;
     uint64_t born_id;
     uint64_t replaced_id;
+    uint64_t nearest_id;
     uint64_t expected_id;
     uint64_t member_id[LEO_STATE_SWARM_MAX];
     float member_activation[LEO_STATE_SWARM_MAX];
@@ -1694,7 +1695,11 @@ typedef struct {
  * exact LeoStateSwarm prefix written by state v27. */
 typedef struct {
     float similarity[LEO_STATE_SWARM_MAX][LEO_STATE_ORGANS];
+    float nearest_similarity[LEO_STATE_ORGANS];
+    float removed_similarity[LEO_STATE_ORGANS];
     uint8_t valid[LEO_STATE_SWARM_MAX];
+    uint8_t nearest_valid;
+    uint8_t removed_valid;
 } LeoStateOrganReceipt;
 
 typedef struct {
@@ -10587,6 +10592,15 @@ static void leo_state_swarm_observe(Leo *leo, const char *reply) {
         }
     }
     receipt.similarity = best >= 0 ? best_similarity : 0.0f;
+    if (best >= 0) {
+        receipt.nearest_id = swarm->weights[best].id;
+        if (organ_receipt && organ_receipt->valid[best]) {
+            memcpy(organ_receipt->nearest_similarity,
+                   organ_receipt->similarity[best],
+                   sizeof organ_receipt->nearest_similarity);
+            organ_receipt->nearest_valid = 1;
+        }
+    }
 
     int slot = -1;
     if (swarm->n == 0 ||
@@ -10599,7 +10613,13 @@ static void leo_state_swarm_observe(Leo *leo, const char *reply) {
         slot = leo_state_weakest(swarm);
         receipt.event = LEO_STATE_SWARM_REPLACED;
         receipt.replaced_id = swarm->weights[slot].id;
-        if (organ_receipt) organ_receipt->valid[slot] = 0;
+        if (organ_receipt) {
+            memcpy(organ_receipt->removed_similarity,
+                   organ_receipt->similarity[slot],
+                   sizeof organ_receipt->removed_similarity);
+            organ_receipt->removed_valid = organ_receipt->valid[slot];
+            organ_receipt->valid[slot] = 0;
+        }
         leo_state_reset_slot(swarm, slot);
         float remaining = 0.0f;
         for (uint32_t i = 0; i < swarm->n; i++)
@@ -14285,10 +14305,24 @@ static void print_flow_stats(const Leo *leo) {
                 printf("%s%.6f", o ? "/" : "",
                        (double)organ_receipt->similarity[i][o]);
         }
+        printf(" nearest=%llu nearest_organs=",
+               (unsigned long long)state_receipt->nearest_id);
+        if (!organ_receipt || !organ_receipt->nearest_valid) printf("na");
+        else
+            for (int o = 0; o < LEO_STATE_ORGANS; o++)
+                printf("%s%.6f", o ? "/" : "",
+                       (double)organ_receipt->nearest_similarity[o]);
         printf(" adjacent=%u", (unsigned)state_receipt->adjacent);
-        if (state_receipt->replaced_id)
+        if (state_receipt->replaced_id) {
             printf(" replaced=%llu",
                    (unsigned long long)state_receipt->replaced_id);
+            printf(" removed_organs=");
+            if (!organ_receipt || !organ_receipt->removed_valid) printf("na");
+            else
+                for (int o = 0; o < LEO_STATE_ORGANS; o++)
+                    printf("%s%.6f", o ? "/" : "",
+                           (double)organ_receipt->removed_similarity[o]);
+        }
         if (state_receipt->adjacent)
             printf(" observed=%.3f/%.3f/%.3f/%.3f",
                    (double)state_receipt->observed_outcome[0],

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -1098,3 +1098,56 @@ activation over all replay turns before displacement.
 A.85 changes no organism code or speech path. Its next use is to predeclare an
 offline per-organ fate analysis and test it on new displacement events before
 considering any reader, freeze, or replacement-policy change.
+
+## A.86: require new displacements before explaining their anatomy
+
+Run the sealed eight-life population:
+
+```sh
+make state-swarm-displacement-anatomy
+```
+
+Each life receives 32 unscored settlement observations followed by all 64
+A.82 writer observations. The eight seed rows are fixed in
+`state_swarm_displacement_anatomy_lives.tsv`; do not add lives after seeing the
+event count. Every post-settlement replacement is admitted automatically.
+
+For an admitted event the runner forks the exact pre-trigger body, repeats the
+trigger with `--no-state-swarm`, and requires equal reply and normalized
+non-swarm diagnostics with different saved bodies. It then derives at most two
+returns from the event's own earlier receipts:
+
+```text
+exact-birth   the observation and seed that created the displaced ID
+exact-anchor  the strongest earlier updated observation won by that ID
+```
+
+Each return enters control and displaced bodies without saving. The control
+qualifies only when the old ID wins with mass `>=0.20` and margin `>=0.02`.
+The displaced receipt is recomputed seven times offline while omitting one
+organ and renormalizing the remaining holistic weights. Values within `0.002`
+of the `0.40` gate are `boundary`; at least `6/7` matching fates is robust.
+
+Population adequacy requires at least eight qualified returns, four events,
+and four lives. The recorded run at
+`/tmp/leo-state-swarm-displacement-anatomy-a86-20260802-r4` has eight settled
+lives but zero replacements in 512 scored writer observations. Its result is
+therefore `insufficient`. Writer minimum similarities range from `0.409` to
+`0.457`; the population approaches but never crosses the gate. Independent
+`r5` receipts, final states, and scientific tables are byte-identical.
+
+The fork/provenance/scorer path is separately exercised on the two old A.85
+seed trajectories. It recovers all three known replacements and processes six
+automatic returns without changing the A.86 population result. Treat those
+rows as a technical receipt only: they reuse discovery lives and fail the
+predeclared event/life adequacy floor.
+
+The runtime-only receipt exposes nearest and removed pre-update seven-organ
+vectors so a future qualified event can be scored without reconstructing lost
+state. It changes no persisted body or update. The shared dialogue parser also
+now accepts the legitimate diffuse case `active=0`: the winner exists even
+when no soft activation reaches the active-membership threshold.
+
+Do not extend A.86 until it produces a preferred answer. If replacement
+incidence itself needs explanation, open a separately sealed population study
+of event rate and near-gate distance first.

--- a/scripts/state_swarm_dialogue_report.awk
+++ b/scripts/state_swarm_dialogue_report.awk
@@ -60,7 +60,7 @@ function parse_quad(value, out,    n, i) {
     forecast_raw = value_after($0, "forecast")
 
     if (!unsigned_number(turn) || !unsigned_number(states) || states + 0 < 1 ||
-        states + 0 > 8 || !unsigned_number(active) || active + 0 < 1 ||
+        states + 0 > 8 || !unsigned_number(active) ||
         active + 0 > states + 0 || !unsigned_number(winner) || winner + 0 < 1 ||
         (event != "updated" && event != "born" && event != "replaced") ||
         !number(similarity) || similarity + 0 < 0 || similarity + 0 > 1.001 ||

--- a/scripts/state_swarm_displacement_anatomy_lives.tsv
+++ b/scripts/state_swarm_displacement_anatomy_lives.tsv
@@ -1,0 +1,9 @@
+life	split	base_seed
+h01	holdout	14939
+h02	holdout	15331
+h03	holdout	16411
+h04	holdout	17519
+h05	holdout	18637
+h06	holdout	19751
+h07	holdout	20873
+h08	holdout	21961

--- a/scripts/state_swarm_displacement_anatomy_log.awk
+++ b/scripts/state_swarm_displacement_anatomy_log.awk
@@ -1,0 +1,121 @@
+# A.86: validate the complete pre-update organ witness in one debug log.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function value_after(line, key,    fields, i, n, prefix, value) {
+    prefix = key "="
+    n = split(line, fields, /[ ]+/)
+    for (i = 1; i <= n; i++) {
+        if (index(fields[i], prefix) != 1) continue
+        value = substr(fields[i], length(prefix) + 1)
+        gsub(/\]$/, "", value)
+        return value
+    }
+    return ""
+}
+
+function number(value) {
+    return value ~ /^-?[0-9]+([.][0-9]+)?$/
+}
+
+function unsigned_number(value) {
+    return value ~ /^[0-9]+$/
+}
+
+function parse_vector(value, target,    part, n, i) {
+    n = split(value, part, "/")
+    if (n != 7) fail()
+    for (i = 1; i <= 7; i++) {
+        if (!number(part[i]) || part[i] + 0 < 0 || part[i] + 0 > 1.001)
+            fail()
+        target[i] = part[i] + 0
+    }
+}
+
+function weighted(value) {
+    return 0.19 * value[1] + 0.19 * value[2] + 0.10 * value[3] + 0.20 * value[4] + 0.18 * value[5] + 0.07 * value[6] + 0.07 * value[7]
+}
+
+/\[state-swarm: turn=/ {
+    found++
+    turn = value_after($0, "turn")
+    states = value_after($0, "states")
+    winner = value_after($0, "winner")
+    event = value_after($0, "event")
+    similarity = value_after($0, "similarity")
+    members = value_after($0, "members")
+    organs = value_after($0, "organs")
+    nearest = value_after($0, "nearest")
+    nearest_raw = value_after($0, "nearest_organs")
+    replaced = value_after($0, "replaced")
+    removed_raw = value_after($0, "removed_organs")
+
+    if (!unsigned_number(turn) || !unsigned_number(states) || states < 1 ||
+        states > 8 || !unsigned_number(winner) || winner < 1 ||
+        (event != "updated" && event != "born" && event != "replaced") ||
+        !number(similarity) || similarity < 0 || similarity > 1.001 ||
+        !unsigned_number(nearest) || members == "" || organs == "") fail()
+
+    member_n = split(members, member_item, ",")
+    organ_n = split(organs, organ_item, ",")
+    if (member_n != states || organ_n != states) fail()
+    invalid = 0
+    winner_seen = 0
+    nearest_seen = 0
+    replaced_seen = 0
+    for (i = 1; i <= member_n; i++) {
+        colon = index(member_item[i], ":")
+        if (!colon) fail()
+        member_id[i] = substr(member_item[i], 1, colon - 1)
+        activation = substr(member_item[i], colon + 1)
+        if (!unsigned_number(member_id[i]) || member_id[i] < 1 ||
+            !number(activation) || activation < 0 || activation > 1.001)
+            fail()
+        if (member_id[i] == winner) winner_seen = 1
+        if (member_id[i] == nearest) nearest_seen = 1
+        if (replaced != "" && member_id[i] == replaced) replaced_seen = 1
+        for (j = 1; j < i; j++) if (member_id[j] == member_id[i]) fail()
+
+        colon = index(organ_item[i], ":")
+        if (!colon || substr(organ_item[i], 1, colon - 1) != member_id[i])
+            fail()
+        raw = substr(organ_item[i], colon + 1)
+        if (raw == "na") invalid++
+        else parse_vector(raw, parsed)
+    }
+    if (!winner_seen || (event == "updated" && invalid != 0) ||
+        (event != "updated" && invalid != 1)) fail()
+
+    if (nearest == 0) {
+        if (nearest_raw != "na" || states != 1 || event != "born" ||
+            similarity > 0.001) fail()
+    } else {
+        if (nearest_raw == "na") fail()
+        parse_vector(nearest_raw, nearest_value)
+        if (weighted(nearest_value) < similarity - 0.0015 ||
+            weighted(nearest_value) > similarity + 0.0015) fail()
+    }
+
+    if (event == "replaced") {
+        if (!unsigned_number(replaced) || replaced < 1 || replaced_seen ||
+            removed_raw == "" || removed_raw == "na") fail()
+        parse_vector(removed_raw, removed_value)
+        if (nearest != replaced && !nearest_seen) fail()
+    } else {
+        if (replaced != "" || removed_raw != "") fail()
+        if (nearest != 0 && !nearest_seen) fail()
+    }
+    if (event == "updated" && nearest != winner) fail()
+}
+
+END {
+    if (fatal) exit 2
+    if (found != 1) exit 1
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+           turn, event, winner, similarity, members,
+           (replaced == "" ? 0 : replaced), nearest, nearest_raw,
+           (removed_raw == "" ? "na" : removed_raw), organs
+}

--- a/scripts/state_swarm_displacement_anatomy_matrix.sh
+++ b/scripts/state_swarm_displacement_anatomy_matrix.sh
@@ -1,0 +1,445 @@
+#!/usr/bin/env bash
+# A.86: measure whether displacement fate belongs to one organ or their geometry.
+set -Eeuo pipefail
+
+trap 'rc=$?; printf "displacement anatomy runner failed: line=%s rc=%s command=%s\n" "$LINENO" "$rc" "$BASH_COMMAND" >&2; exit "$rc"' ERR
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIVES="${LEO_STATE_ANATOMY_LIVES:-$ROOT/scripts/state_swarm_displacement_anatomy_lives.tsv}"
+WARM_CASES="${LEO_STATE_ANATOMY_WARM_CASES:-$ROOT/scripts/state_swarm_settled_warmup_cases.tsv}"
+ALPHABET_CASES="${LEO_STATE_ANATOMY_ALPHABET_CASES:-$ROOT/scripts/state_swarm_alphabet_cases.tsv}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-state-swarm-displacement-anatomy-$STAMP}"
+
+[ ! -e "$OUT" ] || {
+    printf 'output path already exists: %s\n' "$OUT" >&2
+    exit 2
+}
+for file in "$LIVES" "$WARM_CASES" "$ALPHABET_CASES"; do
+    [ -s "$file" ] || {
+        printf 'displacement anatomy input missing: %s\n' "$file" >&2
+        exit 2
+    }
+done
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 3 || $1 != "life" || $2 != "split" ||
+            $3 != "base_seed") exit 1
+        next
+    }
+    {
+        if (NF != 3 || $1 !~ /^h[0-9][0-9]$/ || $2 != "holdout" ||
+            $3 !~ /^[0-9]+$/ || life[$1]++ || seed[$3]++) exit 1
+        rows++
+    }
+    END { if (rows != 8) exit 1 }
+' "$LIVES" || {
+    printf 'invalid displacement anatomy lives: %s\n' "$LIVES" >&2
+    exit 2
+}
+
+awk -F '\t' '
+    BEGIN {
+        name[1] = "home"; name[2] = "storm"
+        name[3] = "wonder"; name[4] = "social"
+    }
+    NR == 1 {
+        if (NF != 4 || $1 != "session" || $2 != "order" ||
+            $3 != "texture" || $4 != "prompt") exit 1
+        next
+    }
+    {
+        if (NF != 4 || $1 < 1 || $1 > 4 || $2 < 1 || $2 > 8 ||
+            $3 !~ /^(home|storm|wonder|social)$/ || $4 == "" ||
+            slot[$1 SUBSEP $2]++ || prompt[$4]++) exit 1
+        texture[$1 SUBSEP $3]++
+        rows++
+    }
+    END {
+        if (rows != 32 || length(slot) != 32) exit 1
+        for (session = 1; session <= 4; session++)
+            for (i = 1; i <= 4; i++)
+                if (texture[session SUBSEP name[i]] != 2) exit 1
+    }
+' "$WARM_CASES" || {
+    printf 'invalid displacement anatomy warm cases: %s\n' "$WARM_CASES" >&2
+    exit 2
+}
+
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 5 || $1 != "kind" || $2 != "session" ||
+            $3 != "order" || $4 != "texture" || $5 != "prompt") exit 1
+        next
+    }
+    $1 == "writer" {
+        if ($2 < 1 || $2 > 8 || $3 < 1 || $3 > 8 ||
+            $4 !~ /^(home|storm|wonder|social)$/ || $5 == "" ||
+            slot[$2 SUBSEP $3]++ || prompt[$5]++) exit 1
+        rows++
+    }
+    $1 != "writer" && $1 != "probe" { exit 1 }
+    END { if (rows != 64 || length(slot) != 64) exit 1 }
+' "$ALPHABET_CASES" || {
+    printf 'invalid displacement anatomy writer cases: %s\n' "$ALPHABET_CASES" >&2
+    exit 2
+}
+
+mkdir -p "$OUT/lives"
+PLAN="$OUT/plan.tsv"
+RECEIPTS="$OUT/receipts.tsv"
+EVENTS="$OUT/events.tsv"
+RAW="$OUT/returns.raw.tsv"
+ANATOMY="$OUT/anatomy.tsv"
+LIFE_SUMMARY="$OUT/life-summary.tsv"
+EVENT_SUMMARY="$OUT/event-summary.tsv"
+VERDICT="$OUT/verdict.txt"
+
+printf 'life\tsplit\tbase_seed\tphase\tsession\torder\ttexture\trun_seed\tprompt\n' > "$PLAN"
+while IFS=$'\t' read -r life split base_seed; do
+    while IFS=$'\t' read -r session order texture prompt; do
+        run_seed=$((base_seed + 3000 + session * 100 + order))
+        printf '%s\t%s\t%s\twarm\t%s\t%s\t%s\t%s\t%s\n' \
+            "$life" "$split" "$base_seed" "$session" "$order" \
+            "$texture" "$run_seed" "$prompt" >> "$PLAN"
+    done < <(tail -n +2 "$WARM_CASES")
+    while IFS=$'\t' read -r kind session order texture prompt; do
+        [ "$kind" = writer ] || continue
+        run_seed=$((base_seed + session * 100 + order))
+        printf '%s\t%s\t%s\twriter\t%s\t%s\t%s\t%s\t%s\n' \
+            "$life" "$split" "$base_seed" "$session" "$order" \
+            "$texture" "$run_seed" "$prompt" >> "$PLAN"
+    done < <(tail -n +2 "$ALPHABET_CASES")
+done < <(tail -n +2 "$LIVES")
+
+awk -F '\t' '
+    NR == 1 { next }
+    {
+        rows++; lives[$1]++; phase[$1 SUBSEP $4]++
+        if (seed[$1 SUBSEP $8]++) exit 1
+    }
+    END {
+        if (rows != 768 || length(lives) != 8) exit 1
+        for (life in lives)
+            if (lives[life] != 96 || phase[life SUBSEP "warm"] != 32 ||
+                phase[life SUBSEP "writer"] != 64) exit 1
+    }
+' "$PLAN" || {
+    printf 'invalid displacement anatomy plan: %s\n' "$PLAN" >&2
+    exit 2
+}
+
+if [ "${LEO_STATE_ANATOMY_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+make -C "$ROOT" leo >/dev/null
+
+printf 'life\tsplit\tbase_seed\tphase\tsession\torder\ttexture\trun_seed\tturn\tstates\tactive\twinner\tevent\tsimilarity\tentropy\tmembers\tmember_sum\tadjacent\treplaced\thas_prediction\texpected\texpected_probability\toverlap\tsurprise\tobserved_grounded\tobserved_distress_relief\tobserved_gap_relief\tobserved_alignment_delta\tforecast_grounded\tforecast_distress_relief\tforecast_gap_relief\tforecast_alignment_delta\tprompt\treply\n' > "$RECEIPTS"
+printf 'event\tlife\tsplit\tsettled\tbase_seed\ttrigger_turn\tdisplaced_id\ttrigger_new_id\tbirth_turn\tbirth_seed\tanchor_available\tanchor_turn\tanchor_seed\tanchor_mass\ttrigger_voice_equal\ttrigger_non_swarm_equal\ttrigger_state_different\ttrigger_prompt\treply\n' > "$EVENTS"
+printf 'event\tlife\tsplit\tsettled\tbase_seed\ttrigger_turn\tdisplaced_id\ttrigger_new_id\tprobe\tkind\treturn_seed\tcontrol_turn\tcontrol_event\tcontrol_winner\tcontrol_similarity\tcontrol_members\tcontrol_replaced\tcontrol_nearest\tcontrol_nearest_organs\tcontrol_removed_organs\tcontrol_organs\tdisplaced_turn\tdisplaced_event\tdisplaced_winner\tdisplaced_similarity\tdisplaced_members\tdisplaced_replaced\tdisplaced_nearest\tdisplaced_nearest_organs\tdisplaced_removed_organs\tdisplaced_organs\tprompt\treply\n' > "$RAW"
+
+reply_from_log() {
+    awk '/leo> / { sub(/^.*leo> /, ""); print; exit }' "$1"
+}
+
+receipt_from_log() {
+    local log="$1" life="$2" split="$3" base_seed="$4"
+    local phase="$5" session="$6" order="$7" texture="$8"
+    local run_seed="$9" prompt="${10}" reply="${11}"
+    awk -v cell="$life" -v cohort="$split" -v base_seed="$base_seed" \
+        -v phase="$phase" -v session="$session" -v order="$order" \
+        -v texture="$texture" -v run_seed="$run_seed" \
+        -v prompt="$prompt" -v reply="$reply" \
+        -f "$ROOT/scripts/state_swarm_dialogue_report.awk" "$log"
+}
+
+normalize_log() {
+    local log="$1" event_dir="$2" main_state="${3:-}"
+    local args=(-e '/\[state-swarm:/d'
+                -e "s|$event_dir/control.state|BODY|g"
+                -e "s|$event_dir/displaced.state|BODY|g")
+    if [ -n "$main_state" ]; then args+=(-e "s|$main_state|BODY|g"); fi
+    sed "${args[@]}" "$log"
+}
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+processes=0
+event_count=0
+while IFS=$'\t' read -r wanted_life wanted_split wanted_seed; do
+    life_dir="$OUT/lives/$wanted_life"
+    mkdir -p "$life_dir/logs" "$life_dir/events"
+    state="$life_dir/leo.state"
+    settled=""
+    expected_turn=0
+
+    while IFS=$'\t' read -r life split base_seed phase session order \
+        texture run_seed prompt; do
+        if [ "$phase" = writer ] && [ -z "$settled" ]; then
+            settled="$(awk -F '\t' -v life="$life" '
+                NR > 1 && $1 == life && $4 == "warm" {
+                    rows++; states = $10
+                    if ($5 == 4 && $13 != "updated") changes++
+                }
+                END { print (rows == 32 && states == 8 && changes == 0) ? "true" : "false" }
+            ' "$RECEIPTS")"
+        fi
+
+        expected_turn=$((expected_turn + 1))
+        stem="${phase}-s${session}-$(printf '%02d' "$order")-${texture}"
+        log="$life_dir/logs/$stem.log"
+        pre_state="$life_dir/pre-${expected_turn}.state"
+        if [ "$phase" = writer ]; then cp "$state" "$pre_state"; fi
+
+        args=("$ROOT/leo")
+        if [ -f "$state" ]; then args+=(--load "$state"); fi
+        args+=(--seed "$run_seed" --respond "$prompt" --debug-field \
+               --save "$state")
+        "${args[@]}" > "$log" 2>&1
+        processes=$((processes + 1))
+        [ -s "$state" ] || exit 1
+        reply="$(reply_from_log "$log")"
+        [ -n "$reply" ] || exit 1
+        receipt="$(receipt_from_log "$log" "$life" "$split" \
+            "$base_seed" "$phase" "$session" "$order" "$texture" \
+            "$run_seed" "$prompt" "$reply")"
+        printf '%s\n' "$receipt" >> "$RECEIPTS"
+        actual_turn="$(printf '%s\n' "$receipt" | awk -F '\t' '{print $9}')"
+        [ "$actual_turn" -eq "$expected_turn" ] || exit 1
+
+        event="$(printf '%s\n' "$receipt" | awk -F '\t' '{print $13}')"
+        if [ "$phase" != writer ] || [ "$event" != replaced ]; then
+            if [ "$phase" = writer ]; then rm -f "$pre_state"; fi
+            continue
+        fi
+
+        event_count=$((event_count + 1))
+        printf -v event_id '%s-t%03d' "$life" "$actual_turn"
+        event_dir="$life_dir/events/$event_id"
+        mkdir -p "$event_dir/returns"
+        mv "$pre_state" "$event_dir/pretrigger.state"
+        cp "$state" "$event_dir/displaced.state"
+
+        trigger_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$log")"
+        IFS=$'\t' read -r trigger_turn trigger_event trigger_new_id \
+            trigger_similarity trigger_members displaced_id trigger_nearest \
+            trigger_nearest_organs trigger_removed_organs trigger_organs \
+            <<< "$trigger_shape"
+        [ "$trigger_turn" -eq "$actual_turn" ] &&
+            [ "$trigger_event" = replaced ] && [ "$displaced_id" -gt 0 ] || exit 1
+
+        cp "$event_dir/pretrigger.state" "$event_dir/control.state"
+        control_trigger_log="$event_dir/trigger.control.log"
+        "$ROOT/leo" --load "$event_dir/control.state" --seed "$run_seed" \
+            --respond "$prompt" --debug-field --no-state-swarm \
+            --save "$event_dir/control.state" > "$control_trigger_log" 2>&1
+        processes=$((processes + 1))
+        control_trigger_reply="$(reply_from_log "$control_trigger_log")"
+        [ -n "$control_trigger_reply" ] && [ "$control_trigger_reply" = "$reply" ] || exit 1
+        ! grep -q '\[state-swarm:' "$control_trigger_log" || exit 1
+        normalize_log "$log" "$event_dir" "$state" > "$event_dir/trigger.displaced.normalized"
+        normalize_log "$control_trigger_log" "$event_dir" "$state" > "$event_dir/trigger.control.normalized"
+        cmp -s "$event_dir/trigger.displaced.normalized" \
+            "$event_dir/trigger.control.normalized" || exit 1
+        ! cmp -s "$event_dir/displaced.state" "$event_dir/control.state" || exit 1
+
+        birth_info="$(awk -F '\t' -v life="$life" -v old="$displaced_id" \
+            -v trigger="$trigger_turn" '
+            NR > 1 && $1 == life && $9 < trigger && $12 == old &&
+                ($13 == "born" || $13 == "replaced") {
+                matches++; value = $9 "\t" $8 "\t" $33
+            }
+            END { if (matches != 1) exit 1; print value }
+        ' "$RECEIPTS")"
+        IFS=$'\t' read -r birth_turn birth_seed birth_prompt <<< "$birth_info"
+
+        anchor_info="$(awk -F '\t' -v life="$life" -v old="$displaced_id" \
+            -v trigger="$trigger_turn" '
+            function abs(value) { return value < 0 ? -value : value }
+            function mass(value, wanted,    item, pair, n, i) {
+                n = split(value, item, ",")
+                for (i = 1; i <= n; i++) {
+                    split(item[i], pair, ":")
+                    if (pair[1] + 0 == wanted) return pair[2] + 0
+                }
+                return 0
+            }
+            NR > 1 && $1 == life && $9 < trigger && $12 == old &&
+                $13 == "updated" {
+                value = mass($16, old)
+                if (!found || value > best + 0.0000001 ||
+                    (abs(value - best) <= 0.0000001 && $9 < turn)) {
+                    found = 1; best = value; turn = $9
+                    seed = $8; prompt = $33
+                }
+            }
+            END {
+                if (found) printf "%s\t%s\t%.6f\t%s\n", turn, seed, best, prompt
+            }
+        ' "$RECEIPTS")"
+        anchor_available=false
+        anchor_turn=0
+        anchor_seed=0
+        anchor_mass=0
+        anchor_prompt=""
+        if [ -n "$anchor_info" ]; then
+            anchor_available=true
+            IFS=$'\t' read -r anchor_turn anchor_seed anchor_mass anchor_prompt \
+                <<< "$anchor_info"
+        fi
+
+        return_plan="$event_dir/returns.plan.tsv"
+        printf '1\texact-birth\t%s\t%s\n' "$birth_seed" "$birth_prompt" > "$return_plan"
+        if [ "$anchor_available" = true ]; then
+            printf '2\texact-anchor\t%s\t%s\n' "$anchor_seed" "$anchor_prompt" >> "$return_plan"
+        fi
+
+        displaced_sha="$(sha256_file "$event_dir/displaced.state")"
+        control_sha="$(sha256_file "$event_dir/control.state")"
+        while IFS=$'\t' read -r probe kind return_seed return_prompt; do
+            control_log="$event_dir/returns/p${probe}.control.log"
+            displaced_log="$event_dir/returns/p${probe}.displaced.log"
+            "$ROOT/leo" --load "$event_dir/control.state" --seed "$return_seed" \
+                --respond "$return_prompt" --debug-field > "$control_log" 2>&1
+            processes=$((processes + 1))
+            "$ROOT/leo" --load "$event_dir/displaced.state" --seed "$return_seed" \
+                --respond "$return_prompt" --debug-field > "$displaced_log" 2>&1
+            processes=$((processes + 1))
+            control_reply="$(reply_from_log "$control_log")"
+            displaced_reply="$(reply_from_log "$displaced_log")"
+            [ -n "$control_reply" ] && [ "$control_reply" = "$displaced_reply" ] || exit 1
+            normalize_log "$control_log" "$event_dir" > "$event_dir/returns/p${probe}.control.normalized"
+            normalize_log "$displaced_log" "$event_dir" > "$event_dir/returns/p${probe}.displaced.normalized"
+            cmp -s "$event_dir/returns/p${probe}.control.normalized" \
+                "$event_dir/returns/p${probe}.displaced.normalized" || exit 1
+
+            control_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$control_log")"
+            displaced_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$displaced_log")"
+            control_turn="$(printf '%s\n' "$control_shape" | awk -F '\t' '{print $1}')"
+            displaced_turn="$(printf '%s\n' "$displaced_shape" | awk -F '\t' '{print $1}')"
+            [ "$control_turn" -eq $((trigger_turn + 1)) ] &&
+                [ "$displaced_turn" -eq "$control_turn" ] || exit 1
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                "$event_id" "$life" "$split" "$settled" "$base_seed" \
+                "$trigger_turn" "$displaced_id" "$trigger_new_id" \
+                "$probe" "$kind" "$return_seed" "$control_shape" \
+                "$displaced_shape" "$return_prompt" "$control_reply" >> "$RAW"
+        done < "$return_plan"
+        [ "$(sha256_file "$event_dir/displaced.state")" = "$displaced_sha" ] &&
+            [ "$(sha256_file "$event_dir/control.state")" = "$control_sha" ] || exit 1
+
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\t%s\t%s\n' \
+            "$event_id" "$life" "$split" "$settled" "$base_seed" \
+            "$trigger_turn" "$displaced_id" "$trigger_new_id" \
+            "$birth_turn" "$birth_seed" "$anchor_available" \
+            "$anchor_turn" "$anchor_seed" "$anchor_mass" "$prompt" "$reply" \
+            >> "$EVENTS"
+    done < <(awk -F '\t' -v life="$wanted_life" 'NR > 1 && $1 == life' "$PLAN")
+    [ -n "$settled" ] || exit 1
+done < <(tail -n +2 "$LIVES")
+
+awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_report.awk" "$RAW" > "$ANATOMY"
+
+printf 'life\tsplit\tbase_seed\tturns\tfinal_states\twarm_changes\twriter_births\twriter_replacements\tsettled\n' > "$LIFE_SUMMARY"
+awk -F '\t' '
+    NR == 1 { next }
+    {
+        rows++; turns[$1]++; cohort[$1] = $2; seed[$1] = $3
+        states[$1] = $10
+        if ($4 == "warm" && $5 == 4 && $13 != "updated") warm_changes[$1]++
+        if ($4 == "writer" && $13 == "born") births[$1]++
+        if ($4 == "writer" && $13 == "replaced") replacements[$1]++
+    }
+    END {
+        if (rows != 768 || length(turns) != 8) exit 1
+        for (life in turns) {
+            if (turns[life] != 96 || states[life] != 8) exit 1
+            settled = warm_changes[life] == 0 ? "true" : "false"
+            printf "%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
+                   life, cohort[life], seed[life], turns[life], states[life],
+                   warm_changes[life] + 0, births[life] + 0,
+                   replacements[life] + 0, settled
+        }
+    }
+' "$RECEIPTS" | sort >> "$LIFE_SUMMARY"
+
+printf 'event\tlife\tsettled\treturns\tqualified\trobust\tsurvivor_return\ttrigger_capture\trebirth\tboundary_projections\n' > "$EVENT_SUMMARY"
+awk -F '\t' '
+    NR == 1 { next }
+    {
+        returns[$1]++; life[$1] = $2; settled[$1] = $4
+        if ($13 == "true") {
+            qualified[$1]++
+            fate[$1 SUBSEP $14]++
+            if ($25 == "true") robust[$1]++
+            for (i = 17; i <= 23; i++) if ($i == "boundary") boundary[$1]++
+        }
+    }
+    END {
+        for (event in returns) {
+            if (returns[event] < 1 || returns[event] > 2) exit 1
+            printf "%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+                   event, life[event], settled[event], returns[event],
+                   qualified[event] + 0, robust[event] + 0,
+                   fate[event SUBSEP "survivor-return"] + 0,
+                   fate[event SUBSEP "trigger-capture"] + 0,
+                   fate[event SUBSEP "rebirth"] + 0, boundary[event] + 0
+        }
+    }
+' "$ANATOMY" | sort >> "$EVENT_SUMMARY"
+
+awk -F '\t' -v processes="$processes" -v event_count="$event_count" '
+    NR == 1 { next }
+    {
+        returns++
+        all_event[$1]++
+        if ($4 != "true" || $13 != "true") next
+        qualified++
+        event[$1] = 1
+        life[$2] = 1
+        fate[$14]++
+        if ($25 == "true") robust++
+        for (i = 17; i <= 23; i++) {
+            if ($i == "boundary") boundary++
+            if ($i != $14) sensitive[i - 16]++
+        }
+    }
+    END {
+        adequate = qualified >= 8 && length(event) >= 4 && length(life) >= 4
+        if (!adequate) result = "insufficient"
+        else if (3 * robust >= 2 * qualified) result = "distributed"
+        else if (3 * robust <= qualified) result = "organ-sensitive"
+        else result = "mixed"
+        print "state-swarm displacement anatomy A.86"
+        printf "processes=%d main_life_turns=768 displacement_events=%d return_processes=%d\n",
+               processes, event_count, processes - 768 - event_count
+        printf "returns=%d qualified=%d events=%d lives=%d robust=%d\n",
+               returns, qualified, length(event), length(life), robust
+        printf "qualified_fates survivor-return=%d trigger-capture=%d rebirth=%d\n",
+               fate["survivor-return"] + 0, fate["trigger-capture"] + 0,
+               fate["rebirth"] + 0
+        printf "loo_changes perception=%d expression=%d own-field=%d body=%d rhythm=%d form=%d darkmatter=%d boundary=%d\n",
+               sensitive[1] + 0, sensitive[2] + 0, sensitive[3] + 0,
+               sensitive[4] + 0, sensitive[5] + 0, sensitive[6] + 0,
+               sensitive[7] + 0, boundary + 0
+        print "adequacy requires >=8 qualified returns across >=4 events and >=4 lives"
+        print "within 0.002 of replacement gate 0.40 is boundary; >=6/7 matching projections is robust"
+        print "all post-settlement replacements and automatic exact birth/strongest prior updated anchors are retained"
+        print "receipts are observational; no projection enters update, persistence, generation, or speech"
+        print "result=" result
+        if (length(all_event) != event_count) exit 1
+    }
+' "$ANATOMY" > "$VERDICT"
+
+cat "$LIFE_SUMMARY"
+printf '\n'
+cat "$EVENT_SUMMARY"
+printf '\n'
+cat "$VERDICT"
+printf '\nplan: %s\nevents: %s\nraw returns: %s\nanatomy: %s\n' \
+    "$PLAN" "$EVENTS" "$RAW" "$ANATOMY"

--- a/scripts/state_swarm_displacement_anatomy_report.awk
+++ b/scripts/state_swarm_displacement_anatomy_report.awk
@@ -1,0 +1,206 @@
+# A.86: classify fate stability under seven leave-one-organ-out projections.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function number(value) {
+    return value ~ /^-?[0-9]+([.][0-9]+)?$/
+}
+
+function unsigned_number(value) {
+    return value ~ /^[0-9]+$/
+}
+
+function abs(value) {
+    return value < 0 ? -value : value
+}
+
+function member_mass(value, wanted,    item, pair, n, i) {
+    n = split(value, item, ",")
+    for (i = 1; i <= n; i++) {
+        split(item[i], pair, ":")
+        if (pair[1] + 0 == wanted) return pair[2] + 0
+    }
+    return 0
+}
+
+function member_present(value, wanted,    item, pair, n, i) {
+    n = split(value, item, ",")
+    for (i = 1; i <= n; i++) {
+        split(item[i], pair, ":")
+        if (pair[1] + 0 == wanted) return 1
+    }
+    return 0
+}
+
+function other_max(value, wanted,    item, pair, n, i, best, mass) {
+    best = 0
+    n = split(value, item, ",")
+    for (i = 1; i <= n; i++) {
+        split(item[i], pair, ":")
+        mass = pair[2] + 0
+        if (pair[1] + 0 != wanted && mass > best) best = mass
+    }
+    return best
+}
+
+function parse_vector(value, target,    part, n, i) {
+    n = split(value, part, "/")
+    if (n != 7) fail()
+    for (i = 1; i <= 7; i++) {
+        if (!number(part[i]) || part[i] + 0 < 0 || part[i] + 0 > 1.001)
+            fail()
+        target[i] = part[i] + 0
+    }
+}
+
+function candidate_score(slot, omit,    organ, total, retained) {
+    total = 0
+    retained = 0
+    for (organ = 1; organ <= 7; organ++) {
+        if (organ == omit) continue
+        total += organ_weight[organ] * candidate_organ[slot, organ]
+        retained += organ_weight[organ]
+    }
+    return retained > 0 ? total / retained : 0
+}
+
+function best_candidate(omit,    i, score, best_score) {
+    chosen_index = 0
+    best_score = -1
+    for (i = 1; i <= candidate_n; i++) {
+        score = candidate_score(i, omit)
+        if (score > best_score + 0.0000001) {
+            best_score = score
+            chosen_index = i
+        }
+    }
+    chosen_score = best_score
+    return candidate_id[chosen_index]
+}
+
+function classify_projection(omit, trigger_new,    winner_id) {
+    winner_id = best_candidate(omit)
+    if (abs(chosen_score - 0.40) < 0.002) return "boundary"
+    if (chosen_score < 0.40) return "rebirth"
+    return winner_id == trigger_new ? "trigger-capture" : "survivor-return"
+}
+
+function parse_candidates(members, event, winner, replaced, removed_raw,
+                          organs,    member_item, organ_item, n, i, j,
+                          colon, member_id, organ_id, raw, invalid,
+                          removed_value) {
+    for (i = 1; i <= candidate_n; i++) {
+        candidate_id[i] = 0
+        for (j = 1; j <= 7; j++) candidate_organ[i, j] = 0
+    }
+    candidate_n = 0
+    n = split(members, member_item, ",")
+    if (n != 8 || split(organs, organ_item, ",") != n) fail()
+    if (event == "replaced") parse_vector(removed_raw, removed_value)
+    invalid = 0
+    for (i = 1; i <= n; i++) {
+        colon = index(member_item[i], ":")
+        if (!colon) fail()
+        member_id = substr(member_item[i], 1, colon - 1)
+        if (!unsigned_number(member_id) || member_id < 1) fail()
+        colon = index(organ_item[i], ":")
+        if (!colon) fail()
+        organ_id = substr(organ_item[i], 1, colon - 1)
+        raw = substr(organ_item[i], colon + 1)
+        if (organ_id != member_id) fail()
+        candidate_n++
+        if (raw == "na") {
+            invalid++
+            if (event != "replaced" || member_id != winner || replaced < 1)
+                fail()
+            candidate_id[candidate_n] = replaced
+            for (j = 1; j <= 7; j++)
+                candidate_organ[candidate_n, j] = removed_value[j]
+        } else {
+            candidate_id[candidate_n] = member_id
+            parse_vector(raw, parsed_value)
+            for (j = 1; j <= 7; j++)
+                candidate_organ[candidate_n, j] = parsed_value[j]
+        }
+        for (j = 1; j < candidate_n; j++)
+            if (candidate_id[j] == candidate_id[candidate_n]) fail()
+    }
+    if ((event == "updated" && invalid != 0) ||
+        (event == "replaced" && invalid != 1)) fail()
+}
+
+BEGIN {
+    FS = "\t"
+    OFS = "\t"
+    organ_weight[1] = 0.19; organ_name[1] = "perception"
+    organ_weight[2] = 0.19; organ_name[2] = "expression"
+    organ_weight[3] = 0.10; organ_name[3] = "own-field"
+    organ_weight[4] = 0.20; organ_name[4] = "body"
+    organ_weight[5] = 0.18; organ_name[5] = "rhythm"
+    organ_weight[6] = 0.07; organ_name[6] = "form"
+    organ_weight[7] = 0.07; organ_name[7] = "darkmatter"
+    print "event", "life", "split", "settled", "base_seed",
+          "trigger_turn", "displaced_id", "trigger_new_id", "probe",
+          "kind", "control_old_mass", "control_margin", "qualified",
+          "fate", "nearest_id", "nearest_similarity", "without_perception",
+          "without_expression", "without_own_field", "without_body",
+          "without_rhythm", "without_form", "without_darkmatter",
+          "stable_organs", "robust", "flip_organs", "prompt", "reply"
+}
+
+NR == 1 { next }
+{
+    if (NF != 33 || $1 == "" || $2 !~ /^h[0-9][0-9]$/ ||
+        $3 != "holdout" || ($4 != "true" && $4 != "false") ||
+        !unsigned_number($5) || !unsigned_number($6) ||
+        !unsigned_number($7) || !unsigned_number($8) ||
+        $9 !~ /^[12]$/ || $10 !~ /^(exact-birth|exact-anchor)$/ ||
+        !unsigned_number($11) || $12 != $6 + 1 || $22 != $12 ||
+        $13 !~ /^(updated|replaced)$/ ||
+        $23 !~ /^(updated|replaced)$/ || $32 == "" || $33 == "") fail()
+
+    old_mass = member_mass($16, $7)
+    margin = old_mass - other_max($16, $7)
+    qualified = $13 == "updated" && $14 == $7 &&
+                old_mass >= 0.20 && margin >= 0.02
+    if (member_present($26, $7)) fail()
+
+    if ($23 == "replaced") fate = "rebirth"
+    else if ($24 == $8) fate = "trigger-capture"
+    else fate = "survivor-return"
+
+    parse_candidates($26, $23, $24, $27, $30, $31)
+    parse_vector($29, nearest_value)
+    nearest_score = 0
+    for (organ = 1; organ <= 7; organ++)
+        nearest_score += organ_weight[organ] * nearest_value[organ]
+    if (abs(nearest_score - $25) > 0.0015) fail()
+    best_id = best_candidate(0)
+    if (best_id != $28 || abs(chosen_score - nearest_score) > 0.0015) fail()
+    if (($23 == "updated" && ($24 != $28 || chosen_score < 0.398)) ||
+        ($23 == "replaced" && chosen_score > 0.4001)) fail()
+
+    stable = 0
+    flips = ""
+    for (organ = 1; organ <= 7; organ++) {
+        projected[organ] = classify_projection(organ, $8)
+        if (projected[organ] == fate) stable++
+        else flips = flips (flips ? "," : "") organ_name[organ] ":" projected[organ]
+    }
+    if (!flips) flips = "none"
+    robust = stable >= 6
+
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.6f\t%.6f\t%s\t%s\t%s\t%.6f",
+           $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+           old_mass, margin, qualified ? "true" : "false", fate, $28, $25
+    for (organ = 1; organ <= 7; organ++) printf "\t%s", projected[organ]
+    printf "\t%d\t%s\t%s\t%s\t%s\n", stable,
+           robust ? "true" : "false", flips, $32, $33
+}
+
+END {
+    if (fatal) exit 2
+}

--- a/scripts/test_state_swarm_displacement_anatomy_log.sh
+++ b/scripts/test_state_swarm_displacement_anatomy_log.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-state-anatomy-log-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+cat > "$TMP/updated.log" <<'EOF'
+     [state-swarm: turn=12 states=2 active=1 winner=2 event=updated similarity=0.700 entropy=0.500 members=1:0.100,2:0.900 organs=1:0.100000/0.100000/0.100000/0.100000/0.100000/0.100000/0.100000,2:0.700000/0.700000/0.700000/0.700000/0.700000/0.700000/0.700000 nearest=2 nearest_organs=0.700000/0.700000/0.700000/0.700000/0.700000/0.700000/0.700000 adjacent=1]
+EOF
+cat > "$TMP/replaced.log" <<'EOF'
+     [state-swarm: turn=19 states=2 active=1 winner=3 event=replaced similarity=0.350 entropy=0.000 members=1:0.000,3:1.000 organs=1:0.200000/0.200000/0.200000/0.200000/0.200000/0.200000/0.200000,3:na nearest=2 nearest_organs=0.350000/0.350000/0.350000/0.350000/0.350000/0.350000/0.350000 adjacent=1 replaced=2 removed_organs=0.350000/0.350000/0.350000/0.350000/0.350000/0.350000/0.350000]
+EOF
+
+awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" \
+    "$TMP/updated.log" > "$TMP/updated.tsv"
+awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" \
+    "$TMP/replaced.log" > "$TMP/replaced.tsv"
+
+awk -F '\t' 'NF != 10 || $1 != 12 || $2 != "updated" || $3 != 2 ||
+    $6 != 0 || $7 != 2 || $9 != "na" { exit 1 }' "$TMP/updated.tsv"
+awk -F '\t' 'NF != 10 || $1 != 19 || $2 != "replaced" || $3 != 3 ||
+    $6 != 2 || $7 != 2 || $9 == "na" { exit 1 }' "$TMP/replaced.tsv"
+
+sed 's/similarity=0.350/similarity=0.450/' "$TMP/replaced.log" \
+    > "$TMP/bad.log"
+if awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" \
+    "$TMP/bad.log" >/dev/null 2>&1; then
+    printf 'anatomy parser accepted a false nearest reconstruction\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm displacement anatomy log parser: ok\n'

--- a/scripts/test_state_swarm_displacement_anatomy_matrix.sh
+++ b/scripts/test_state_swarm_displacement_anatomy_matrix.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-state-anatomy-plan.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+LEO_STATE_ANATOMY_PLAN_ONLY=1 \
+    "$ROOT/scripts/state_swarm_displacement_anatomy_matrix.sh" "$TMP/run" \
+    > "$TMP/plan.stdout"
+
+cmp -s "$TMP/run/plan.tsv" "$TMP/plan.stdout"
+awk -F '\t' '
+    NR == 1 {
+        if (NF != 9 || $1 != "life" || $4 != "phase" ||
+            $8 != "run_seed" || $9 != "prompt") exit 1
+        next
+    }
+    {
+        rows++; lives[$1]++; phases[$1 SUBSEP $4]++
+        if ($2 != "holdout" || $3 !~ /^[0-9]+$/ ||
+            $4 !~ /^(warm|writer)$/ || $5 < 1 || $6 < 1 ||
+            $7 !~ /^(home|storm|wonder|social)$/ || $8 !~ /^[0-9]+$/ ||
+            $9 == "" || seed[$1 SUBSEP $8]++) exit 1
+    }
+    END {
+        if (rows != 768 || length(lives) != 8) exit 1
+        for (life in lives)
+            if (lives[life] != 96 || phases[life SUBSEP "warm"] != 32 ||
+                phases[life SUBSEP "writer"] != 64) exit 1
+    }
+' "$TMP/run/plan.tsv"
+
+printf 'state-swarm displacement anatomy matrix plan: ok\n'

--- a/scripts/test_state_swarm_displacement_anatomy_report.sh
+++ b/scripts/test_state_swarm_displacement_anatomy_report.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-state-anatomy-report-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+RAW="$TMP/raw.tsv"
+
+printf 'event\tlife\tsplit\tsettled\tbase_seed\ttrigger_turn\tdisplaced_id\ttrigger_new_id\tprobe\tkind\treturn_seed\tcontrol_turn\tcontrol_event\tcontrol_winner\tcontrol_similarity\tcontrol_members\tcontrol_replaced\tcontrol_nearest\tcontrol_nearest_organs\tcontrol_removed_organs\tcontrol_organs\tdisplaced_turn\tdisplaced_event\tdisplaced_winner\tdisplaced_similarity\tdisplaced_members\tdisplaced_replaced\tdisplaced_nearest\tdisplaced_nearest_organs\tdisplaced_removed_organs\tdisplaced_organs\tprompt\treply\n' > "$RAW"
+
+small='0.100000/0.100000/0.100000/0.100000/0.100000/0.100000/0.100000'
+control_high='0.700000/0.700000/0.700000/0.700000/0.700000/0.700000/0.700000'
+capture_high='0.800000/0.800000/0.800000/0.800000/0.800000/0.800000/0.800000'
+control_members='1:0.050,2:0.050,3:0.650,4:0.050,5:0.050,6:0.050,7:0.050,8:0.050'
+control_organs="1:${small},2:${small},3:${control_high},4:${small},5:${small},6:${small},7:${small},8:${small}"
+control_shape="52\tupdated\t3\t0.700\t${control_members}\t0\t3\t${control_high}\tna\t${control_organs}"
+
+capture_members='1:0.050,2:0.050,9:0.650,4:0.050,5:0.050,6:0.050,7:0.050,8:0.050'
+capture_organs="1:${small},2:${small},9:${capture_high},4:${small},5:${small},6:${small},7:${small},8:${small}"
+capture_shape="52\tupdated\t9\t0.800\t${capture_members}\t0\t9\t${capture_high}\tna\t${capture_organs}"
+printf 'e1\th01\tholdout\ttrue\t14939\t51\t3\t9\t1\texact-birth\t15824\t%b\t%b\tprompt one\treply one\n' \
+    "$control_shape" "$capture_shape" >> "$RAW"
+
+rebirth_members='1:0.125,2:0.125,9:0.125,4:0.125,5:0.125,6:0.125,7:0.125,10:0.125'
+low='0.350000/0.350000/0.350000/0.350000/0.350000/0.350000/0.350000'
+lower='0.200000/0.200000/0.200000/0.200000/0.200000/0.200000/0.200000'
+rebirth_organs="1:${low},2:${lower},9:${lower},4:${lower},5:${lower},6:${lower},7:${lower},10:na"
+rebirth_shape="52\treplaced\t10\t0.350\t${rebirth_members}\t8\t1\t${low}\t${lower}\t${rebirth_organs}"
+printf 'e2\th02\tholdout\ttrue\t15331\t51\t3\t9\t1\texact-birth\t15824\t%b\t%b\tprompt two\treply two\n' \
+    "$control_shape" "$rebirth_shape" >> "$RAW"
+
+awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_report.awk" "$RAW" \
+    > "$TMP/anatomy.tsv"
+awk -F '\t' '
+    NR == 1 { next }
+    $1 == "e1" {
+        if ($13 != "true" || $14 != "trigger-capture" ||
+            $24 != 7 || $25 != "true" || $26 != "none") exit 1
+    }
+    $1 == "e2" {
+        if ($13 != "true" || $14 != "rebirth" ||
+            $24 != 7 || $25 != "true" || $26 != "none") exit 1
+    }
+    END { if (NR != 3) exit 1 }
+' "$TMP/anatomy.tsv"
+
+sed '2s/9:0.650/3:0.650/' "$RAW" > "$TMP/bad.tsv"
+if awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_report.awk" \
+    "$TMP/bad.tsv" >/dev/null 2>&1; then
+    printf 'anatomy scorer accepted the displaced old ID\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm displacement anatomy scorer: ok\n'

--- a/scripts/test_state_swarm_ecology_matrix.sh
+++ b/scripts/test_state_swarm_ecology_matrix.sh
@@ -52,6 +52,22 @@ printf '%s\n' "$first" | awk -F '\t' '
     END { exit !ok }
 '
 
+cat > "$TMP/diffuse.log" <<'EOF'
+     [state-swarm: turn=31 states=8 active=0 winner=4 event=updated similarity=0.482 entropy=0.993 members=1:0.135,2:0.117,9:0.075,4:0.146,5:0.131,6:0.127,7:0.137,8:0.132 adjacent=1 observed=0.000/0.000/-0.233/-0.500 expected=2(0.250) overlap=0.122 surprise=2.104 forecast=0.000/-0.002/0.002/0.008 clocks=0.11/0.10/0.32/0.78]
+EOF
+diffuse="$(
+    awk -v cell=diffuse -v cohort=holdout -v base_seed=20873 \
+        -v phase=warm -v session=4 -v order=7 -v texture=wonder \
+        -v run_seed=24280 -v prompt='A blue thread enters a crack.' \
+        -v reply='It waits.' \
+        -f "$ROOT/scripts/state_swarm_dialogue_report.awk" \
+        "$TMP/diffuse.log"
+)"
+printf '%s\n' "$diffuse" | awk -F '\t' '
+    NR == 1 { ok = NF == 34 && $9 == 31 && $10 == 8 && $11 == 0 && $12 == 4 }
+    END { exit !(ok && NR == 1) }
+'
+
 cat > "$TMP/bad.log" <<'EOF'
      [state-swarm: turn=7 states=2 active=1 winner=1 event=updated similarity=0.700 entropy=0.500 members=1:0.400,2:0.400 adjacent=1 observed=0.000/0.000/0.000/0.000 clocks=1.00/1.00/1.00/1.00]
 EOF

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -7395,6 +7395,8 @@ int main(void) {
                   fabsf(state->state_swarm_receipt.member_activation[0] - 1.0f) < 1e-6f &&
                   leo_state_organ_receipt(state) &&
                   !leo_state_organ_receipt(state)->valid[0] &&
+                  !leo_state_organ_receipt(state)->nearest_valid &&
+                  !state->state_swarm_receipt.nearest_id &&
                   !state->state_swarm_receipt.adjacent &&
                   !state->state_swarm_receipt.has_prediction,
                   "state-swarm: a birth exposes activation but does not launder self-similarity into organ evidence");
@@ -7405,8 +7407,10 @@ int main(void) {
                   state->state_swarm_receipt.event == LEO_STATE_SWARM_UPDATED &&
                   state->state_swarm->weights[0].observations == 2 &&
                   state->state_swarm_receipt.active == 1 &&
+                  state->state_swarm_receipt.nearest_id == 1 &&
                   leo_state_organ_receipt(state) &&
-                  leo_state_organ_receipt(state)->valid[0],
+                  leo_state_organ_receipt(state)->valid[0] &&
+                  leo_state_organ_receipt(state)->nearest_valid,
                   "state-swarm: a repeated life deepens one state instead of multiplying names");
             {
                 const float *organ =
@@ -7589,8 +7593,26 @@ int main(void) {
                   full->state_swarm->n == LEO_STATE_SWARM_MAX &&
                   full->state_swarm->weights[0].id ==
                       LEO_STATE_SWARM_MAX + 1 &&
+                  full->state_swarm_receipt.nearest_id > 0 &&
+                  leo_state_organ_receipt(full)->nearest_valid &&
+                  leo_state_organ_receipt(full)->removed_valid &&
                   leo_state_swarm_valid(full),
                   "state-swarm: a full swarm replaces its weakest decayed coordinate, not its strongest memory");
+            {
+                const float *nearest =
+                    leo_state_organ_receipt(full)->nearest_similarity;
+                float reconstructed =
+                    0.19f * nearest[LEO_STATE_ORGAN_PERCEPTION] +
+                    0.19f * nearest[LEO_STATE_ORGAN_EXPRESSION] +
+                    0.10f * nearest[LEO_STATE_ORGAN_FIELD] +
+                    0.20f * nearest[LEO_STATE_ORGAN_BODY] +
+                    0.18f * nearest[LEO_STATE_ORGAN_RHYTHM] +
+                    0.07f * nearest[LEO_STATE_ORGAN_FORM] +
+                    0.07f * nearest[LEO_STATE_ORGAN_DARKMATTER];
+                CHECK(fabsf(reconstructed -
+                            full->state_swarm_receipt.similarity) < 1e-6f,
+                      "state-swarm: replacement preserves the nearest pre-update organ witness");
+            }
             leo_free(full);
             free(full);
         } else {


### PR DESCRIPTION
## What changed

- preserve runtime-only nearest and removed pre-update seven-organ witnesses for state-swarm replacement
- add the sealed eight-life A.86 displacement-anatomy runner, automatic birth/anchor provenance, and seven leave-one-organ-out scorer
- accept the legitimate diffuse `active=0` receipt and cover it with a regression fixture
- record the reproduced insufficient population result and the separate A.85 event-path verification

## Why

A.85 showed that a displaced experience may return through several different fates. A.86 asks whether those fates belong to one similarity organ or to distributed geometry, while refusing to infer anatomy when a new sealed population produces no replacement events.

## Impact

The new organ witnesses are observational and runtime-only. Persisted v27 state, state update law, routing, generation, and visible speech are unchanged.

## Validation

- `make test` (`549/549` C tests plus all script contracts)
- canonical A.86 `r4` and independent `r5`: byte-identical 768 receipts, final states, scientific tables, and verdict
- technical event replay: all three known A.85 replacements, six automatic returns, and complete fork/provenance/LOO path
- `git diff --check`
