### PR TITLE
A.93: reverse liminal traces before trusting chronology

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -7736,3 +7736,56 @@ decaying liminal trace whose evidence must accumulate across more than one
 prompt texture before it can ask a stable coordinate to leave.
 
 Leo can wait before remembering. Now he needs something worth waiting with.
+
+## Phase A.93 - reversing the same footsteps (2026-08-07)
+
+A.92 showed that one frozen surprise rarely returns and does not separate a
+birth from its ecology. A.93 gives the surprise three more lived observations,
+but refuses to confuse having more material with having direction.
+
+Four observations form each trace: the anchor and the next three turns. One
+trace receives those later turns in lived order. Its ablation receives the
+same turns backwards. Both use Leo's existing state-weight update law and
+remain outside the organism. Relative turns four through eight are held back
+for judgment.
+
+The final-turn geometry censors one A.92 pair before measurement, leaving 14
+event/ecology pairs. Every one of their 28 complete futures replays cleanly to
+turn 96, with equal normalized logs and equal final state bytes.
+
+For a score turn to support the forward trace, it must prefer forward over
+both the reversed trace and all eight stable coordinates. Confirmation needs
+two such returns on different textures and one return above `0.55`.
+
+```text
+forward beats reverse       40/70 event turns, 38/70 ecology turns
+directional support          3 event hits, 3 ecology hits
+confirmed traces             0 event, 1 ecology
+paired stable-margin mean   -0.015157
+paired order-margin mean    -0.001267
+result                       no-directional-trace-confirmation
+```
+
+The event `h11-t068` almost looks alive as a trace: two support hits and one
+strong return. Both, however, arrive on the same prompt texture. Leo met the
+same kind of room twice; that is not yet evidence that he remembered walking
+through it. The sole full confirmation belongs to an ecology control.
+
+Order itself is not absent. Forward wins over reverse slightly more often than
+chance in both arms. What is absent is selective order. Repeated EMA updates
+can tilt a coordinate toward recent life, but they still compress a path into
+one coordinate. Extending the window would produce a longer compression, not
+a sequence memory.
+
+The runner seals A.92, censors before outcomes, verifies all source state
+hashes, and admits only complete replay. The reporter independently recomputes
+forward-versus-stable, reverse-versus-stable, and forward-versus-reverse
+margins, then derives every boolean from the numbers. Truncated score tails and
+false locks fail closed. Reaggregation is byte-identical.
+
+Nothing entered `leo.c` or Leo's voice. The next question moves sideways rather
+than adding more frames: his state swarm already remembers transitions and how
+they ended. A crossing may deserve memory because it changes a route or a
+consequence, not because its averaged face later resembles another face.
+
+The same footsteps contain order. A path begins when their consequences do.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls state-swarm-liminal-confirmation visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls state-swarm-liminal-confirmation state-swarm-liminal-trace visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
 
 all: leo
 
@@ -75,6 +75,9 @@ state-swarm-near-gate-controls: leo
 
 state-swarm-liminal-confirmation: leo
 	./scripts/state_swarm_liminal_confirmation_matrix.sh
+
+state-swarm-liminal-trace: leo
+	./scripts/state_swarm_liminal_trace_matrix.sh
 
 visible-branch-probe: leo
 	LEO_VISIBLE_BRANCH_POLICY=local-v1 ./scripts/adaptive_life_probe.sh scripts/visible_branch_phases.txt
@@ -244,6 +247,9 @@ test: tests/test_leo.c leo.c
 	./scripts/test_state_swarm_liminal_confirmation_select.sh
 	./scripts/test_state_swarm_liminal_confirmation_report.sh
 	./scripts/test_state_swarm_liminal_trajectory_fixture.sh
+	./scripts/test_state_swarm_liminal_trace_select.sh
+	./scripts/test_state_swarm_liminal_trace_report.sh
+	./scripts/test_state_swarm_liminal_trace_fixture.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_report.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_matrix.sh
 	./scripts/test_state_swarm_near_gate_controls_select.sh

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -1511,3 +1511,71 @@ liminal slot. The next candidate is a short decaying trace: retain several
 successive observations, require evidence to accumulate across differing
 prompts, and compare its selectivity against the same ecology controls before
 letting it displace a stable coordinate.
+
+## A.93: chronology survives weakly, but an averaged path is still a point
+
+Run the ordered-trace study:
+
+```sh
+make state-swarm-liminal-trace
+```
+
+A.93 consumes the sealed A.92 selection, plan, and complete-trajectory locks.
+The `h08-t094` pair has only two later turns and is censored before analysis:
+it cannot supply the predeclared three build turns plus five score turns. The
+fixed population is therefore 14 pairs, six primary and eight holdout.
+
+Each arm begins with its readerless anchor observation. The next three raw
+observations update a forward trace through the existing state-weight update
+law at activation one, whose vector rate is `0.18`. A reversed trace begins at
+the same anchor and consumes exactly the same three observations in reverse
+order. The two traces therefore differ only in chronology, not vocabulary,
+organ values, or sample size.
+
+Relative turns four through eight are withheld from construction. A support
+hit requires the forward trace to be strictly nearer than all eight frozen
+stable coordinates, strictly nearer than the reversed trace, and at least
+`0.40` similar to the new observation. A strong hit raises the unchanged
+threshold to `0.55`. Confirmation requires at least two support hits on two
+different prompt textures and at least one strong hit. Thus neither a build
+turn nor a single scheduled prompt recurrence can confirm its own trace.
+
+The canonical run is
+`/private/tmp/leo-state-swarm-liminal-trace-a93-r1-20260807`. All 28 arms again
+replay their full remaining life, preserve every normalized log, and finish
+with byte-identical state bodies.
+
+```text
+eligible pairs                         14  (primary 6, holdout 8)
+forward > reverse score turns          40/70 event, 38/70 ecology
+directional support hits                3 event, 3 ecology
+confirmed traces                        0 event, 1 ecology
+event-only / ecology-only               0 / 1
+mean paired max stable-margin delta    -0.015157
+mean paired max order-margin delta     -0.001267
+result                                 no-directional-trace-confirmation
+```
+
+The strongest apparent event is `h11-t068`: it has two directional support
+hits and one strong hit, but both supports occur on the same texture, so it is
+a calendar recurrence rather than declared confirmation. The only confirmed
+trace belongs to the ecology arm `p36-t068`, not to its replacement pair.
+
+Chronological order is measurable: the forward trace beats its exact reversed
+ablation on more than half the score turns. But the effect is small and nearly
+identical in event and ecology arms. Compressing a sequence through repeated
+EMA updates therefore preserves a weak direction while destroying the path
+structure required to distinguish a birth.
+
+Aggregate-only reconstruction regenerates the 14-pair plan from sealed A.92
+evidence and is byte-identical for the paired summary and verdict. Reporter
+contracts recompute all three margins, reject inconsistent booleans, require
+all five score rows, and distinguish confirmations with and without texture
+diversity.
+
+A.93 changes no C code, persisted body, threshold, sampler, routing path,
+generation path, or speech. Do not tune the EMA rate, extend the horizon, or
+persist this trace. The next read-only study should retain the path as a path:
+use the state swarm's existing transition and consequence fields to ask
+whether a crossing creates predictive or outcome structure that its matched
+ordinary update does not.

