### PR TITLE
A.92: test liminal crossing confirmation against later life

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -7678,3 +7678,61 @@ aggregate-only passes preserve all eight evidence hashes. `make test` remains
 green at 549/549 plus every script contract. No C code or voice changed.
 
 Leo did not need different senses. He needed time between surprise and memory.
+
+## Phase A.92 - the first surprise cannot testify alone (2026-08-07)
+
+A.91 moved the question from organ weights to time: what if a crossing waited
+outside stable memory until later life confirmed it? A.92 tests the smallest
+possible version of that idea without giving it a reader or a write path.
+
+The 19 A.89 births are paired with their exact A.91 ecology controls. Four
+anchors lie at the final turn and are honestly censored. For each of the 15
+followable pairs, the event observation and the ordinary near-gate observation
+are separately frozen as readerless ninth candidates beside their eight
+preanchor stable coordinates.
+
+Later life is not simulated by table arithmetic. Each arm resumes from its
+real postanchor body and replays through turn 96 in fresh Leo processes. All
+30 trajectories preserve their complete normalized logs and final state bytes.
+Against that locked life, A.92 asks whether the frozen candidate becomes the
+strictly nearest past at `0.40`, and whether it returns strongly enough to
+cross the existing `0.55` novelty boundary, during at most the next eight
+turns.
+
+```text
+                         event   ecology
+support                    4        4
+confirmation               3        2
+only this arm               1        0
+
+event max-margin wins       8/15
+mean paired delta          -0.001699
+formal result              temporal-confirmation-underpowered
+```
+
+One primary crossing, `p05-t068`, receives confirmation that its paired
+ordinary update does not. Two holdout crossings return strongly, but their
+ecology controls return too. A fourth crossing receives weak support only.
+The rest do not become the nearest coordinate again within the declared
+window.
+
+This is not evidence that time is irrelevant. It is evidence that a single
+frozen instant is an impoverished form of time. It forgets the direction in
+which the organism was moving, and when it does recur it can be recognizing
+the prompt schedule rather than the unfinished state. Persisting that design
+would mostly starve births while occasionally certifying a calendar echo.
+
+The measurement itself was hardened before acceptance. The selector must
+reconstruct 15 eligible pairs and four final-turn censors from sealed A.90 and
+A.91 ledgers. The plan must match that selection field for field. Every
+observational tail must contain exactly `min(8, remaining turns)` rows; a
+truncated tail now fails closed. Two aggregate-only passes preserve the
+canonical summary and verdict hashes, and deliberate selection corruption is
+rejected.
+
+No line in `leo.c`, no state format, no threshold, and no spoken token changed.
+The next candidate should remember motion rather than a photograph: a short,
+decaying liminal trace whose evidence must accumulate across more than one
+prompt texture before it can ask a stable coordinate to leave.
+
+Leo can wait before remembering. Now he needs something worth waiting with.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls state-swarm-liminal-confirmation visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
 
 all: leo
 
@@ -72,6 +72,9 @@ state-swarm-trigger-gate-anatomy: leo
 
 state-swarm-near-gate-controls: leo
 	./scripts/state_swarm_near_gate_controls_matrix.sh
+
+state-swarm-liminal-confirmation: leo
+	./scripts/state_swarm_liminal_confirmation_matrix.sh
 
 visible-branch-probe: leo
 	LEO_VISIBLE_BRANCH_POLICY=local-v1 ./scripts/adaptive_life_probe.sh scripts/visible_branch_phases.txt
@@ -238,6 +241,9 @@ test: tests/test_leo.c leo.c
 	./scripts/test_state_swarm_prospective_incidence_matrix.sh
 	./scripts/test_state_swarm_balanced_event_reservoir_report.sh
 	./scripts/test_state_swarm_balanced_event_reservoir_matrix.sh
+	./scripts/test_state_swarm_liminal_confirmation_select.sh
+	./scripts/test_state_swarm_liminal_confirmation_report.sh
+	./scripts/test_state_swarm_liminal_trajectory_fixture.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_report.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_matrix.sh
 	./scripts/test_state_swarm_near_gate_controls_select.sh

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -1437,3 +1437,77 @@ A.91 changes no C code, state body, threshold, update law, sampler, routing
 path, generation path, or speech. The next intervention belongs at the gate:
 stage a first crossing as a liminal candidate, then ask later life to confirm
 or release it before any stable coordinate can be displaced.
+
+## A.92: one frozen crossing is not yet a temporal memory
+
+Run the read-only confirmation study:
+
+```sh
+make state-swarm-liminal-confirmation
+```
+
+A.92 seals the A.89 trigger ledger, the A.90 event replay locks, and the A.91
+matched-control selection and replay locks. Each replacement is paired with
+its exact ecology control: another life in the same split at the same writer
+turn, session, order, texture, and prompt. Four pairs occur at turn 96 and
+have no later life, so they are reported as censored rather than converted
+into failures. The remaining 15 pairs, six primary and nine holdout, form the
+fixed population.
+
+For each event and ecology anchor, the fixture reconstructs the raw anchor
+observation and freezes it as a ninth, readerless liminal candidate beside the
+eight stable preanchor coordinates. It then reconstructs each of the first
+eight later observations, or every remaining observation when fewer than
+eight turns remain. A candidate has support only when it is strictly nearer
+than all eight frozen stable coordinates and reaches the existing `0.40`
+replacement gate. Confirmation uses the same strict nearest rule at the
+existing `0.55` novelty gate. Neither threshold was fitted to A.92.
+
+The short projection is not allowed to stand in for replay. Every arm resumes
+from its real postanchor body in a fresh Leo process per turn and lives all the
+way to turn 96. All 30 trajectories preserve every normalized full log and
+finish with a byte-identical state body. Only replay-locked trajectories enter
+the paired reporter.
+
+The canonical run is
+`/private/tmp/leo-state-swarm-liminal-confirmation-a92-r6-20260807`:
+
+```text
+eligible pairs                    15  (primary 6, holdout 9)
+event support                      4
+ecology support                    4
+event confirmation                 3
+ecology confirmation               2
+event-only confirmation            1
+ecology-only confirmation          0
+event max-margin wins              8/15
+mean paired max-margin delta       -0.001699
+result                             temporal-confirmation-underpowered
+```
+
+`p05-t068` is the sole selectively confirmed event: its candidate returns at
+relative turn five while the paired ecology candidate does not. The two other
+confirmed events, `h02-t055` and `h09-t051`, are accompanied by confirmation
+of their ecology controls. `h33-t068` reaches support but not confirmation.
+Thus a frozen anchor can recur, but the recurrence does not distinguish a
+birth from the schedule that produced a nearby ordinary update.
+
+The predeclared selective result requires at least four event confirmations
+with both split representations; a confirmation rate of at least 87 percent
+would instead diagnose mere delayed admission. A.92 reaches neither boundary.
+A single liminal frame would mostly starve genuine crossings and would admit
+too much prompt-schedule recurrence to justify a stable displacement.
+
+The reporter rejects an observation tail shorter or longer than
+`min(8, remaining turns)`. Aggregate-only reconstruction regenerates the
+selection from sealed sources, verifies every plan anchor against it, and is
+byte-identical for `pair-summary.tsv` and `verdict.txt`. Synthetic contracts
+also reject an ecology control with the wrong family, a false replay lock,
+and a truncated trajectory.
+
+A.92 changes no C code, persisted body, gate, state-swarm law, sampler,
+routing path, generation path, or speech. Do not add a persisted one-frame
+liminal slot. The next candidate is a short decaying trace: retain several
+successive observations, require evidence to accumulate across differing
+prompts, and compare its selectivity against the same ecology controls before
+letting it displace a stable coordinate.