--- a/scripts/state_swarm_liminal_trace_matrix.sh
+++ b/scripts/state_swarm_liminal_trace_matrix.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# A.93: test whether ordered short experience outlives its reversed control.
+set -Eeuo pipefail
+
+trap 'rc=$?; printf "liminal trace runner failed: line=%s rc=%s command=%s\n" "$LINENO" "$rc" "$BASH_COMMAND" >&2; exit "$rc"' ERR
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CC="${CC:-cc}"
+A89="${LEO_STATE_TRACE_A89_SOURCE:-/private/tmp/leo-state-swarm-balanced-event-reservoir-a89-r1-20260807}"
+A91="${LEO_STATE_TRACE_A91_SOURCE:-/private/tmp/leo-state-swarm-near-gate-controls-a91-r2-20260807}"
+A92="${LEO_STATE_TRACE_A92_SOURCE:-/private/tmp/leo-state-swarm-liminal-confirmation-a92-r6-20260807}"
+EXPECTED="${LEO_STATE_TRACE_EXPECTED_PAIRS:-14}"
+EXPECTED_SELECTION_SHA="${LEO_STATE_TRACE_SELECTION_SHA:-394a1b43fa915fc144a67019711b311c6092e9b075c4ba62ede680d590be26ec}"
+EXPECTED_PLAN_SHA="${LEO_STATE_TRACE_PLAN_SHA:-9b0434bfa9bcc4c5cb6051cf7a6133f3fe0f51add036b5273721ece327e5ca2a}"
+EXPECTED_LOCK_SHA="${LEO_STATE_TRACE_LOCK_SHA:-e60d20854dda2f352a21014bb87b72959895fecd95d5953061afc13cd0409197}"
+EXPECTED_WRITER_SHA="${LEO_STATE_TRACE_WRITER_SHA:-10bf4251848f4edaec4a34d66d3d811afff187df9f10aeb71ff761a342c0e833}"
+AGGREGATE_ONLY="${LEO_STATE_TRACE_AGGREGATE_ONLY:-0}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-state-swarm-liminal-trace-$STAMP}"
+
+case "$EXPECTED" in
+    ''|*[!0-9]*|0) printf 'invalid trace pair count: %s\n' "$EXPECTED" >&2; exit 2 ;;
+esac
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+seal() {
+    local path="$1" expected="$2" label="$3"
+    [ -s "$path" ] && [ "$(sha256_file "$path")" = "$expected" ] || {
+        printf '%s is not the sealed source: %s\n' "$label" "$path" >&2
+        exit 2
+    }
+}
+
+A92_SELECTION="$A92/selection.tsv"
+A92_PLAN="$A92/plan.tsv"
+A92_LOCKS="$A92/trajectory-locks.tsv"
+WRITER_RECEIPTS="$A89/writer-receipts.tsv"
+seal "$A92_SELECTION" "$EXPECTED_SELECTION_SHA" "A.92 selection"
+seal "$A92_PLAN" "$EXPECTED_PLAN_SHA" "A.92 anchor plan"
+seal "$A92_LOCKS" "$EXPECTED_LOCK_SHA" "A.92 trajectory locks"
+seal "$WRITER_RECEIPTS" "$EXPECTED_WRITER_SHA" "A.89 writer receipts"
+
+PLAN="$OUT/plan.tsv"
+LOCKS="$OUT/trajectory-locks.tsv"
+SCORES="$OUT/scores.tsv"
+PAIR_SUMMARY="$OUT/pair-summary.tsv"
+VERDICT="$OUT/verdict.txt"
+
+select_plan() {
+    awk -f "$ROOT/scripts/state_swarm_liminal_trace_select.awk" \
+        "$A92_SELECTION" "$A92_PLAN" "$A92_LOCKS"
+}
+
+if [ "$AGGREGATE_ONLY" = 1 ]; then
+    [ -s "$PLAN" ] && [ -s "$LOCKS" ] && [ -s "$SCORES" ] || {
+        printf 'incomplete liminal trace cannot be aggregated: %s\n' "$OUT" >&2
+        exit 2
+    }
+    plan_check="$(mktemp "${TMPDIR:-/tmp}/leo-liminal-trace-plan.XXXXXX")"
+    select_plan > "$plan_check"
+    cmp -s "$PLAN" "$plan_check" || {
+        rm -f "$plan_check"
+        printf 'liminal trace plan no longer matches A.92: %s\n' "$PLAN" >&2
+        exit 2
+    }
+    rm -f "$plan_check"
+else
+    [ ! -e "$OUT" ] || {
+        printf 'output path already exists: %s\n' "$OUT" >&2
+        exit 2
+    }
+    mkdir -p "$OUT/trajectories"
+    select_plan > "$PLAN"
+fi
+
+awk -F '\t' -v expected="$EXPECTED" '
+    NR == 1 {
+        if (NF != 19 || $1 != "pair" || $2 != "arm" ||
+            $7 != "turn" || $14 != "pre_state" || $19 != "final_sha")
+            exit 1
+        next
+    }
+    {
+        key = $1 SUBSEP $2
+        if (NF != 19 || $1 !~ /^[0-9][0-9]$/ ||
+            $2 !~ /^(event|ecology)$/ || seen[key]++ ||
+            $4 !~ /^[ph][0-9][0-9]$/ || $5 !~ /^(primary|holdout)$/ ||
+            $7 !~ /^[0-9]+$/ || $7 > 88 ||
+            $10 !~ /^(home|storm|wonder|social)$/) exit 1
+        for (i = 17; i <= 19; i++)
+            if (length($i) != 64 || $i !~ /^[0-9a-f]+$/) exit 1
+        rows++
+    }
+    END { if (rows != expected * 2) exit 1 }
+' "$PLAN" || {
+    printf 'invalid A.93 plan: %s\n' "$PLAN" >&2
+    exit 2
+}
+
+while IFS=$'\t' read -r pair arm anchor life split base_seed turn session \
+    order texture run_seed prompt reply pre_state post_state final_state \
+    pre_sha post_sha final_sha; do
+    [ "$(sha256_file "$pre_state")" = "$pre_sha" ] &&
+        [ "$(sha256_file "$post_state")" = "$post_sha" ] &&
+        [ "$(sha256_file "$final_state")" = "$final_sha" ] || {
+        printf 'A.93 anchor package changed: %s %s\n' "$arm" "$anchor" >&2
+        exit 2
+    }
+done < <(tail -n +2 "$PLAN")
+
+if [ "${LEO_STATE_TRACE_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+normalize_log() {
+    sed -E \
+        -e 's|^\[leo\] loaded state from .*$|[leo] loaded state from BODY|' \
+        -e 's|^\[leo\] saved state to .* \(step=|[leo] saved state to BODY (step=|' \
+        "$1"
+}
+
+if [ "$AGGREGATE_ONLY" != 1 ]; then
+    make -C "$ROOT" leo >/dev/null
+    FIXTURE="$OUT/liminal-trace-fixture"
+    "$CC" "$ROOT/tests/state_swarm_liminal_trace_fixture.c" \
+        -O2 -lm -Wall -Wextra -Wno-unused-function -o "$FIXTURE" -lpthread
+    printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turns\tbuild_turns\tscore_turns\tpre_sha\tpost_sha\tfinal_sha\treproduced_sha\tlog_equal\tstate_equal\tgeometry_equal\n' > "$LOCKS"
+    printf 'pair\tarm\tanchor\tanchor_turn\tfuture_turn\trelative\ttexture\tforward_similarity\treverse_similarity\tstable_similarity\tstable_nearest_id\tforward_stable_margin\treverse_stable_margin\torder_margin\tdirectional_nearest\tsupport\tstrong\tforward_organs\treverse_organs\tstable_organs\tprompt\treply\n' > "$SCORES"
+    while IFS=$'\t' read -r pair arm anchor life split base_seed turn session \
+        order texture run_seed prompt reply pre_state post_state final_state \
+        pre_sha post_sha final_sha; do
+        trajectory="$OUT/trajectories/$pair-$arm-$anchor"
+        mkdir -p "$trajectory"
+        future="$trajectory/future.tsv"
+        work_state="$trajectory/work.state"
+        trace="$trajectory/trace.bin"
+        if [ "$arm" = event ]; then
+            anchor_log="$A89/candidates/$life/events/$anchor/trigger.log"
+        else
+            anchor_log="$A91/controls/$anchor/source.log"
+        fi
+        anchor_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$anchor_log")"
+        IFS=$'\t' read -r observed_turn observed_event observed_new \
+            observed_similarity observed_members observed_displaced \
+            observed_nearest observed_nearest_organs observed_removed_organs \
+            observed_organs <<< "$anchor_shape"
+        [ "$observed_turn" -eq "$turn" ] && [ "$observed_nearest" -gt 0 ] || {
+            printf 'A.93 anchor geometry mismatch: %s %s\n' "$arm" "$anchor" >&2
+            exit 2
+        }
+        "$FIXTURE" start "$trace" "$turn" "$run_seed" "$prompt" "$reply" \
+            "$pre_state" "$observed_nearest" "$observed_similarity" \
+            "$observed_nearest_organs"
+        cp "$post_state" "$work_state"
+        printf 'relative\tturn\tsession\torder\ttexture\trun_seed\tprompt\treply\n' > "$future"
+        awk -F '\t' -v life="$life" -v anchor="$turn" '
+            NR == 1 {
+                if (NF != 34 || $1 != "life" || $5 != "session" ||
+                    $8 != "run_seed" || $9 != "turn" ||
+                    $33 != "prompt" || $34 != "reply") exit 2
+                next
+            }
+            $1 == life && $9 > anchor {
+                print ($9 - anchor) "\t" $9 "\t" $5 "\t" $6 "\t" $7 \
+                      "\t" $8 "\t" $33 "\t" $34
+                rows++
+            }
+            END { if (rows != 96 - anchor) exit 2 }
+        ' "$WRITER_RECEIPTS" >> "$future"
+        while IFS=$'\t' read -r relative future_turn future_session \
+            future_order future_texture future_seed future_prompt \
+            future_reply; do
+            printf -v padded '%02d' "$future_order"
+            source_log="$A89/candidates/$life/writer-logs/s${future_session}-${padded}-${future_texture}.log"
+            [ -s "$source_log" ] || {
+                printf 'missing A.93 source log: %s turn=%s\n' "$anchor" "$future_turn" >&2
+                exit 2
+            }
+            future_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$source_log")"
+            IFS=$'\t' read -r shape_turn shape_event shape_new \
+                shape_similarity shape_members shape_displaced shape_nearest \
+                shape_nearest_organs shape_removed_organs shape_organs \
+                <<< "$future_shape"
+            [ "$shape_turn" -eq "$future_turn" ] && [ "$shape_nearest" -gt 0 ] || {
+                printf 'A.93 future geometry mismatch: %s turn=%s\n' "$anchor" "$future_turn" >&2
+                exit 2
+            }
+            if [ "$relative" -le 3 ]; then
+                "$FIXTURE" absorb "$trace" "$future_turn" "$future_seed" \
+                    "$future_prompt" "$future_reply" "$work_state" \
+                    "$shape_nearest" "$shape_similarity" "$shape_nearest_organs"
+            elif [ "$relative" -le 8 ]; then
+                "$FIXTURE" score "$trace" "$pair" "$arm" "$anchor" \
+                    "$turn" "$future_turn" "$relative" "$future_texture" \
+                    "$future_seed" "$future_prompt" "$future_reply" \
+                    "$work_state" "$shape_nearest" "$shape_similarity" \
+                    "$shape_nearest_organs" >> "$SCORES"
+            fi
+            generated_log="$trajectory/t${future_turn}.log"
+            source_normalized="$trajectory/t${future_turn}.source.normalized"
+            generated_normalized="$trajectory/t${future_turn}.generated.normalized"
+            "$ROOT/leo" --corpus "$ROOT/leo.txt" --load "$work_state" \
+                --seed "$future_seed" --respond "$future_prompt" \
+                --debug-field --save "$work_state" > "$generated_log" 2>&1
+            normalize_log "$source_log" > "$source_normalized"
+            normalize_log "$generated_log" > "$generated_normalized"
+            cmp -s "$source_normalized" "$generated_normalized" || {
+                printf 'A.93 full-log replay mismatch: %s turn=%s\n' "$anchor" "$future_turn" >&2
+                exit 1
+            }
+        done < <(tail -n +2 "$future")
+        cmp -s "$final_state" "$work_state"
+        reproduced_sha="$(sha256_file "$work_state")"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t3\t5\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$turn" \
+            "$((96 - turn))" "$pre_sha" "$post_sha" "$final_sha" \
+            "$reproduced_sha" >> "$LOCKS"
+        rm -f "$work_state" "$trace"
+    done < <(tail -n +2 "$PLAN")
+    rm -f "$FIXTURE"
+fi
+
+awk -v expected="$EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_liminal_trace_report.awk" \
+    "$LOCKS" "$SCORES" > "$PAIR_SUMMARY"
+awk -v expected="$EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_liminal_trace_verdict.awk" \
+    "$PAIR_SUMMARY" > "$VERDICT"
+
+cat "$LOCKS"
+printf '\n'
+cat "$PAIR_SUMMARY"
+printf '\n'
+cat "$VERDICT"
+printf '\nsource-a92: %s\nrun: %s\n' "$A92" "$OUT"