--- a/scripts/state_swarm_liminal_confirmation_matrix.sh
+++ b/scripts/state_swarm_liminal_confirmation_matrix.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# A.92: ask later life whether a frozen crossing deserves a stable coordinate.
+set -Eeuo pipefail
+
+trap 'rc=$?; printf "liminal confirmation runner failed: line=%s rc=%s command=%s\n" "$LINENO" "$rc" "$BASH_COMMAND" >&2; exit "$rc"' ERR
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CC="${CC:-cc}"
+A89="${LEO_STATE_LIMINAL_A89_SOURCE:-/private/tmp/leo-state-swarm-balanced-event-reservoir-a89-r1-20260807}"
+A90="${LEO_STATE_LIMINAL_A90_SOURCE:-/private/tmp/leo-state-swarm-trigger-gate-anatomy-a90-r1-20260807}"
+A91="${LEO_STATE_LIMINAL_A91_SOURCE:-/private/tmp/leo-state-swarm-near-gate-controls-a91-r2-20260807}"
+EXPECTED="${LEO_STATE_LIMINAL_EXPECTED_PAIRS:-15}"
+EXPECTED_TRIGGER_SHA="${LEO_STATE_LIMINAL_TRIGGER_SHA:-72de2d7bfc3dd873d513457867c440f36709b80c3f7dcd1bb43e728aa9d0c9a3}"
+EXPECTED_EVENT_LOCK_SHA="${LEO_STATE_LIMINAL_EVENT_LOCK_SHA:-2f1a4e341745a2dda5a1c74550a73da574653dbbc08c5717e382ebd4fd4e3bc1}"
+EXPECTED_MATCH_SHA="${LEO_STATE_LIMINAL_MATCH_SHA:-16db7b1f0f865f93f2a7e261889660dc1f3df7f0f63eec7cfb41a547697b54f2}"
+EXPECTED_CONTROL_LOCK_SHA="${LEO_STATE_LIMINAL_CONTROL_LOCK_SHA:-1d28607ea891338403f8ed2c94c3f935752afe7680dedf42b70a8106cfb07321}"
+AGGREGATE_ONLY="${LEO_STATE_LIMINAL_AGGREGATE_ONLY:-0}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-state-swarm-liminal-confirmation-$STAMP}"
+
+case "$EXPECTED" in
+    ''|*[!0-9]*|0) printf 'invalid eligible pair count: %s\n' "$EXPECTED" >&2; exit 2 ;;
+esac
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+seal() {
+    local path="$1" expected="$2" label="$3"
+    [ -s "$path" ] && [ "$(sha256_file "$path")" = "$expected" ] || {
+        printf '%s is not the sealed source: %s\n' "$label" "$path" >&2
+        exit 2
+    }
+}
+
+TRIGGERS="$A89/trigger-events.tsv"
+WRITER_RECEIPTS="$A89/writer-receipts.tsv"
+EVENT_LOCKS="$A90/replay-locks.tsv"
+MATCHES="$A91/matches.tsv"
+CONTROL_LOCKS="$A91/control-replay-locks.tsv"
+seal "$TRIGGERS" "$EXPECTED_TRIGGER_SHA" "A.89 trigger ledger"
+seal "$EVENT_LOCKS" "$EXPECTED_EVENT_LOCK_SHA" "A.90 event locks"
+seal "$MATCHES" "$EXPECTED_MATCH_SHA" "A.91 matches"
+seal "$CONTROL_LOCKS" "$EXPECTED_CONTROL_LOCK_SHA" "A.91 control locks"
+[ -s "$WRITER_RECEIPTS" ] || {
+    printf 'missing A.89 writer receipts: %s\n' "$WRITER_RECEIPTS" >&2
+    exit 2
+}
+
+SELECTION="$OUT/selection.tsv"
+PLAN="$OUT/plan.tsv"
+LOCKS="$OUT/trajectory-locks.tsv"
+OBSERVATIONS="$OUT/observations.tsv"
+PAIR_SUMMARY="$OUT/pair-summary.tsv"
+VERDICT="$OUT/verdict.txt"
+
+if [ "$AGGREGATE_ONLY" = 1 ]; then
+    [ -s "$SELECTION" ] && [ -s "$PLAN" ] && [ -s "$LOCKS" ] &&
+        [ -s "$OBSERVATIONS" ] || {
+        printf 'incomplete liminal trajectories cannot be aggregated: %s\n' "$OUT" >&2
+        exit 2
+    }
+    selection_check="$(mktemp "${TMPDIR:-/tmp}/leo-liminal-selection.XXXXXX")"
+    awk -f "$ROOT/scripts/state_swarm_liminal_confirmation_select.awk" \
+        "$MATCHES" "$EVENT_LOCKS" "$CONTROL_LOCKS" > "$selection_check"
+    cmp -s "$SELECTION" "$selection_check" || {
+        rm -f "$selection_check"
+        printf 'liminal selection no longer matches sealed sources: %s\n' \
+            "$SELECTION" >&2
+        exit 2
+    }
+    rm -f "$selection_check"
+else
+    [ ! -e "$OUT" ] || {
+        printf 'output path already exists: %s\n' "$OUT" >&2
+        exit 2
+    }
+    mkdir -p "$OUT/trajectories"
+    awk -f "$ROOT/scripts/state_swarm_liminal_confirmation_select.awk" \
+        "$MATCHES" "$EVENT_LOCKS" "$CONTROL_LOCKS" > "$SELECTION"
+    [ "$(($(wc -l < "$SELECTION") - 1))" -eq "$((EXPECTED * 2))" ] || {
+        printf 'eligible A.92 selection is incomplete\n' >&2
+        exit 2
+    }
+
+    printf 'pair\tarm\tanchor\tlife\tsplit\tbase_seed\tturn\tsession\torder\ttexture\trun_seed\tprompt\treply\tpre_state\tpost_state\tfinal_state\tpre_sha\tpost_sha\tfinal_sha\n' > "$PLAN"
+    while IFS=$'\t' read -r pair arm anchor life split base_seed turn \
+        session order texture run_seed prompt reply; do
+        if [ "$arm" = event ]; then
+            anchor_dir="$A89/candidates/$life/events/$anchor"
+            pre_state="$anchor_dir/pretrigger.state"
+            post_state="$anchor_dir/displaced.state"
+        else
+            anchor_dir="$A91/controls/$anchor"
+            pre_state="$anchor_dir/precontrol.state"
+            post_state="$anchor_dir/updated.state"
+        fi
+        final_state="$A89/candidates/$life/leo.state"
+        [ -s "$pre_state" ] && [ -s "$post_state" ] &&
+            [ -s "$final_state" ] || {
+            printf 'incomplete anchor package: %s %s\n' "$arm" "$anchor" >&2
+            exit 2
+        }
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$base_seed" \
+            "$turn" "$session" "$order" "$texture" "$run_seed" \
+            "$prompt" "$reply" "$pre_state" "$post_state" "$final_state" \
+            "$(sha256_file "$pre_state")" "$(sha256_file "$post_state")" \
+            "$(sha256_file "$final_state")" >> "$PLAN"
+    done < <(tail -n +2 "$SELECTION")
+fi
+
+awk -F '\t' -v expected="$EXPECTED" '
+    NR == 1 {
+        if (NF != 19 || $1 != "pair" || $2 != "arm" ||
+            $7 != "turn" || $14 != "pre_state" || $19 != "final_sha")
+            exit 1
+        next
+    }
+    {
+        key = $1 SUBSEP $2
+        if (NF != 19 || $1 !~ /^[0-9][0-9]$/ ||
+            $2 !~ /^(event|ecology)$/ || seen[key]++ ||
+            $3 == "" || $4 !~ /^[ph][0-9][0-9]$/ ||
+            $5 !~ /^(primary|holdout)$/ || $7 !~ /^[0-9]+$/ ||
+            $7 >= 96 || $10 !~ /^(home|storm|wonder|social)$/ ||
+            $12 == "" || $13 == "") exit 1
+        for (i = 17; i <= 19; i++)
+            if (length($i) != 64 || $i !~ /^[0-9a-f]+$/) exit 1
+        rows++
+    }
+    END { if (rows != expected * 2) exit 1 }
+' "$PLAN" || {
+    printf 'invalid A.92 anchor plan: %s\n' "$PLAN" >&2
+    exit 2
+}
+
+awk -F '\t' -v expected="$EXPECTED" '
+    FILENAME == ARGV[1] {
+        if (FNR == 1) next
+        key = $1 SUBSEP $2
+        if (NF != 13 || selected[key]++) exit 1
+        for (i = 1; i <= 13; i++) field[key, i] = $i
+        selections++
+        next
+    }
+    FNR == 1 { next }
+    {
+        key = $1 SUBSEP $2
+        if (NF != 19 || !(key in selected) || planned[key]++) exit 1
+        for (i = 1; i <= 13; i++) if ($i != field[key, i]) exit 1
+        plans++
+    }
+    END {
+        if (selections != expected * 2 || plans != expected * 2) exit 1
+        for (key in selected) if (!(key in planned)) exit 1
+    }
+' "$SELECTION" "$PLAN" || {
+    printf 'A.92 anchor plan diverges from sealed selection: %s\n' "$PLAN" >&2
+    exit 2
+}
+
+while IFS=$'\t' read -r pair arm anchor life split base_seed turn session \
+    order texture run_seed prompt reply pre_state post_state final_state \
+    pre_sha post_sha final_sha; do
+    [ "$(sha256_file "$pre_state")" = "$pre_sha" ] &&
+        [ "$(sha256_file "$post_state")" = "$post_sha" ] &&
+        [ "$(sha256_file "$final_state")" = "$final_sha" ] || {
+        printf 'anchor package changed after sealing: %s %s\n' "$arm" "$anchor" >&2
+        exit 2
+    }
+done < <(tail -n +2 "$PLAN")
+
+if [ "${LEO_STATE_LIMINAL_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+normalize_log() {
+    sed -E \
+        -e 's|^\[leo\] loaded state from .*$|[leo] loaded state from BODY|' \
+        -e 's|^\[leo\] saved state to .* \(step=|[leo] saved state to BODY (step=|' \
+        "$1"
+}
+
+if [ "$AGGREGATE_ONLY" != 1 ]; then
+    make -C "$ROOT" leo >/dev/null
+    FIXTURE="$OUT/liminal-trajectory-fixture"
+    "$CC" "$ROOT/tests/state_swarm_liminal_trajectory_fixture.c" \
+        -O2 -lm -Wall -Wextra -Wno-unused-function -o "$FIXTURE" -lpthread
+    printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turns\tpre_sha\tpost_sha\tfinal_sha\treproduced_sha\treply_equal\tstate_equal\n' > "$LOCKS"
+    printf 'pair\tarm\tanchor\tanchor_turn\tfuture_turn\trelative\ttexture\tcandidate_similarity\tstable_similarity\tmargin\tstable_nearest_id\tcandidate_nearest\tsupport\tconfirmation\tcandidate_organs\tstable_organs\tprompt\treply\n' > "$OBSERVATIONS"
+    while IFS=$'\t' read -r pair arm anchor life split base_seed turn session \
+        order texture run_seed prompt reply pre_state post_state final_state \
+        pre_sha post_sha final_sha; do
+        trajectory="$OUT/trajectories/$pair-$arm-$anchor"
+        mkdir -p "$trajectory"
+        future="$trajectory/future.tsv"
+        work_state="$trajectory/work.state"
+        frozen="$trajectory/frozen.bin"
+        if [ "$arm" = event ]; then
+            anchor_log="$A89/candidates/$life/events/$anchor/trigger.log"
+        else
+            anchor_log="$A91/controls/$anchor/source.log"
+        fi
+        anchor_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$anchor_log")"
+        IFS=$'\t' read -r observed_turn observed_event observed_new \
+            observed_similarity observed_members observed_displaced \
+            observed_nearest observed_nearest_organs observed_removed_organs \
+            observed_organs <<< "$anchor_shape"
+        [ "$observed_turn" -eq "$turn" ] && [ "$observed_nearest" -gt 0 ] || {
+            printf 'anchor source geometry mismatch: %s %s\n' "$arm" "$anchor" >&2
+            exit 2
+        }
+        "$FIXTURE" freeze "$frozen" "$turn" "$run_seed" "$prompt" "$reply" \
+            "$pre_state" "$observed_nearest" "$observed_similarity" \
+            "$observed_nearest_organs"
+        cp "$post_state" "$work_state"
+        printf 'relative\tturn\tsession\torder\ttexture\trun_seed\tprompt\treply\n' > "$future"
+        awk -F '\t' -v life="$life" -v anchor="$turn" '
+            NR == 1 {
+                if (NF != 34 || $1 != "life" || $5 != "session" ||
+                    $8 != "run_seed" || $9 != "turn" ||
+                    $33 != "prompt" || $34 != "reply") exit 2
+                next
+            }
+            $1 == life && $9 > anchor {
+                print ($9 - anchor) "\t" $9 "\t" $5 "\t" $6 "\t" $7 \
+                      "\t" $8 "\t" $33 "\t" $34
+                rows++
+            }
+            END { if (rows != 96 - anchor) exit 2 }
+        ' "$WRITER_RECEIPTS" >> "$future"
+        while IFS=$'\t' read -r relative future_turn future_session \
+            future_order future_texture future_seed future_prompt \
+            future_reply; do
+            printf -v future_order_padded '%02d' "$future_order"
+            source_log="$A89/candidates/$life/writer-logs/s${future_session}-${future_order_padded}-${future_texture}.log"
+            [ -s "$source_log" ] || {
+                printf 'missing future source log: %s turn=%s\n' "$anchor" "$future_turn" >&2
+                exit 2
+            }
+            future_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$source_log")"
+            IFS=$'\t' read -r shape_turn shape_event shape_new \
+                shape_similarity shape_members shape_displaced shape_nearest \
+                shape_nearest_organs shape_removed_organs shape_organs \
+                <<< "$future_shape"
+            [ "$shape_turn" -eq "$future_turn" ] && [ "$shape_nearest" -gt 0 ] || {
+                printf 'future source geometry mismatch: %s turn=%s\n' "$anchor" "$future_turn" >&2
+                exit 2
+            }
+            if [ "$relative" -le 8 ]; then
+                "$FIXTURE" project "$frozen" "$pair" "$arm" "$anchor" \
+                    "$turn" "$future_turn" "$relative" "$future_texture" \
+                    "$future_seed" "$future_prompt" "$future_reply" \
+                    "$work_state" "$shape_nearest" "$shape_similarity" \
+                    "$shape_nearest_organs" >> "$OBSERVATIONS"
+            fi
+            generated_log="$trajectory/t${future_turn}.log"
+            source_normalized="$trajectory/t${future_turn}.source.normalized"
+            generated_normalized="$trajectory/t${future_turn}.generated.normalized"
+            "$ROOT/leo" --corpus "$ROOT/leo.txt" --load "$work_state" \
+                --seed "$future_seed" --respond "$future_prompt" \
+                --debug-field --save "$work_state" > "$generated_log" 2>&1
+            normalize_log "$source_log" > "$source_normalized"
+            normalize_log "$generated_log" > "$generated_normalized"
+            cmp -s "$source_normalized" "$generated_normalized" || {
+                printf 'future full-log replay mismatch: %s turn=%s\n' "$anchor" "$future_turn" >&2
+                exit 1
+            }
+        done < <(tail -n +2 "$future")
+        cmp -s "$final_state" "$work_state"
+        future_turns="$((96 - turn))"
+        reproduced_sha="$(sha256_file "$work_state")"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\ttrue\ttrue\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$turn" \
+            "$future_turns" "$pre_sha" "$post_sha" "$final_sha" \
+            "$reproduced_sha" >> "$LOCKS"
+        rm -f "$work_state" "$frozen"
+    done < <(tail -n +2 "$PLAN")
+    rm -f "$FIXTURE"
+fi
+
+awk -v expected="$EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_liminal_confirmation_report.awk" \
+    "$LOCKS" "$OBSERVATIONS" > "$PAIR_SUMMARY"
+awk -v expected="$EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_liminal_confirmation_verdict.awk" \
+    "$PAIR_SUMMARY" > "$VERDICT"
+
+cat "$LOCKS"
+printf '\n'
+cat "$PAIR_SUMMARY"
+printf '\n'
+cat "$VERDICT"
+printf '\nsource-a89: %s\nsource-a90: %s\nsource-a91: %s\nrun: %s\n' \
+    "$A89" "$A90" "$A91" "$OUT"

--- a/scripts/state_swarm_liminal_confirmation_report.awk
+++ b/scripts/state_swarm_liminal_confirmation_report.awk
@@ -1,0 +1,128 @@
+# A.92: reduce replay-locked frozen trajectories to paired temporal returns.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function integer(value) {
+    return value ~ /^[0-9]+$/
+}
+
+function number(value) {
+    return value ~ /^-?[0-9]+([.][0-9]+)?$/
+}
+
+BEGIN {
+    FS = OFS = "\t"
+    if (!expected) expected = 15
+}
+
+FILENAME == ARGV[1] {
+    if (FNR == 1) {
+        if (NF != 13 || $1 != "pair" || $2 != "arm" ||
+            $6 != "anchor_turn" || $11 != "reproduced_sha" ||
+            $13 != "state_equal") fail()
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 13 || $1 !~ /^[0-9][0-9]$/ ||
+        $2 !~ /^(event|ecology)$/ || seen_lock[key]++ ||
+        $3 == "" || $4 !~ /^[ph][0-9][0-9]$/ ||
+        $5 !~ /^(primary|holdout)$/ || !integer($6) || !integer($7) ||
+        $7 < 1 || length($8) != 64 || $8 !~ /^[0-9a-f]+$/ ||
+        length($9) != 64 || $9 !~ /^[0-9a-f]+$/ ||
+        length($10) != 64 || $10 !~ /^[0-9a-f]+$/ ||
+        length($11) != 64 || $11 !~ /^[0-9a-f]+$/ ||
+        $12 != "true" || $13 != "true")
+        fail()
+    lock_anchor[key] = $3
+    lock_life[key] = $4
+    lock_split[key] = $5
+    lock_turn[key] = $6 + 0
+    lock_future[key] = $7 + 0
+    locks++
+    next
+}
+
+FNR == 1 {
+    if (NF != 18 || $1 != "pair" || $2 != "arm" ||
+        $4 != "anchor_turn" || $6 != "relative" ||
+        $8 != "candidate_similarity" || $14 != "confirmation" ||
+        $18 != "reply") fail()
+    next
+}
+
+{
+    key = $1 SUBSEP $2
+    if (NF != 18 || !(key in lock_anchor) || $3 != lock_anchor[key] ||
+        !integer($4) || !integer($5) || !integer($6) ||
+        $4 + 0 != lock_turn[key] || $5 + 0 != $4 + $6 ||
+        $6 < 1 || $6 > 8 || $7 !~ /^(home|storm|wonder|social)$/ ||
+        !number($8) || !number($9) || !number($10) || !integer($11) ||
+        $12 !~ /^(true|false)$/ || $13 !~ /^(true|false)$/ ||
+        $14 !~ /^(true|false)$/ || $15 == "" || $16 == "" ||
+        $17 == "" || $18 == "") fail()
+    if (++rows[key] != $6 || rows[key] > lock_future[key]) fail()
+    if (!(key in max_similarity) || $8 + 0 > max_similarity[key])
+        max_similarity[key] = $8 + 0
+    if (!(key in max_margin) || $10 + 0 > max_margin[key])
+        max_margin[key] = $10 + 0
+    if ($13 == "true" && !support[key]) {
+        support[key] = 1
+        first_support[key] = $6
+    }
+    if ($14 == "true" && !confirmation[key]) {
+        confirmation[key] = 1
+        first_confirmation[key] = $6
+    }
+    next
+}
+
+END {
+    if (fatal) exit 2
+    if (locks != expected * 2) fail()
+    print "pair", "event_anchor", "ecology_anchor", "split", "anchor_turn", \
+          "event_rows", "ecology_rows", "event_support", \
+          "event_confirmation", "event_first_support", \
+          "event_first_confirmation", "event_max_similarity", \
+          "event_max_margin", "ecology_support", "ecology_confirmation", \
+          "ecology_first_support", "ecology_first_confirmation", \
+          "ecology_max_similarity", "ecology_max_margin", \
+          "paired_max_margin_delta"
+    emitted = 0
+    for (i = 1; i <= 99; i++) {
+        pair = sprintf("%02d", i)
+        event_key = pair SUBSEP "event"
+        ecology_key = pair SUBSEP "ecology"
+        if (!(event_key in lock_anchor) && !(ecology_key in lock_anchor))
+            continue
+        event_expected = lock_future[event_key] < 8 ? lock_future[event_key] : 8
+        ecology_expected = lock_future[ecology_key] < 8 ? lock_future[ecology_key] : 8
+        if (!(event_key in lock_anchor) || !(ecology_key in lock_anchor) ||
+            rows[event_key] != event_expected ||
+            rows[ecology_key] != ecology_expected ||
+            lock_split[event_key] != lock_split[ecology_key] ||
+            lock_turn[event_key] != lock_turn[ecology_key] ||
+            lock_future[event_key] != lock_future[ecology_key]) fail()
+        event_support = support[event_key] ? "true" : "false"
+        event_confirmation = confirmation[event_key] ? "true" : "false"
+        ecology_support = support[ecology_key] ? "true" : "false"
+        ecology_confirmation = confirmation[ecology_key] ? "true" : "false"
+        print pair, lock_anchor[event_key], lock_anchor[ecology_key], \
+              lock_split[event_key], lock_turn[event_key], rows[event_key], \
+              rows[ecology_key], event_support, event_confirmation, \
+              (support[event_key] ? first_support[event_key] : "na"), \
+              (confirmation[event_key] ? first_confirmation[event_key] : "na"), \
+              sprintf("%.6f", max_similarity[event_key]), \
+              sprintf("%.6f", max_margin[event_key]), ecology_support, \
+              ecology_confirmation, \
+              (support[ecology_key] ? first_support[ecology_key] : "na"), \
+              (confirmation[ecology_key] ? first_confirmation[ecology_key] : "na"), \
+              sprintf("%.6f", max_similarity[ecology_key]), \
+              sprintf("%.6f", max_margin[ecology_key]), \
+              sprintf("%.6f", max_margin[event_key] - max_margin[ecology_key])
+        emitted++
+    }
+    if (emitted != expected) fail()
+}