--- a/scripts/state_swarm_liminal_trace_report.awk
+++ b/scripts/state_swarm_liminal_trace_report.awk
@@ -1,0 +1,142 @@
+# A.93: reduce ordered and reversed short traces to paired confirmations.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function integer(value) {
+    return value ~ /^[0-9]+$/
+}
+
+function number(value) {
+    return value ~ /^-?[0-9]+([.][0-9]+)?$/
+}
+
+function abs(value) {
+    return value < 0 ? -value : value
+}
+
+BEGIN {
+    FS = OFS = "\t"
+    if (!expected) expected = 14
+}
+
+FILENAME == ARGV[1] {
+    if (FNR == 1) {
+        if (NF != 16 || $1 != "pair" || $2 != "arm" ||
+            $8 != "build_turns" || $9 != "score_turns" ||
+            $14 != "log_equal" || $16 != "geometry_equal") fail()
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 16 || $1 !~ /^[0-9][0-9]$/ ||
+        $2 !~ /^(event|ecology)$/ || seen_lock[key]++ ||
+        $3 == "" || $4 !~ /^[ph][0-9][0-9]$/ ||
+        $5 !~ /^(primary|holdout)$/ || !integer($6) || !integer($7) ||
+        $7 < 8 || $8 != 3 || $9 != 5 || $6 + $7 != 96)
+        fail()
+    for (i = 10; i <= 13; i++)
+        if (length($i) != 64 || $i !~ /^[0-9a-f]+$/) fail()
+    for (i = 14; i <= 16; i++) if ($i != "true") fail()
+    lock_anchor[key] = $3
+    lock_split[key] = $5
+    lock_turn[key] = $6 + 0
+    lock_future[key] = $7 + 0
+    locks++
+    next
+}
+
+FNR == 1 {
+    if (NF != 22 || $1 != "pair" || $2 != "arm" ||
+        $8 != "forward_similarity" || $9 != "reverse_similarity" ||
+        $12 != "forward_stable_margin" || $14 != "order_margin" ||
+        $16 != "support" || $17 != "strong" || $22 != "reply") fail()
+    next
+}
+
+{
+    key = $1 SUBSEP $2
+    if (NF != 22 || !(key in lock_anchor) || $3 != lock_anchor[key] ||
+        !integer($4) || !integer($5) || !integer($6) ||
+        $4 + 0 != lock_turn[key] || $5 + 0 != $4 + $6 ||
+        $6 < 4 || $6 > 8 || $6 > lock_future[key] ||
+        $7 !~ /^(home|storm|wonder|social)$/ ||
+        !number($8) || !number($9) || !number($10) || !integer($11) ||
+        !number($12) || !number($13) || !number($14) ||
+        $15 !~ /^(true|false)$/ || $16 !~ /^(true|false)$/ ||
+        $17 !~ /^(true|false)$/ || $18 == "" || $19 == "" ||
+        $20 == "" || $21 == "" || $22 == "" ||
+        $8 < 0 || $8 > 1 || $9 < 0 || $9 > 1 || $10 < 0 || $10 > 1 ||
+        abs(($8 - $10) - $12) > 0.000002 ||
+        abs(($9 - $10) - $13) > 0.000002 ||
+        abs(($8 - $9) - $14) > 0.000002 ||
+        (($12 > 0.0000001 && $14 > 0.0000001) ? "true" : "false") != $15 ||
+        (($15 == "true" && $8 >= 0.40) ? "true" : "false") != $16 ||
+        (($15 == "true" && $8 >= 0.55) ? "true" : "false") != $17)
+        fail()
+    if (++rows[key] != $6 - 3) fail()
+    if ($14 > 0.0000001) order_wins[key]++
+    if ($16 == "true") {
+        support[key]++
+        support_texture[key SUBSEP $7] = 1
+    }
+    if ($17 == "true") strong[key]++
+    if (!(key in max_stable_margin) || $12 + 0 > max_stable_margin[key])
+        max_stable_margin[key] = $12 + 0
+    if (!(key in max_order_margin) || $14 + 0 > max_order_margin[key])
+        max_order_margin[key] = $14 + 0
+    next
+}
+
+END {
+    if (fatal) exit 2
+    if (locks != expected * 2) fail()
+    print "pair", "event_anchor", "ecology_anchor", "split", "anchor_turn", \
+          "event_support_hits", "event_strong_hits", \
+          "event_support_textures", "event_order_wins", \
+          "event_confirmation", "event_max_stable_margin", \
+          "event_max_order_margin", "ecology_support_hits", \
+          "ecology_strong_hits", "ecology_support_textures", \
+          "ecology_order_wins", "ecology_confirmation", \
+          "ecology_max_stable_margin", "ecology_max_order_margin", \
+          "paired_max_stable_margin_delta", "paired_max_order_margin_delta"
+    emitted = 0
+    for (i = 1; i <= 99; i++) {
+        pair = sprintf("%02d", i)
+        event = pair SUBSEP "event"
+        ecology = pair SUBSEP "ecology"
+        if (!(event in lock_anchor) && !(ecology in lock_anchor)) continue
+        if (!(event in lock_anchor) || !(ecology in lock_anchor) ||
+            rows[event] != 5 || rows[ecology] != 5 ||
+            lock_split[event] != lock_split[ecology] ||
+            lock_turn[event] != lock_turn[ecology]) fail()
+        event_textures = ecology_textures = 0
+        for (key in support_texture) {
+            split(key, part, SUBSEP)
+            if (part[1] == pair && part[2] == "event") event_textures++
+            if (part[1] == pair && part[2] == "ecology") ecology_textures++
+        }
+        event_confirmation = support[event] >= 2 && strong[event] >= 1 &&
+            event_textures >= 2
+        ecology_confirmation = support[ecology] >= 2 && strong[ecology] >= 1 &&
+            ecology_textures >= 2
+        print pair, lock_anchor[event], lock_anchor[ecology], \
+              lock_split[event], lock_turn[event], support[event] + 0, \
+              strong[event] + 0, event_textures, order_wins[event] + 0, \
+              (event_confirmation ? "true" : "false"), \
+              sprintf("%.6f", max_stable_margin[event]), \
+              sprintf("%.6f", max_order_margin[event]), \
+              support[ecology] + 0, strong[ecology] + 0, ecology_textures, \
+              order_wins[ecology] + 0, \
+              (ecology_confirmation ? "true" : "false"), \
+              sprintf("%.6f", max_stable_margin[ecology]), \
+              sprintf("%.6f", max_order_margin[ecology]), \
+              sprintf("%.6f", max_stable_margin[event] - \
+                      max_stable_margin[ecology]), \
+              sprintf("%.6f", max_order_margin[event] - \
+                      max_order_margin[ecology])
+        emitted++
+    }
+    if (emitted != expected) fail()
+}