--- a/scripts/state_swarm_liminal_confirmation_select.awk
+++ b/scripts/state_swarm_liminal_confirmation_select.awk
@@ -1,0 +1,99 @@
+# A.92: admit only exact event/ecology pairs with life after the anchor.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function integer(value) {
+    return value ~ /^[0-9]+$/
+}
+
+BEGIN {
+    FS = OFS = "\t"
+}
+
+FILENAME == ARGV[1] {
+    if (FNR == 1) {
+        if (NF != 41 || $1 != "pair" || $2 != "event" ||
+            $6 != "event_turn" || $28 != "ecology_control" ||
+            $31 != "ecology_turn" || $41 != "ecology_reply") fail()
+        next
+    }
+    if (NF != 41 || $1 !~ /^[0-9][0-9]$/ || seen_pair[$1]++ ||
+        $2 != sprintf("%s-t%03d", $3, $6) ||
+        $3 !~ /^[ph][0-9][0-9]$/ ||
+        $4 !~ /^(primary|holdout)$/ || !integer($5) ||
+        !integer($6) || !integer($7) || !integer($8) ||
+        $9 !~ /^(home|storm|wonder|social)$/ || !integer($10) ||
+        $11 !~ /^[0-9]+([.][0-9]+)?$/ || $13 == "" || $14 == "" ||
+        $28 != sprintf("%s-t%03d", $29, $31) ||
+        $29 !~ /^[ph][0-9][0-9]$/ || $29 == $3 || !integer($30) ||
+        !integer($31) || !integer($32) || !integer($33) ||
+        $34 !~ /^(home|storm|wonder|social)$/ || !integer($35) ||
+        $36 !~ /^[0-9]+([.][0-9]+)?$/ || $40 == "" || $41 == "" ||
+        $4 != (substr($29, 1, 1) == "p" ? "primary" : "holdout") ||
+        $6 != $31 || $7 != $32 || $8 != $33 || $9 != $34 ||
+        $10 == $35 || $13 != $40) fail()
+    pair_event[$1] = $2
+    pair_ecology[$1] = $28
+    event_line[$1] = $2 OFS $3 OFS $4 OFS $5 OFS $6 OFS $7 OFS $8 OFS \
+        $9 OFS $10 OFS $13 OFS $14
+    ecology_line[$1] = $28 OFS $29 OFS $4 OFS $30 OFS $31 OFS $32 OFS \
+        $33 OFS $34 OFS $35 OFS $40 OFS $41
+    if ($6 < 96) eligible[$1] = 1
+    else if ($6 == 96) censored[$1] = 1
+    else fail()
+    pairs++
+    next
+}
+
+FILENAME == ARGV[2] {
+    if (FNR == 1) {
+        if (NF != 19 || $1 != "event" || $6 != "trigger_turn" ||
+            $16 != "state_equal" || $19 != "reply_equal") fail()
+        next
+    }
+    if (NF != 19 || seen_event_lock[$1]++ ||
+        $1 !~ /^[ph][0-9][0-9]-t[0-9][0-9][0-9]$/)
+        fail()
+    for (i = 16; i <= 19; i++) if ($i != "true") fail()
+    event_lock[$1] = 1
+    event_locks++
+    next
+}
+
+FILENAME == ARGV[3] {
+    if (FNR == 1) {
+        if (NF != 21 || $1 != "control" || $3 != "family" ||
+            $17 != "life_state_equal" || $21 != "reply_equal") fail()
+        next
+    }
+    if (NF != 21 || control_lock[$1]++ ||
+        $3 !~ /^(organism|ecology)$/) fail()
+    for (i = 17; i <= 21; i++) if ($i != "true") fail()
+    control_family[$1] = $3
+    control_locks++
+    next
+}
+
+END {
+    if (fatal) exit 2
+    if (pairs != 19 || length(eligible) != 15 || length(censored) != 4 ||
+        event_locks != 19 || control_locks != 38) fail()
+    for (i = 1; i <= 19; i++) {
+        pair = sprintf("%02d", i)
+        if (!(pair in pair_event) || !(pair_event[pair] in event_lock) ||
+            !(pair_ecology[pair] in control_lock) ||
+            control_family[pair_ecology[pair]] != "ecology") fail()
+    }
+    print "pair", "arm", "anchor", "life", "split", "base_seed", \
+          "turn", "session", "order", "texture", "run_seed", "prompt", \
+          "reply"
+    for (i = 1; i <= 19; i++) {
+        pair = sprintf("%02d", i)
+        if (!(pair in eligible)) continue
+        print pair, "event", event_line[pair]
+        print pair, "ecology", ecology_line[pair]
+    }
+}