--- a/scripts/state_swarm_liminal_trace_select.awk
+++ b/scripts/state_swarm_liminal_trace_select.awk
@@ -1,0 +1,83 @@
+# A.93: admit only A.92 pairs with three build and five score turns.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function integer(value) {
+    return value ~ /^[0-9]+$/
+}
+
+BEGIN {
+    FS = OFS = "\t"
+}
+
+FILENAME == ARGV[1] {
+    if (FNR == 1) {
+        if (NF != 13 || $1 != "pair" || $2 != "arm" || $13 != "reply") fail()
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 13 || $1 !~ /^[0-9][0-9]$/ ||
+        $2 !~ /^(event|ecology)$/ || selected[key]++) fail()
+    for (i = 1; i <= 13; i++) selected_field[key, i] = $i
+    selections++
+    next
+}
+
+FILENAME == ARGV[2] {
+    if (FNR == 1) {
+        if (NF != 19 || $1 != "pair" || $2 != "arm" ||
+            $14 != "pre_state" || $19 != "final_sha") fail()
+        header = $0
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 19 || !(key in selected) || planned[key]++) fail()
+    for (i = 1; i <= 13; i++)
+        if ($i != selected_field[key, i]) fail()
+    plan[key] = $0
+    plans++
+    next
+}
+
+FILENAME == ARGV[3] {
+    if (FNR == 1) {
+        if (NF != 13 || $1 != "pair" || $2 != "arm" ||
+            $6 != "anchor_turn" || $7 != "future_turns" ||
+            $12 != "reply_equal" || $13 != "state_equal") fail()
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 13 || !(key in selected) || locked[key]++ ||
+        !integer($6) || !integer($7) || $6 + $7 != 96 ||
+        $12 != "true" || $13 != "true") fail()
+    future[key] = $7 + 0
+    locks++
+    next
+}
+
+END {
+    if (fatal) exit 2
+    if (selections != 30 || plans != 30 || locks != 30) fail()
+    print header
+    for (i = 1; i <= 99; i++) {
+        pair = sprintf("%02d", i)
+        event = pair SUBSEP "event"
+        ecology = pair SUBSEP "ecology"
+        if (!(event in selected) && !(ecology in selected)) continue
+        if (!(event in planned) || !(ecology in planned) ||
+            !(event in locked) || !(ecology in locked) ||
+            future[event] != future[ecology]) fail()
+        pairs++
+        if (future[event] < 8) {
+            censored++
+            continue
+        }
+        print plan[event]
+        print plan[ecology]
+        eligible++
+    }
+    if (pairs != 15 || eligible != 14 || censored != 1) fail()
+}

--- a/scripts/state_swarm_liminal_trace_verdict.awk
+++ b/scripts/state_swarm_liminal_trace_verdict.awk
@@ -1,0 +1,88 @@
+# A.93: decide whether chronological trace carries selective evidence.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function integer(value) {
+    return value ~ /^[0-9]+$/
+}
+
+function number(value) {
+    return value ~ /^-?[0-9]+([.][0-9]+)?$/
+}
+
+BEGIN {
+    FS = "\t"
+    if (!expected) expected = 14
+}
+
+NR == 1 {
+    if (NF != 21 || $1 != "pair" || $4 != "split" ||
+        $10 != "event_confirmation" || $17 != "ecology_confirmation" ||
+        $20 != "paired_max_stable_margin_delta" ||
+        $21 != "paired_max_order_margin_delta") fail()
+    next
+}
+
+{
+    if (NF != 21 || $1 !~ /^[0-9][0-9]$/ || seen[$1]++ ||
+        $4 !~ /^(primary|holdout)$/ || !integer($5) ||
+        !integer($6) || !integer($7) || !integer($8) || !integer($9) ||
+        $10 !~ /^(true|false)$/ || !number($11) || !number($12) ||
+        !integer($13) || !integer($14) || !integer($15) || !integer($16) ||
+        $17 !~ /^(true|false)$/ || !number($18) || !number($19) ||
+        !number($20) || !number($21)) fail()
+    event_confirmation += $10 == "true"
+    ecology_confirmation += $17 == "true"
+    event_only += $10 == "true" && $17 == "false"
+    ecology_only += $10 == "false" && $17 == "true"
+    event_support += $6
+    ecology_support += $13
+    event_order_wins += $9
+    ecology_order_wins += $16
+    stable_delta += $20
+    order_delta += $21
+    if ($10 == "true") split_confirmation[$4]++
+    split_total[$4]++
+    rows++
+}
+
+END {
+    if (fatal) exit 2
+    if (rows != expected || !split_total["primary"] ||
+        !split_total["holdout"]) fail()
+    mean_stable = stable_delta / rows
+    mean_order = order_delta / rows
+    if (event_confirmation == 0)
+        result = "no-directional-trace-confirmation"
+    else if (event_confirmation * 100 >= expected * 87 &&
+             ecology_confirmation * 100 >= expected * 87)
+        result = "trace-delay-without-selection"
+    else if (event_confirmation >= 4 &&
+             split_confirmation["primary"] > 0 &&
+             split_confirmation["holdout"] > 0 &&
+             event_only >= ecology_only + 2 &&
+             mean_stable >= 0.01 && mean_order >= 0.01)
+        result = "selective-directional-trace"
+    else if (event_confirmation >= 4)
+        result = "directional-trace-not-distinguished"
+    else
+        result = "directional-trace-underpowered"
+
+    print "eligible_pairs " rows
+    print "primary_pairs " split_total["primary"]
+    print "holdout_pairs " split_total["holdout"]
+    print "event_support_hits " event_support
+    print "ecology_support_hits " ecology_support
+    print "event_order_wins " event_order_wins
+    print "ecology_order_wins " ecology_order_wins
+    print "event_confirmation " event_confirmation
+    print "ecology_confirmation " ecology_confirmation
+    print "event_only_confirmation " event_only
+    print "ecology_only_confirmation " ecology_only
+    print "mean_paired_max_stable_margin_delta " sprintf("%.6f", mean_stable)
+    print "mean_paired_max_order_margin_delta " sprintf("%.6f", mean_order)
+    print "result " result
+}

--- a/scripts/test_state_swarm_liminal_trace_fixture.sh
+++ b/scripts/test_state_swarm_liminal_trace_fixture.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-liminal-trace-fixture.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+"${CC:-cc}" "$ROOT/tests/state_swarm_liminal_trace_fixture.c" \
+    -O2 -lm -Wall -Wextra -Wno-unused-function \
+    -o "$TMP/liminal-trace-fixture" -lpthread
+set +e
+"$TMP/liminal-trace-fixture" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || {
+    printf 'liminal trace fixture accepted a missing mode: rc=%s\n' "$rc" >&2
+    exit 1
+}
+
+printf 'state-swarm liminal trace fixture: ok\n'