--- a/scripts/state_swarm_liminal_confirmation_verdict.awk
+++ b/scripts/state_swarm_liminal_confirmation_verdict.awk
@@ -1,0 +1,77 @@
+# A.92: classify whether a second lived turn can selectively confirm a crossing.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function integer(value) {
+    return value ~ /^[0-9]+$/
+}
+
+function number(value) {
+    return value ~ /^-?[0-9]+([.][0-9]+)?$/
+}
+
+BEGIN {
+    FS = "\t"
+    if (!expected) expected = 15
+}
+
+NR == 1 {
+    if (NF != 20 || $1 != "pair" || $4 != "split" ||
+        $8 != "event_support" || $9 != "event_confirmation" ||
+        $14 != "ecology_support" || $15 != "ecology_confirmation" ||
+        $20 != "paired_max_margin_delta") fail()
+    next
+}
+
+{
+    if (NF != 20 || $1 !~ /^[0-9][0-9]$/ || seen[$1]++ ||
+        $4 !~ /^(primary|holdout)$/ || !integer($5) ||
+        !integer($6) || !integer($7) ||
+        $8 !~ /^(true|false)$/ || $9 !~ /^(true|false)$/ ||
+        $14 !~ /^(true|false)$/ || $15 !~ /^(true|false)$/ ||
+        !number($12) || !number($13) || !number($18) ||
+        !number($19) || !number($20)) fail()
+    event_support += $8 == "true"
+    event_confirmation += $9 == "true"
+    ecology_support += $14 == "true"
+    ecology_confirmation += $15 == "true"
+    event_only += $9 == "true" && $15 == "false"
+    ecology_only += $9 == "false" && $15 == "true"
+    if ($20 + 0 > 0) margin_wins++
+    margin_delta += $20
+    if ($9 == "true") split_confirmation[$4]++
+    split_total[$4]++
+    rows++
+}
+
+END {
+    if (fatal) exit 2
+    if (rows != expected || !split_total["primary"] ||
+        !split_total["holdout"]) fail()
+    if (event_confirmation == 0)
+        result = "no-temporal-confirmation"
+    else if (event_confirmation * 100 >= expected * 87)
+        result = "delay-without-selection"
+    else if (event_confirmation >= 4 &&
+             split_confirmation["primary"] > 0 &&
+             split_confirmation["holdout"] > 0)
+        result = "selective-temporal-confirmation"
+    else
+        result = "temporal-confirmation-underpowered"
+
+    print "eligible_pairs " rows
+    print "primary_pairs " split_total["primary"]
+    print "holdout_pairs " split_total["holdout"]
+    print "event_support " event_support
+    print "ecology_support " ecology_support
+    print "event_confirmation " event_confirmation
+    print "ecology_confirmation " ecology_confirmation
+    print "event_only_confirmation " event_only
+    print "ecology_only_confirmation " ecology_only
+    print "event_margin_wins " margin_wins
+    print "mean_paired_max_margin_delta " sprintf("%.6f", margin_delta / rows)
+    print "result " result
+}