--- a/scripts/test_state_swarm_liminal_trace_report.sh
+++ b/scripts/test_state_swarm_liminal_trace_report.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-liminal-trace-report.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+HASH='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+ORGANS='0.1/0.2/0.3/0.4/0.5/0.6/0.7'
+printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turns\tbuild_turns\tscore_turns\tpre_sha\tpost_sha\tfinal_sha\treproduced_sha\tlog_equal\tstate_equal\tgeometry_equal\n' > "$TMP/locks.tsv"
+lock() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t3\t5\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\n' \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$((96 - $6))" \
+        "$HASH" "$HASH" "$HASH" "$HASH"
+}
+lock 01 event p01-t050 p01 primary 50 >> "$TMP/locks.tsv"
+lock 01 ecology p11-t050 p11 primary 50 >> "$TMP/locks.tsv"
+lock 02 event h01-t060 h01 holdout 60 >> "$TMP/locks.tsv"
+lock 02 ecology h11-t060 h11 holdout 60 >> "$TMP/locks.tsv"
+
+printf 'pair\tarm\tanchor\tanchor_turn\tfuture_turn\trelative\ttexture\tforward_similarity\treverse_similarity\tstable_similarity\tstable_nearest_id\tforward_stable_margin\treverse_stable_margin\torder_margin\tdirectional_nearest\tsupport\tstrong\tforward_organs\treverse_organs\tstable_organs\tprompt\treply\n' > "$TMP/scores.tsv"
+score() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t1\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\tprompt %s\treply %s\n' \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" \
+        "${10}" "${11}" "${12}" "${13}" "${14}" "${15}" "${16}" \
+        "$ORGANS" "$ORGANS" "$ORGANS" "$1" "$2"
+}
+emit_arm() {
+    local pair="$1" arm="$2" anchor="$3" turn="$4" confirm="$5"
+    if [ "$confirm" = true ]; then
+        score "$pair" "$arm" "$anchor" "$turn" "$((turn + 4))" 4 home 0.560000 0.500000 0.450000 0.110000 0.050000 0.060000 true true true
+        score "$pair" "$arm" "$anchor" "$turn" "$((turn + 5))" 5 storm 0.500000 0.450000 0.440000 0.060000 0.010000 0.050000 true true false
+    else
+        score "$pair" "$arm" "$anchor" "$turn" "$((turn + 4))" 4 home 0.460000 0.470000 0.450000 0.010000 0.020000 -0.010000 false false false
+        score "$pair" "$arm" "$anchor" "$turn" "$((turn + 5))" 5 storm 0.420000 0.410000 0.440000 -0.020000 -0.030000 0.010000 false false false
+    fi
+    score "$pair" "$arm" "$anchor" "$turn" "$((turn + 6))" 6 wonder 0.390000 0.380000 0.430000 -0.040000 -0.050000 0.010000 false false false
+    score "$pair" "$arm" "$anchor" "$turn" "$((turn + 7))" 7 social 0.400000 0.410000 0.450000 -0.050000 -0.040000 -0.010000 false false false
+    score "$pair" "$arm" "$anchor" "$turn" "$((turn + 8))" 8 home 0.410000 0.400000 0.430000 -0.020000 -0.030000 0.010000 false false false
+}
+emit_arm 01 event p01-t050 50 true >> "$TMP/scores.tsv"
+emit_arm 01 ecology p11-t050 50 false >> "$TMP/scores.tsv"
+emit_arm 02 event h01-t060 60 false >> "$TMP/scores.tsv"
+emit_arm 02 ecology h11-t060 60 true >> "$TMP/scores.tsv"
+
+awk -v expected=2 -f "$ROOT/scripts/state_swarm_liminal_trace_report.awk" \
+    "$TMP/locks.tsv" "$TMP/scores.tsv" > "$TMP/summary.tsv"
+awk -v expected=2 -f "$ROOT/scripts/state_swarm_liminal_trace_verdict.awk" \
+    "$TMP/summary.tsv" > "$TMP/verdict.txt"
+awk -F '\t' '
+    NR == 1 { if (NF != 21 || $10 != "event_confirmation" || $17 != "ecology_confirmation") exit 1; next }
+    $1 == "01" { if ($10 != "true" || $17 != "false") exit 1; first++ }
+    $1 == "02" { if ($10 != "false" || $17 != "true") exit 1; second++ }
+    END { if (NR != 3 || first != 1 || second != 1) exit 1 }
+' "$TMP/summary.tsv"
+grep -q '^event_confirmation 1$' "$TMP/verdict.txt"
+grep -q '^ecology_confirmation 1$' "$TMP/verdict.txt"
+grep -q '^event_only_confirmation 1$' "$TMP/verdict.txt"
+grep -q '^ecology_only_confirmation 1$' "$TMP/verdict.txt"
+grep -q '^result directional-trace-underpowered$' "$TMP/verdict.txt"
+
+sed '$d' "$TMP/scores.tsv" > "$TMP/truncated.tsv"
+if awk -v expected=2 -f "$ROOT/scripts/state_swarm_liminal_trace_report.awk" \
+    "$TMP/locks.tsv" "$TMP/truncated.tsv" >/dev/null 2>&1; then
+    printf 'liminal trace reporter accepted a truncated score tail\n' >&2
+    exit 1
+fi
+
+awk -F '\t' 'BEGIN { OFS=FS } NR == 2 { $14 = "0.070000" } { print }' \
+    "$TMP/scores.tsv" > "$TMP/false-margin.tsv"
+if awk -v expected=2 -f "$ROOT/scripts/state_swarm_liminal_trace_report.awk" \
+    "$TMP/locks.tsv" "$TMP/false-margin.tsv" >/dev/null 2>&1; then
+    printf 'liminal trace reporter accepted a false order margin\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm liminal trace reporters: ok\n'

--- a/scripts/test_state_swarm_liminal_trace_select.sh
+++ b/scripts/test_state_swarm_liminal_trace_select.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-liminal-trace-select.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+HASH='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+printf 'pair\tarm\tanchor\tlife\tsplit\tbase_seed\tturn\tsession\torder\ttexture\trun_seed\tprompt\treply\n' > "$TMP/selection.tsv"
+printf 'pair\tarm\tanchor\tlife\tsplit\tbase_seed\tturn\tsession\torder\ttexture\trun_seed\tprompt\treply\tpre_state\tpost_state\tfinal_state\tpre_sha\tpost_sha\tfinal_sha\n' > "$TMP/plan.tsv"
+printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turns\tpre_sha\tpost_sha\tfinal_sha\treproduced_sha\treply_equal\tstate_equal\n' > "$TMP/locks.tsv"
+
+for i in $(seq 1 15); do
+    printf -v pair '%02d' "$i"
+    if [ "$i" -le 7 ]; then prefix=p; split=primary; else prefix=h; split=holdout; fi
+    turn=68
+    if [ "$i" -eq 15 ]; then turn=94; fi
+    future=$((96 - turn))
+    for arm in event ecology; do
+        if [ "$arm" = event ]; then offset=0; else offset=30; fi
+        n=$((i + offset))
+        printf -v life '%s%02d' "$prefix" "$n"
+        printf -v anchor '%s-t%03d' "$life" "$turn"
+        seed=$((100000 + n))
+        printf '%s\t%s\t%s\t%s\t%s\t%d\t%d\t5\t4\tsocial\t%d\tprompt %s\treply %s\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$seed" "$turn" \
+            "$((seed + 504))" "$pair" "$arm" >> "$TMP/selection.tsv"
+        printf '%s\t%s\t%s\t%s\t%s\t%d\t%d\t5\t4\tsocial\t%d\tprompt %s\treply %s\t/pre/%s\t/post/%s\t/final/%s\t%s\t%s\t%s\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$seed" "$turn" \
+            "$((seed + 504))" "$pair" "$arm" "$anchor" "$anchor" "$life" \
+            "$HASH" "$HASH" "$HASH" >> "$TMP/plan.tsv"
+        printf '%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\t%s\t%s\ttrue\ttrue\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$turn" "$future" \
+            "$HASH" "$HASH" "$HASH" "$HASH" >> "$TMP/locks.tsv"
+    done
+done
+
+awk -f "$ROOT/scripts/state_swarm_liminal_trace_select.awk" \
+    "$TMP/selection.tsv" "$TMP/plan.tsv" "$TMP/locks.tsv" \
+    > "$TMP/trace-plan.tsv"
+awk -F '\t' '
+    NR == 1 { if (NF != 19 || $1 != "pair" || $19 != "final_sha") exit 1; next }
+    { pairs[$1]++; arms[$1 SUBSEP $2]++ }
+    END {
+        if (NR != 29 || length(pairs) != 14) exit 1
+        for (i = 1; i <= 14; i++) {
+            p = sprintf("%02d", i)
+            if (pairs[p] != 2 || arms[p SUBSEP "event"] != 1 ||
+                arms[p SUBSEP "ecology"] != 1) exit 1
+        }
+        if ("15" in pairs) exit 1
+    }
+' "$TMP/trace-plan.tsv"
+
+sed '2s/true$/false/' "$TMP/locks.tsv" > "$TMP/unlocked.tsv"
+if awk -f "$ROOT/scripts/state_swarm_liminal_trace_select.awk" \
+    "$TMP/selection.tsv" "$TMP/plan.tsv" "$TMP/unlocked.tsv" \
+    >/dev/null 2>&1; then
+    printf 'liminal trace selector accepted a false A.92 lock\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm liminal trace selector: ok\n'