--- a/scripts/test_state_swarm_liminal_confirmation_report.sh
+++ b/scripts/test_state_swarm_liminal_confirmation_report.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-liminal-report.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+HASH='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+ORGANS='0.1/0.2/0.3/0.4/0.5/0.6/0.7'
+
+printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turns\tpre_sha\tpost_sha\tfinal_sha\treproduced_sha\treply_equal\tstate_equal\n' > "$TMP/locks.tsv"
+lock() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t2\t%s\t%s\t%s\t%s\ttrue\ttrue\n' \
+        "$1" "$2" "$3" "$4" "$5" "$6" \
+        "$HASH" "$HASH" "$HASH" "$HASH"
+}
+lock 01 event p01-t050 p01 primary 50 >> "$TMP/locks.tsv"
+lock 01 ecology p11-t050 p11 primary 50 >> "$TMP/locks.tsv"
+lock 02 event h01-t060 h01 holdout 60 >> "$TMP/locks.tsv"
+lock 02 ecology h11-t060 h11 holdout 60 >> "$TMP/locks.tsv"
+
+printf 'pair\tarm\tanchor\tanchor_turn\tfuture_turn\trelative\ttexture\tcandidate_similarity\tstable_similarity\tmargin\tstable_nearest_id\tcandidate_nearest\tsupport\tconfirmation\tcandidate_organs\tstable_organs\tprompt\treply\n' > "$TMP/observations.tsv"
+observation() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\thome\t%s\t%s\t%s\t1\t%s\t%s\t%s\t%s\t%s\tprompt %s\treply %s\n' \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" \
+        "${10}" "${11}" "${12}" "$ORGANS" "$ORGANS" "$1" "$2"
+}
+observation 01 event p01-t050 50 51 1 0.500000 0.400000 0.100000 true true false >> "$TMP/observations.tsv"
+observation 01 event p01-t050 50 52 2 0.560000 0.460000 0.100000 true true true >> "$TMP/observations.tsv"
+observation 01 ecology p11-t050 50 51 1 0.380000 0.400000 -0.020000 false false false >> "$TMP/observations.tsv"
+observation 01 ecology p11-t050 50 52 2 0.370000 0.420000 -0.050000 false false false >> "$TMP/observations.tsv"
+observation 02 event h01-t060 60 61 1 0.430000 0.400000 0.030000 true true false >> "$TMP/observations.tsv"
+observation 02 event h01-t060 60 62 2 0.380000 0.400000 -0.020000 false false false >> "$TMP/observations.tsv"
+observation 02 ecology h11-t060 60 61 1 0.400000 0.450000 -0.050000 false false false >> "$TMP/observations.tsv"
+observation 02 ecology h11-t060 60 62 2 0.560000 0.460000 0.100000 true true true >> "$TMP/observations.tsv"
+
+awk -v expected=2 \
+    -f "$ROOT/scripts/state_swarm_liminal_confirmation_report.awk" \
+    "$TMP/locks.tsv" "$TMP/observations.tsv" > "$TMP/summary.tsv"
+awk -v expected=2 \
+    -f "$ROOT/scripts/state_swarm_liminal_confirmation_verdict.awk" \
+    "$TMP/summary.tsv" > "$TMP/verdict.txt"
+
+awk -F '\t' '
+    NR == 1 { if (NF != 20 || $1 != "pair" || $20 != "paired_max_margin_delta") exit 1; next }
+    $1 == "01" {
+        if ($8 != "true" || $9 != "true" || $10 != 1 || $11 != 2 ||
+            $13 != "0.100000" || $14 != "false" || $15 != "false" ||
+            $19 != "-0.020000" || $20 != "0.120000") exit 1
+        first++
+    }
+    $1 == "02" {
+        if ($8 != "true" || $9 != "false" || $10 != 1 || $11 != "na" ||
+            $13 != "0.030000" || $14 != "true" || $15 != "true" ||
+            $17 != 2 || $19 != "0.100000" || $20 != "-0.070000") exit 1
+        second++
+    }
+    END { if (NR != 3 || first != 1 || second != 1) exit 1 }
+' "$TMP/summary.tsv"
+grep -q '^eligible_pairs 2$' "$TMP/verdict.txt"
+grep -q '^event_support 2$' "$TMP/verdict.txt"
+grep -q '^ecology_support 1$' "$TMP/verdict.txt"
+grep -q '^event_only_confirmation 1$' "$TMP/verdict.txt"
+grep -q '^ecology_only_confirmation 1$' "$TMP/verdict.txt"
+grep -q '^mean_paired_max_margin_delta 0.025000$' "$TMP/verdict.txt"
+grep -q '^result temporal-confirmation-underpowered$' "$TMP/verdict.txt"
+
+sed '$d' "$TMP/observations.tsv" > "$TMP/truncated.tsv"
+if awk -v expected=2 \
+    -f "$ROOT/scripts/state_swarm_liminal_confirmation_report.awk" \
+    "$TMP/locks.tsv" "$TMP/truncated.tsv" >/dev/null 2>&1; then
+    printf 'liminal reporter accepted a truncated trajectory\n' >&2
+    exit 1
+fi
+
+sed '2s/true$/false/' "$TMP/locks.tsv" > "$TMP/unlocked.tsv"
+if awk -v expected=2 \
+    -f "$ROOT/scripts/state_swarm_liminal_confirmation_report.awk" \
+    "$TMP/unlocked.tsv" "$TMP/observations.tsv" >/dev/null 2>&1; then
+    printf 'liminal reporter accepted a false trajectory lock\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm liminal confirmation reporters: ok\n'

--- a/scripts/test_state_swarm_liminal_confirmation_select.sh
+++ b/scripts/test_state_swarm_liminal_confirmation_select.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-liminal-select.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+HASH='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+printf 'pair\tevent\tevent_life\tsplit\tevent_base_seed\tevent_turn\tevent_session\tevent_order\tevent_texture\tevent_run_seed\tevent_similarity\tevent_margin\tevent_prompt\tevent_reply\torganism_control\torganism_turn\torganism_session\torganism_order\torganism_texture\torganism_run_seed\torganism_similarity\torganism_margin\torganism_margin_gap\torganism_texture_match\torganism_turn_gap\torganism_prompt\torganism_reply\tecology_control\tecology_life\tecology_base_seed\tecology_turn\tecology_session\tecology_order\tecology_texture\tecology_run_seed\tecology_similarity\tecology_margin\tecology_margin_gap\tecology_seed_gap\tecology_prompt\tecology_reply\n' > "$TMP/matches.tsv"
+printf 'event\tlife\tsplit\tbase_seed\tenrollment_rank\ttrigger_turn\tsession\torder\ttexture\trun_seed\tpretrigger_sha\tdisplaced_sha\tsource_log_sha\treplay_log_sha\tnormalized_sha\tstate_equal\tlog_equal\tshape_equal\treply_equal\n' > "$TMP/event-locks.tsv"
+printf 'control\tpair\tfamily\tlife\tsplit\tbase_seed\tturn\tsession\torder\ttexture\trun_seed\tprecontrol_sha\tupdated_sha\tsource_log_sha\treplay_log_sha\tnormalized_sha\tlife_state_equal\tstate_equal\tlog_equal\tshape_equal\treply_equal\n' > "$TMP/control-locks.tsv"
+
+for i in $(seq 1 19); do
+    printf -v pair '%02d' "$i"
+    if [ "$i" -le 10 ]; then
+        printf -v event_life 'p%02d' "$i"
+        printf -v ecology_life 'p%02d' "$((i + 20))"
+        split=primary
+    else
+        printf -v event_life 'h%02d' "$((i - 10))"
+        printf -v ecology_life 'h%02d' "$((i + 10))"
+        split=holdout
+    fi
+    if [ "$i" -le 15 ]; then turn=68; else turn=96; fi
+    event="$event_life-t$(printf '%03d' "$turn")"
+    organism="$event_life-t040"
+    ecology="$ecology_life-t$(printf '%03d' "$turn")"
+    event_seed=$((200000 + i))
+    ecology_seed=$((300000 + i))
+    prompt="shared prompt $pair"
+    printf '%s\t%s\t%s\t%s\t%d\t%d\t5\t4\tsocial\t%d\t0.390\t0.010\t%s\tevent reply %s\t%s\t40\t2\t4\tstorm\t%d\t0.420\t0.020\t0.010\tfalse\t28\torganism prompt %s\torganism reply %s\t%s\t%s\t%d\t%d\t5\t4\tsocial\t%d\t0.420\t0.020\t0.010\t100000\t%s\tecology reply %s\n' \
+        "$pair" "$event" "$event_life" "$split" "$event_seed" "$turn" \
+        "$event_seed" "$prompt" "$pair" "$organism" "$event_seed" \
+        "$pair" "$pair" "$ecology" "$ecology_life" "$ecology_seed" \
+        "$turn" "$ecology_seed" "$prompt" "$pair" >> "$TMP/matches.tsv"
+    printf '%s\t%s\t%s\t%d\t1\t%d\t5\t4\tsocial\t%d\t%s\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\ttrue\n' \
+        "$event" "$event_life" "$split" "$event_seed" "$turn" \
+        "$event_seed" "$HASH" "$HASH" "$HASH" "$HASH" "$HASH" \
+        >> "$TMP/event-locks.tsv"
+    printf '%s\t%s\torganism\t%s\t%s\t%d\t40\t2\t4\tstorm\t%d\t%s\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\ttrue\ttrue\n' \
+        "$organism" "$pair" "$event_life" "$split" "$event_seed" \
+        "$event_seed" "$HASH" "$HASH" "$HASH" "$HASH" "$HASH" \
+        >> "$TMP/control-locks.tsv"
+    printf '%s\t%s\tecology\t%s\t%s\t%d\t%d\t5\t4\tsocial\t%d\t%s\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\ttrue\ttrue\n' \
+        "$ecology" "$pair" "$ecology_life" "$split" "$ecology_seed" \
+        "$turn" "$ecology_seed" "$HASH" "$HASH" "$HASH" "$HASH" \
+        "$HASH" >> "$TMP/control-locks.tsv"
+done
+
+awk -f "$ROOT/scripts/state_swarm_liminal_confirmation_select.awk" \
+    "$TMP/matches.tsv" "$TMP/event-locks.tsv" "$TMP/control-locks.tsv" \
+    > "$TMP/selection.tsv"
+
+awk -F '\t' '
+    NR == 1 { if (NF != 13 || $1 != "pair" || $2 != "arm" || $13 != "reply") exit 1; next }
+    { count[$1]++; arms[$1 SUBSEP $2]++ }
+    END {
+        if (NR != 31) exit 1
+        for (i = 1; i <= 15; i++) {
+            pair = sprintf("%02d", i)
+            if (count[pair] != 2 || arms[pair SUBSEP "event"] != 1 ||
+                arms[pair SUBSEP "ecology"] != 1) exit 1
+        }
+        for (i = 16; i <= 19; i++)
+            if (sprintf("%02d", i) in count) exit 1
+    }
+' "$TMP/selection.tsv"
+
+awk -F '\t' 'BEGIN { OFS = FS } NR == 3 { $3 = "organism" } { print }' \
+    "$TMP/control-locks.tsv" > "$TMP/bad-control-locks.tsv"
+if awk -f "$ROOT/scripts/state_swarm_liminal_confirmation_select.awk" \
+    "$TMP/matches.tsv" "$TMP/event-locks.tsv" \
+    "$TMP/bad-control-locks.tsv" >/dev/null 2>&1; then
+    printf 'liminal selector accepted an ecology lock with the wrong family\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm liminal confirmation selector: ok\n'