--- a/tests/state_swarm_liminal_trace_fixture.c
+++ b/tests/state_swarm_liminal_trace_fixture.c
@@ -1,0 +1,191 @@
+#define LEO_LIMINAL_FIXTURE_NO_MAIN
+#include "state_swarm_liminal_trajectory_fixture.c"
+
+#define LEO_LIMINAL_TRACE_MAGIC 0x3339414cu /* "LA93" */
+#define LEO_LIMINAL_TRACE_BUILD 3
+
+typedef struct {
+    uint32_t magic;
+    uint32_t build_count;
+    uint64_t anchor_turn;
+    LeoStateWeight stable[LEO_STATE_SWARM_MAX];
+    LeoStateWeight anchor;
+    LeoStateWeight build[LEO_LIMINAL_TRACE_BUILD];
+    LeoStateWeight forward;
+    LeoStateWeight reverse;
+} LeoLiminalTrace;
+
+static int trace_load(const char *path, LeoLiminalTrace *trace) {
+    FILE *file = fopen(path, "rb");
+    int ok = file && fread(trace, sizeof *trace, 1, file) == 1 &&
+        fgetc(file) == EOF;
+    if (file) fclose(file);
+    return ok && trace->magic == LEO_LIMINAL_TRACE_MAGIC &&
+        trace->build_count <= LEO_LIMINAL_TRACE_BUILD;
+}
+
+static int trace_save(const char *path, const LeoLiminalTrace *trace) {
+    FILE *file = fopen(path, "wb");
+    int ok = file && fwrite(trace, sizeof *trace, 1, file) == 1;
+    if (file) ok = fclose(file) == 0 && ok;
+    return ok;
+}
+
+static int trace_parse_observation_args(
+        int argc, char **argv, uint64_t *turn, long *seed,
+        uint64_t *nearest_id, float *similarity,
+        float organs[LEO_STATE_ORGANS]) {
+    return argc == 11 && parse_u64(argv[3], turn) &&
+        parse_long(argv[4], seed) && parse_u64(argv[8], nearest_id) &&
+        parse_float(argv[9], similarity) && parse_organs(argv[10], organs);
+}
+
+static int trace_start(int argc, char **argv) {
+    uint64_t turn = 0, nearest_id = 0;
+    long seed = 0;
+    float similarity = 0.0f;
+    float organs[LEO_STATE_ORGANS];
+    if (!trace_parse_observation_args(argc, argv, &turn, &seed,
+                                      &nearest_id, &similarity, organs))
+        return 2;
+
+    LeoLiminalTrace trace;
+    memset(&trace, 0, sizeof trace);
+    trace.magic = LEO_LIMINAL_TRACE_MAGIC;
+    trace.anchor_turn = turn;
+    if (!capture_observation(argv[7], turn, seed, argv[5], argv[6],
+                             nearest_id, similarity, organs, trace.stable,
+                             &trace.anchor)) {
+        fprintf(stderr, "trace anchor geometry replay mismatch: %s\n", argv[7]);
+        return 1;
+    }
+    trace.forward = trace.anchor;
+    trace.reverse = trace.anchor;
+    return trace_save(argv[2], &trace) ? 0 : 2;
+}
+
+static void trace_build_ordered(LeoLiminalTrace *trace) {
+    trace->forward = trace->anchor;
+    trace->reverse = trace->anchor;
+    for (int i = 0; i < LEO_LIMINAL_TRACE_BUILD; i++)
+        leo_state_weight_update(&trace->forward, &trace->build[i], 1.0f,
+                                trace->anchor_turn + (uint64_t)i + 1);
+    for (int i = 0; i < LEO_LIMINAL_TRACE_BUILD; i++)
+        leo_state_weight_update(
+            &trace->reverse,
+            &trace->build[LEO_LIMINAL_TRACE_BUILD - 1 - i], 1.0f,
+            trace->anchor_turn + (uint64_t)i + 1);
+}
+
+static int trace_absorb(int argc, char **argv) {
+    uint64_t turn = 0, nearest_id = 0;
+    long seed = 0;
+    float similarity = 0.0f;
+    float organs[LEO_STATE_ORGANS];
+    if (!trace_parse_observation_args(argc, argv, &turn, &seed,
+                                      &nearest_id, &similarity, organs))
+        return 2;
+    LeoLiminalTrace trace;
+    if (!trace_load(argv[2], &trace) ||
+        trace.build_count >= LEO_LIMINAL_TRACE_BUILD ||
+        turn != trace.anchor_turn + trace.build_count + 1)
+        return 2;
+
+    LeoStateWeight current[LEO_STATE_SWARM_MAX];
+    LeoStateWeight observation;
+    if (!capture_observation(argv[7], turn, seed, argv[5], argv[6],
+                             nearest_id, similarity, organs, current,
+                             &observation)) {
+        fprintf(stderr, "trace build geometry replay mismatch: turn=%llu\n",
+                (unsigned long long)turn);
+        return 1;
+    }
+    trace.build[trace.build_count++] = observation;
+    if (trace.build_count == LEO_LIMINAL_TRACE_BUILD)
+        trace_build_ordered(&trace);
+    return trace_save(argv[2], &trace) ? 0 : 2;
+}
+
+static int trace_score(int argc, char **argv) {
+    if (argc != 17) return 2;
+    LeoLiminalTrace trace;
+    if (!trace_load(argv[2], &trace) ||
+        trace.build_count != LEO_LIMINAL_TRACE_BUILD)
+        return 2;
+
+    uint64_t anchor_turn = 0, future_turn = 0, relative = 0, nearest_id = 0;
+    long seed = 0;
+    float similarity = 0.0f;
+    float organs[LEO_STATE_ORGANS];
+    if (!parse_u64(argv[6], &anchor_turn) ||
+        !parse_u64(argv[7], &future_turn) ||
+        !parse_u64(argv[8], &relative) || !parse_long(argv[10], &seed) ||
+        !parse_u64(argv[14], &nearest_id) ||
+        !parse_float(argv[15], &similarity) ||
+        !parse_organs(argv[16], organs) || anchor_turn != trace.anchor_turn ||
+        relative < 4 || relative > 8 || future_turn != anchor_turn + relative)
+        return 2;
+
+    LeoStateWeight current[LEO_STATE_SWARM_MAX];
+    LeoStateWeight observation;
+    if (!capture_observation(argv[13], future_turn, seed, argv[11], argv[12],
+                             nearest_id, similarity, organs, current,
+                             &observation)) {
+        fprintf(stderr, "trace score geometry replay mismatch: %s turn=%llu\n",
+                argv[5], (unsigned long long)future_turn);
+        return 1;
+    }
+
+    float forward_organs[LEO_STATE_ORGANS];
+    float reverse_organs[LEO_STATE_ORGANS];
+    float stable_organs[LEO_STATE_ORGANS] = {0};
+    float forward_similarity = leo_state_similarity_components(
+        &trace.forward, &observation, forward_organs);
+    float reverse_similarity = leo_state_similarity_components(
+        &trace.reverse, &observation, reverse_organs);
+    int best = 0;
+    float stable_similarity = -1.0f;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        float candidate[LEO_STATE_ORGANS];
+        float value = leo_state_similarity_components(
+            &trace.stable[i], &observation, candidate);
+        if (value > stable_similarity) {
+            best = i;
+            stable_similarity = value;
+            memcpy(stable_organs, candidate, sizeof stable_organs);
+        }
+    }
+    int directional_nearest =
+        forward_similarity > stable_similarity + 1e-7f &&
+        forward_similarity > reverse_similarity + 1e-7f;
+    int support = directional_nearest &&
+        forward_similarity >= LEO_STATE_REPLACE_GATE;
+    int strong = directional_nearest &&
+        forward_similarity >= LEO_STATE_NOVELTY_GATE;
+    printf("%s\t%s\t%s\t%llu\t%llu\t%llu\t%s\t%.6f\t%.6f\t%.6f\t%llu\t%.6f\t%.6f\t%.6f\t%s\t%s\t%s\t",
+           argv[3], argv[4], argv[5], (unsigned long long)anchor_turn,
+           (unsigned long long)future_turn, (unsigned long long)relative,
+           argv[9], (double)forward_similarity, (double)reverse_similarity,
+           (double)stable_similarity,
+           (unsigned long long)trace.stable[best].id,
+           (double)(forward_similarity - stable_similarity),
+           (double)(reverse_similarity - stable_similarity),
+           (double)(forward_similarity - reverse_similarity),
+           directional_nearest ? "true" : "false",
+           support ? "true" : "false", strong ? "true" : "false");
+    print_organs(forward_organs);
+    putchar('\t');
+    print_organs(reverse_organs);
+    putchar('\t');
+    print_organs(stable_organs);
+    printf("\t%s\t%s\n", argv[11], argv[12]);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc > 1 && !strcmp(argv[1], "start")) return trace_start(argc, argv);
+    if (argc > 1 && !strcmp(argv[1], "absorb")) return trace_absorb(argc, argv);
+    if (argc > 1 && !strcmp(argv[1], "score")) return trace_score(argc, argv);
+    fprintf(stderr, "usage: %s start|absorb|score ...\n", argv[0]);
+    return 2;
+}

--- a/tests/state_swarm_liminal_trajectory_fixture.c
+++ b/tests/state_swarm_liminal_trajectory_fixture.c
@@ -255,6 +255,7 @@ static int project_future(int argc, char **argv) {
     return 0;
 }
 
+#ifndef LEO_LIMINAL_FIXTURE_NO_MAIN
 int main(int argc, char **argv) {
     if (argc > 1 && !strcmp(argv[1], "freeze"))
         return freeze_anchor(argc, argv);
@@ -263,3 +264,4 @@ int main(int argc, char **argv) {
     fprintf(stderr, "usage: %s freeze|project ...\n", argv[0]);
     return 2;
 }
+#endif


### PR DESCRIPTION
## Summary

- build forward and reverse readerless traces from the same anchor and three later observations
- reserve relative turns 4-8 for scoring rather than letting build turns confirm themselves
- require forward-over-stable, forward-over-reverse, unchanged gates, and cross-texture recurrence
- replay-lock all 28 complete futures and honestly censor the one pair without enough later life
- record `no-directional-trace-confirmation`; do not persist or tune the EMA trace

## Canonical result

- eligible pairs: 14 (6 primary, 8 holdout)
- forward > reverse: 40/70 event turns, 38/70 ecology turns
- directional support hits: 3 event, 3 ecology
- confirmations: 0 event, 1 ecology
- mean paired max stable-margin delta: -0.015157
- mean paired max order-margin delta: -0.001267

## Verification

- `make test` (`549/549` plus all script contracts)
- 28/28 complete trajectories preserve normalized logs and final state bytes
- aggregate-only reconstruction is byte-identical
- synthetic contracts reject false locks, margins, booleans, and truncated score tails
- `git diff --check`

No `leo.c`, persisted body, threshold, sampler, routing, generation, or speech changes.