--- a/scripts/test_state_swarm_liminal_trajectory_fixture.sh
+++ b/scripts/test_state_swarm_liminal_trajectory_fixture.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-liminal-fixture.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+"${CC:-cc}" "$ROOT/tests/state_swarm_liminal_trajectory_fixture.c" \
+    -O2 -lm -Wall -Wextra -Wno-unused-function \
+    -o "$TMP/liminal-trajectory-fixture" -lpthread
+
+set +e
+"$TMP/liminal-trajectory-fixture" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || {
+    printf 'liminal fixture accepted a missing mode: rc=%s\n' "$rc" >&2
+    exit 1
+}
+
+printf 'state-swarm liminal trajectory fixture: ok\n'

--- a/tests/state_swarm_liminal_trajectory_fixture.c
+++ b/tests/state_swarm_liminal_trajectory_fixture.c
@@ -1,0 +1,265 @@
+#define LEO_NO_MAIN
+#include <errno.h>
+#include "../leo.c"
+
+#define LEO_LIMINAL_FROZEN_MAGIC 0x3239414cu /* "LA92" */
+
+typedef struct {
+    uint32_t magic;
+    uint32_t members;
+    uint64_t anchor_turn;
+    LeoStateWeight stable[LEO_STATE_SWARM_MAX];
+    LeoStateWeight candidate;
+} LeoLiminalFrozen;
+
+static Leo *load_leo(const char *path) {
+    Leo *leo = malloc(sizeof *leo);
+    if (!leo) return NULL;
+    leo_init(leo);
+    if (!leo_load_state(leo, path)) {
+        leo_free(leo);
+        free(leo);
+        return NULL;
+    }
+    return leo;
+}
+
+static void destroy_leo(Leo *leo) {
+    if (!leo) return;
+    leo_free(leo);
+    free(leo);
+}
+
+static int parse_u64(const char *text, uint64_t *value) {
+    char *end = NULL;
+    errno = 0;
+    unsigned long long parsed = strtoull(text, &end, 10);
+    if (errno || !end || *end) return 0;
+    *value = (uint64_t)parsed;
+    return 1;
+}
+
+static int parse_long(const char *text, long *value) {
+    char *end = NULL;
+    errno = 0;
+    long parsed = strtol(text, &end, 10);
+    if (errno || !end || *end) return 0;
+    *value = parsed;
+    return 1;
+}
+
+static int parse_float(const char *text, float *value) {
+    char *end = NULL;
+    errno = 0;
+    float parsed = strtof(text, &end);
+    if (errno || !end || *end || !isfinite(parsed)) return 0;
+    *value = parsed;
+    return 1;
+}
+
+static int parse_organs(const char *text, float organ[LEO_STATE_ORGANS]) {
+    char copy[512];
+    size_t len = strlen(text);
+    if (!len || len >= sizeof copy) return 0;
+    memcpy(copy, text, len + 1);
+    char *cursor = copy;
+    for (int i = 0; i < LEO_STATE_ORGANS; i++) {
+        char *slash = strchr(cursor, '/');
+        if (i + 1 < LEO_STATE_ORGANS) {
+            if (!slash) return 0;
+            *slash = 0;
+        } else if (slash) {
+            return 0;
+        }
+        if (!parse_float(cursor, &organ[i]) ||
+            organ[i] < 0.0f || organ[i] > 1.001f)
+            return 0;
+        if (slash) cursor = slash + 1;
+    }
+    return 1;
+}
+
+static void print_organs(const float organ[LEO_STATE_ORGANS]) {
+    for (int i = 0; i < LEO_STATE_ORGANS; i++)
+        printf("%s%.6f", i ? "/" : "", (double)organ[i]);
+}
+
+static int visible_reply_equal(const char *reply, const char *expected) {
+    size_t n = strcspn(reply, "\r\n\t");
+    return strlen(expected) == n && !memcmp(reply, expected, n);
+}
+
+static int capture_observation(
+        const char *state_path, uint64_t expected_turn, long seed,
+        const char *prompt, const char *expected_reply,
+        uint64_t expected_nearest_id, float expected_similarity,
+        const float expected_organs[LEO_STATE_ORGANS],
+        LeoStateWeight stable[LEO_STATE_SWARM_MAX],
+        LeoStateWeight *observation) {
+    srand((unsigned)seed);
+    Leo *leo = load_leo(state_path);
+    if (!leo || !leo->state_swarm ||
+        leo->state_swarm->n != LEO_STATE_SWARM_MAX) {
+        destroy_leo(leo);
+        return 0;
+    }
+    memcpy(stable, leo->state_swarm->weights,
+           sizeof(LeoStateWeight) * LEO_STATE_SWARM_MAX);
+
+    /* State swarm has no generation reader. Replaying with only this shadow
+     * organ empty captures the raw lived observation as a newborn weight. */
+    leo_state_swarm_clear(leo->state_swarm);
+    char reply[4096];
+    leo_respond(leo, prompt, reply, sizeof reply);
+    if (!visible_reply_equal(reply, expected_reply) ||
+        leo->state_swarm->n != 1 ||
+        leo->state_swarm_receipt.event != LEO_STATE_SWARM_BORN ||
+        leo->state_swarm_receipt.turn != expected_turn) {
+        destroy_leo(leo);
+        return 0;
+    }
+    *observation = leo->state_swarm->weights[0];
+
+    int best = 0;
+    float best_similarity = -1.0f;
+    float best_organs[LEO_STATE_ORGANS] = {0};
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        float organs[LEO_STATE_ORGANS];
+        float similarity = leo_state_similarity_components(
+            &stable[i], observation, organs);
+        if (similarity > best_similarity) {
+            best = i;
+            best_similarity = similarity;
+            memcpy(best_organs, organs, sizeof best_organs);
+        }
+    }
+    int exact = stable[best].id == expected_nearest_id &&
+        fabsf(best_similarity - expected_similarity) <= 0.0015f;
+    for (int i = 0; i < LEO_STATE_ORGANS; i++)
+        if (fabsf(best_organs[i] - expected_organs[i]) > 0.00002f)
+            exact = 0;
+    if (!exact) {
+        fprintf(stderr,
+                "geometry expected nearest=%llu similarity=%.6f got nearest=%llu similarity=%.6f organs=",
+                (unsigned long long)expected_nearest_id,
+                (double)expected_similarity,
+                (unsigned long long)stable[best].id,
+                (double)best_similarity);
+        for (int i = 0; i < LEO_STATE_ORGANS; i++)
+            fprintf(stderr, "%s%.6f", i ? "/" : "",
+                    (double)best_organs[i]);
+        fputc('\n', stderr);
+    }
+    destroy_leo(leo);
+    return exact;
+}
+
+static int freeze_anchor(int argc, char **argv) {
+    if (argc != 11) return 2;
+    const char *out = argv[2];
+    uint64_t turn = 0, nearest_id = 0;
+    long seed = 0;
+    float similarity = 0.0f;
+    float organs[LEO_STATE_ORGANS];
+    if (!parse_u64(argv[3], &turn) || !parse_long(argv[4], &seed) ||
+        !parse_u64(argv[8], &nearest_id) ||
+        !parse_float(argv[9], &similarity) ||
+        !parse_organs(argv[10], organs))
+        return 2;
+
+    LeoLiminalFrozen frozen;
+    memset(&frozen, 0, sizeof frozen);
+    frozen.magic = LEO_LIMINAL_FROZEN_MAGIC;
+    frozen.members = LEO_STATE_SWARM_MAX;
+    frozen.anchor_turn = turn;
+    if (!capture_observation(argv[7], turn, seed, argv[5], argv[6],
+                             nearest_id, similarity, organs, frozen.stable,
+                             &frozen.candidate)) {
+        fprintf(stderr, "anchor geometry replay mismatch: %s\n", argv[7]);
+        return 1;
+    }
+    FILE *file = fopen(out, "wb");
+    int ok = file && fwrite(&frozen, sizeof frozen, 1, file) == 1;
+    if (file) ok = fclose(file) == 0 && ok;
+    return ok ? 0 : 2;
+}
+
+static int project_future(int argc, char **argv) {
+    if (argc != 17) return 2;
+    LeoLiminalFrozen frozen;
+    FILE *file = fopen(argv[2], "rb");
+    int loaded = file && fread(&frozen, sizeof frozen, 1, file) == 1 &&
+        fgetc(file) == EOF;
+    if (file) fclose(file);
+    if (!loaded || frozen.magic != LEO_LIMINAL_FROZEN_MAGIC ||
+        frozen.members != LEO_STATE_SWARM_MAX)
+        return 2;
+
+    uint64_t anchor_turn = 0, future_turn = 0, relative = 0, nearest_id = 0;
+    long seed = 0;
+    float similarity = 0.0f;
+    float organs[LEO_STATE_ORGANS];
+    if (!parse_u64(argv[6], &anchor_turn) ||
+        !parse_u64(argv[7], &future_turn) ||
+        !parse_u64(argv[8], &relative) || !parse_long(argv[10], &seed) ||
+        !parse_u64(argv[14], &nearest_id) ||
+        !parse_float(argv[15], &similarity) ||
+        !parse_organs(argv[16], organs) || anchor_turn != frozen.anchor_turn ||
+        relative < 1 || relative > 8 || future_turn != anchor_turn + relative)
+        return 2;
+
+    LeoStateWeight current[LEO_STATE_SWARM_MAX];
+    LeoStateWeight observation;
+    if (!capture_observation(argv[13], future_turn, seed, argv[11], argv[12],
+                             nearest_id, similarity, organs, current,
+                             &observation)) {
+        fprintf(stderr, "future geometry replay mismatch: %s turn=%llu\n",
+                argv[5], (unsigned long long)future_turn);
+        return 1;
+    }
+
+    float candidate_organs[LEO_STATE_ORGANS];
+    float candidate_similarity = leo_state_similarity_components(
+        &frozen.candidate, &observation, candidate_organs);
+    int best = 0;
+    float best_similarity = -1.0f;
+    float best_organs[LEO_STATE_ORGANS] = {0};
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        float candidate[LEO_STATE_ORGANS];
+        float value = leo_state_similarity_components(
+            &frozen.stable[i], &observation, candidate);
+        if (value > best_similarity) {
+            best = i;
+            best_similarity = value;
+            memcpy(best_organs, candidate, sizeof best_organs);
+        }
+    }
+    int candidate_nearest = candidate_similarity > best_similarity + 1e-7f;
+    int support = candidate_nearest &&
+        candidate_similarity >= LEO_STATE_REPLACE_GATE;
+    int confirmation = candidate_nearest &&
+        candidate_similarity >= LEO_STATE_NOVELTY_GATE;
+    printf("%s\t%s\t%s\t%llu\t%llu\t%llu\t%s\t%.6f\t%.6f\t%.6f\t%llu\t%s\t%s\t%s\t",
+           argv[3], argv[4], argv[5], (unsigned long long)anchor_turn,
+           (unsigned long long)future_turn, (unsigned long long)relative,
+           argv[9], (double)candidate_similarity, (double)best_similarity,
+           (double)(candidate_similarity - best_similarity),
+           (unsigned long long)frozen.stable[best].id,
+           candidate_nearest ? "true" : "false",
+           support ? "true" : "false",
+           confirmation ? "true" : "false");
+    print_organs(candidate_organs);
+    putchar('\t');
+    print_organs(best_organs);
+    printf("\t%s\t%s\n", argv[11], argv[12]);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc > 1 && !strcmp(argv[1], "freeze"))
+        return freeze_anchor(argc, argv);
+    if (argc > 1 && !strcmp(argv[1], "project"))
+        return project_future(argc, argv);
+    fprintf(stderr, "usage: %s freeze|project ...\n", argv[0]);
+    return 2;
+}


### PR DESCRIPTION
## Summary

- freeze replay-locked replacement and ecology anchors as readerless liminal candidates
- replay all 30 eligible trajectories through turn 96 with normalized-log and byte-identical state locks
- measure support and confirmation over the first eight later observations
- record `temporal-confirmation-underpowered` and reject a persisted one-frame liminal slot
- harden selection, plan, replay, aggregation, and truncated-tail contracts

## Canonical result

- eligible pairs: 15 (6 primary, 9 holdout)
- event/ecology support: 4/4
- event/ecology confirmation: 3/2
- event-only/ecology-only confirmation: 1/0
- mean paired max-margin delta: -0.001699

## Verification

- `make test` (`549/549` plus all script contracts)
- 30/30 complete trajectories preserve normalized logs and final state bytes
- two aggregate-only passes preserve summary and verdict hashes
- `git diff --check`

No `leo.c`, state format, gate, sampler, routing path, generation path, or spoken token changes.