### PR TITLE
A.94: measure transition and consequence debt

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -7789,3 +7789,51 @@ they ended. A crossing may deserve memory because it changes a route or a
 consequence, not because its averaged face later resembles another face.
 
 The same footsteps contain order. A path begins when their consequences do.
+
+## Phase A.94 - the map does not single out the crossing (2026-08-09)
+
+A.93 found a weak arrow inside an averaged trace, but no selective path. A.94
+turns to the route memory Leo already owns: eight stable coordinates, a soft
+transition graph, and four remembered consequences on every directed edge.
+
+The 15 followable A.92 crossings and their matched ordinary updates are fixed
+before measurement. At each preanchor body, A.94 freezes the graph, rebuilds
+the raw anchor observation, and lets the existing transition field predict the
+next real observation. The graph does not see the postanchor update before it
+must answer. Grounded wonder, distress relief, gap relief, and alignment delta
+are forecast from the same frozen edges.
+
+No historical row is trusted alone. Each exact next turn grows again from the
+postanchor body with its original prompt and seed. All 30 visible replies,
+state-swarm geometries, and normalized full debug logs equal the sealed A.89
+life.
+
+```text
+joint debt: event greater 8/15, ecology greater 7/15
+mean transition-debt difference          -0.000305
+mean consequence-error difference        -0.014089
+mean joint-debt difference                -0.011675
+primary / holdout joint difference       -0.030114 / +0.000618
+formal result                             transition-consequence-debt-not-distinguished
+```
+
+The crossing is not where the map fails. Event and ecology overlaps are
+`0.130209` and `0.129905`, almost identical. The more important observation is
+that both are close to the uniform eight-state overlap of `0.125`; next-state
+activation entropy averages `0.914792`. Leo's graph has an outgoing path in
+every arm, but its destination remains broad.
+
+That last comparison is a new question, not a retroactive verdict. The graph
+may know a conditional route weakly, or it may be repeating the marginal
+popularity of destinations because diffuse activations write outer products
+across nearly every edge. A.95 must compare conditional prediction with both
+uniform and destination-prior forecasts under a proper score before any edge
+law changes.
+
+The canonical evidence lives at
+`/private/tmp/leo-state-swarm-transition-consequence-a94-r1-20260809`.
+Reaggregation is byte-identical, synthetic contracts attack every derived
+quantity, and `leo.c` remains untouched.
+
+The map did not forget the threshold. It may not yet know which road is its
+own.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls state-swarm-liminal-confirmation state-swarm-liminal-trace visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls state-swarm-liminal-confirmation state-swarm-liminal-trace state-swarm-transition-consequence visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
 
 all: leo
 
@@ -78,6 +78,9 @@ state-swarm-liminal-confirmation: leo
 
 state-swarm-liminal-trace: leo
 	./scripts/state_swarm_liminal_trace_matrix.sh
+
+state-swarm-transition-consequence: leo
+	./scripts/state_swarm_transition_consequence_matrix.sh
 
 visible-branch-probe: leo
 	LEO_VISIBLE_BRANCH_POLICY=local-v1 ./scripts/adaptive_life_probe.sh scripts/visible_branch_phases.txt
@@ -250,6 +253,9 @@ test: tests/test_leo.c leo.c
 	./scripts/test_state_swarm_liminal_trace_select.sh
 	./scripts/test_state_swarm_liminal_trace_report.sh
 	./scripts/test_state_swarm_liminal_trace_fixture.sh
+	./scripts/test_state_swarm_transition_consequence_select.sh
+	./scripts/test_state_swarm_transition_consequence_report.sh
+	./scripts/test_state_swarm_transition_consequence_fixture.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_report.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_matrix.sh
 	./scripts/test_state_swarm_near_gate_controls_select.sh

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -1579,3 +1579,67 @@ persist this trace. The next read-only study should retain the path as a path:
 use the state swarm's existing transition and consequence fields to ask
 whether a crossing creates predictive or outcome structure that its matched
 ordinary update does not.
+
+## A.94: the graph is diffuse, not selectively blind to crossings
+
+Run the frozen transition-and-consequence study:
+
+```sh
+make state-swarm-transition-consequence
+```
+
+A.94 restores the censored short-future pair and consumes all 15 replay-locked
+A.92 event/ecology pairs. At each preanchor body, the fixture freezes the eight
+stable coordinates plus the transition and four-channel consequence arrays.
+It reconstructs the raw anchor observation, projects it onto those eight
+coordinates with the organism's unchanged `0.12` activation temperature, and
+asks that frozen graph to predict the exact next lived observation.
+
+The transition prediction is normalized before overlap with the next soft
+activation. `transition_debt` is one minus that overlap. Consequence error is
+the mean absolute error across grounded wonder, distress relief, gap relief,
+and alignment delta. Their product is `joint_debt`, so an absent outgoing path
+does not become evidence merely by being absent: it must also miss a nonzero
+consequence.
+
+Every next turn is independently regenerated from the real postanchor body.
+All 30 replies, parsed geometries, and normalized complete debug logs match
+their sealed A.89 sources. The canonical run is
+`/private/tmp/leo-state-swarm-transition-consequence-a94-r1-20260809`:
+
+```text
+eligible pairs                              15  (primary 6, holdout 9)
+event/ecology positive joint-debt delta      8 / 7
+mean paired transition-debt delta       -0.000305
+mean paired consequence-MAE delta       -0.014089
+mean paired joint-debt delta             -0.011675
+primary / holdout joint-debt delta       -0.030114 / +0.000618
+mean event / ecology forward overlap      0.130209 / 0.129905
+mean anchor / next activation entropy     0.960337 / 0.914792
+result                                    transition-consequence-debt-not-distinguished
+```
+
+The predeclared crossing-specific criterion required 12 positive pairs, mean
+joint debt of at least `+0.01`, positive transition and consequence components,
+and positive means in both splits. No component reaches that result. Crossings
+do not expose a route or consequence failure that ordinary matched updates do
+not already carry.
+
+The negative contrast reveals a broader anatomical warning. With eight
+coordinates, a uniform prediction overlaps any normalized target by `0.125`.
+Both observed means sit only about `0.005` above that value, while the target
+activations themselves remain highly entropic. This comparison is diagnostic,
+not a predeclared A.94 verdict: raw overlap cannot yet tell whether the graph
+contains conditional route information or merely reproduces destination
+frequency under diffuse outer-product updates.
+
+Aggregate-only reconstruction regenerates the plan from sealed A.92 sources
+and is byte-identical for the paired summary and verdict. Reporter contracts
+recompute transition debt, arrow margin, consequence MAE, and joint debt;
+false locks, truncated score sets, and altered arithmetic fail closed.
+
+A.94 changes no C code, state body, threshold, update law, sampler, routing
+path, generation path, or speech. Do not add a special crossing consequence
+channel. A.95 should score the existing conditional graph against uniform and
+destination-prior baselines with proper distribution scores, and measure
+whether the transition matrix carries information beyond a rank-one ecology.

--- a/scripts/state_swarm_transition_consequence_matrix.sh
+++ b/scripts/state_swarm_transition_consequence_matrix.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# A.94: ask whether a crossing exposes debt in the frozen state graph.
+set -Eeuo pipefail
+
+trap 'rc=$?; printf "transition consequence runner failed: line=%s rc=%s command=%s\n" "$LINENO" "$rc" "$BASH_COMMAND" >&2; exit "$rc"' ERR
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CC="${CC:-cc}"
+A89="${LEO_STATE_CONSEQUENCE_A89_SOURCE:-/private/tmp/leo-state-swarm-balanced-event-reservoir-a89-r1-20260807}"
+A91="${LEO_STATE_CONSEQUENCE_A91_SOURCE:-/private/tmp/leo-state-swarm-near-gate-controls-a91-r2-20260807}"
+A92="${LEO_STATE_CONSEQUENCE_A92_SOURCE:-/private/tmp/leo-state-swarm-liminal-confirmation-a92-r6-20260807}"
+EXPECTED="${LEO_STATE_CONSEQUENCE_EXPECTED_PAIRS:-15}"
+EXPECTED_SELECTION_SHA="${LEO_STATE_CONSEQUENCE_SELECTION_SHA:-394a1b43fa915fc144a67019711b311c6092e9b075c4ba62ede680d590be26ec}"
+EXPECTED_PLAN_SHA="${LEO_STATE_CONSEQUENCE_PLAN_SHA:-9b0434bfa9bcc4c5cb6051cf7a6133f3fe0f51add036b5273721ece327e5ca2a}"
+EXPECTED_LOCK_SHA="${LEO_STATE_CONSEQUENCE_LOCK_SHA:-e60d20854dda2f352a21014bb87b72959895fecd95d5953061afc13cd0409197}"
+EXPECTED_WRITER_SHA="${LEO_STATE_CONSEQUENCE_WRITER_SHA:-10bf4251848f4edaec4a34d66d3d811afff187df9f10aeb71ff761a342c0e833}"
+AGGREGATE_ONLY="${LEO_STATE_CONSEQUENCE_AGGREGATE_ONLY:-0}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-state-swarm-transition-consequence-$STAMP}"
+
+case "$EXPECTED" in
+    ''|*[!0-9]*|0) printf 'invalid consequence pair count: %s\n' "$EXPECTED" >&2; exit 2 ;;
+esac
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+seal() {
+    local path="$1" expected="$2" label="$3"
+    [ -s "$path" ] && [ "$(sha256_file "$path")" = "$expected" ] || {
+        printf '%s is not the sealed source: %s\n' "$label" "$path" >&2
+        exit 2
+    }
+}
+
+A92_SELECTION="$A92/selection.tsv"
+A92_PLAN="$A92/plan.tsv"
+A92_LOCKS="$A92/trajectory-locks.tsv"
+WRITER_RECEIPTS="$A89/writer-receipts.tsv"
+seal "$A92_SELECTION" "$EXPECTED_SELECTION_SHA" "A.92 selection"
+seal "$A92_PLAN" "$EXPECTED_PLAN_SHA" "A.92 anchor plan"
+seal "$A92_LOCKS" "$EXPECTED_LOCK_SHA" "A.92 trajectory locks"
+seal "$WRITER_RECEIPTS" "$EXPECTED_WRITER_SHA" "A.89 writer receipts"
+
+PLAN="$OUT/plan.tsv"
+LOCKS="$OUT/replay-locks.tsv"
+SCORES="$OUT/scores.tsv"
+PAIR_SUMMARY="$OUT/pair-summary.tsv"
+VERDICT="$OUT/verdict.txt"
+
+select_plan() {
+    awk -f "$ROOT/scripts/state_swarm_transition_consequence_select.awk" \
+        "$A92_SELECTION" "$A92_PLAN" "$A92_LOCKS"
+}
+
+if [ "$AGGREGATE_ONLY" = 1 ]; then
+    [ -s "$PLAN" ] && [ -s "$LOCKS" ] && [ -s "$SCORES" ] || {
+        printf 'incomplete transition consequence run: %s\n' "$OUT" >&2
+        exit 2
+    }
+    plan_check="$(mktemp "${TMPDIR:-/tmp}/leo-transition-consequence-plan.XXXXXX")"
+    select_plan > "$plan_check"
+    cmp -s "$PLAN" "$plan_check" || {
+        rm -f "$plan_check"
+        printf 'transition consequence plan no longer matches A.92: %s\n' \
+            "$PLAN" >&2
+        exit 2
+    }
+    rm -f "$plan_check"
+else
+    [ ! -e "$OUT" ] || {
+        printf 'output path already exists: %s\n' "$OUT" >&2
+        exit 2
+    }
+    mkdir -p "$OUT/replays"
+    select_plan > "$PLAN"
+fi
+
+awk -F '\t' -v expected="$EXPECTED" '
+    NR == 1 {
+        if (NF != 19 || $1 != "pair" || $2 != "arm" ||
+            $7 != "turn" || $14 != "pre_state" || $19 != "final_sha")
+            exit 1
+        next
+    }
+    {
+        key = $1 SUBSEP $2
+        if (NF != 19 || $1 !~ /^[0-9][0-9]$/ ||
+            $2 !~ /^(event|ecology)$/ || seen[key]++ || $3 == "" ||
+            $4 !~ /^[ph][0-9][0-9]$/ || $5 !~ /^(primary|holdout)$/ ||
+            $7 !~ /^[0-9]+$/ || $7 >= 96 ||
+            $10 !~ /^(home|storm|wonder|social)$/ ||
+            $12 == "" || $13 == "") exit 1
+        for (i = 17; i <= 19; i++)
+            if (length($i) != 64 || $i !~ /^[0-9a-f]+$/) exit 1
+        rows++
+    }
+    END { if (rows != expected * 2) exit 1 }
+' "$PLAN" || {
+    printf 'invalid A.94 plan: %s\n' "$PLAN" >&2
+    exit 2
+}
+
+while IFS=$'\t' read -r pair arm anchor life split base_seed turn session \
+    order texture run_seed prompt reply pre_state post_state final_state \
+    pre_sha post_sha final_sha; do
+    [ "$(sha256_file "$pre_state")" = "$pre_sha" ] &&
+        [ "$(sha256_file "$post_state")" = "$post_sha" ] &&
+        [ "$(sha256_file "$final_state")" = "$final_sha" ] || {
+        printf 'A.94 anchor package changed: %s %s\n' "$arm" "$anchor" >&2
+        exit 2
+    }
+done < <(tail -n +2 "$PLAN")
+
+if [ "${LEO_STATE_CONSEQUENCE_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+normalize_log() {
+    sed -E \
+        -e 's|^\[leo\] loaded state from .*$|[leo] loaded state from BODY|' \
+        -e 's|^\[leo\] saved state to .* \(step=|[leo] saved state to BODY (step=|' \
+        "$1"
+}
+
+if [ "$AGGREGATE_ONLY" != 1 ]; then
+    make -C "$ROOT" leo >/dev/null
+    FIXTURE="$OUT/transition-consequence-fixture"
+    "$CC" "$ROOT/tests/state_swarm_transition_consequence_fixture.c" \
+        -O2 -lm -Wall -Wextra -Wno-unused-function -o "$FIXTURE" -lpthread
+    printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turns\tpre_sha\tpost_sha\tsource_log_sha\treplay_log_sha\tnormalized_sha\ta92_reply_equal\ta92_state_equal\tnext_log_equal\tgeometry_equal\n' > "$LOCKS"
+    printf 'pair\tarm\tanchor\tanchor_turn\tfuture_turn\ttexture\tanchor_similarity\tanchor_entropy\tnext_similarity\tnext_entropy\ttransition_mass\tforward_overlap\treverse_mass\treverse_overlap\ttransition_debt\tarrow_margin\tforecast_grounded\tforecast_distress_relief\tforecast_gap_relief\tforecast_alignment_delta\tactual_grounded\tactual_distress_relief\tactual_gap_relief\tactual_alignment_delta\toutcome_mae\tjoint_debt\tprompt\treply\n' > "$SCORES"
+    while IFS=$'\t' read -r pair arm anchor life split base_seed turn session \
+        order texture run_seed prompt reply pre_state post_state final_state \
+        pre_sha post_sha final_sha; do
+        replay="$OUT/replays/$pair-$arm-$anchor"
+        mkdir -p "$replay"
+        graph="$replay/frozen-graph.bin"
+        work_state="$replay/work.state"
+        if [ "$arm" = event ]; then
+            anchor_log="$A89/candidates/$life/events/$anchor/trigger.log"
+        else
+            anchor_log="$A91/controls/$anchor/source.log"
+        fi
+        anchor_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$anchor_log")"
+        IFS=$'\t' read -r observed_turn observed_event observed_new \
+            observed_similarity observed_members observed_displaced \
+            observed_nearest observed_nearest_organs observed_removed_organs \
+            observed_organs <<< "$anchor_shape"
+        [ "$observed_turn" -eq "$turn" ] && [ "$observed_nearest" -gt 0 ] || {
+            printf 'A.94 anchor geometry mismatch: %s %s\n' "$arm" "$anchor" >&2
+            exit 2
+        }
+        "$FIXTURE" start "$graph" "$turn" "$run_seed" "$prompt" "$reply" \
+            "$pre_state" "$observed_nearest" "$observed_similarity" \
+            "$observed_nearest_organs"
+
+        next_receipt="$replay/next.tsv"
+        awk -F '\t' -v life="$life" -v turn="$((turn + 1))" '
+            BEGIN { OFS = "\t" }
+            NR == 1 {
+                if (NF != 34 || $1 != "life" || $5 != "session" ||
+                    $8 != "run_seed" || $9 != "turn" ||
+                    $25 != "observed_grounded" || $28 != "observed_alignment_delta" ||
+                    $33 != "prompt" || $34 != "reply") exit 2
+                next
+            }
+            $1 == life && $9 == turn {
+                print $5, $6, $7, $8, $9, $25, $26, $27, $28, $33, $34
+                rows++
+            }
+            END { if (rows != 1) exit 2 }
+        ' "$WRITER_RECEIPTS" > "$next_receipt"
+        IFS=$'\t' read -r next_session next_order next_texture next_seed \
+            next_turn actual_grounded actual_distress actual_gap \
+            actual_alignment next_prompt next_reply < "$next_receipt"
+        printf -v padded '%02d' "$next_order"
+        source_log="$A89/candidates/$life/writer-logs/s${next_session}-${padded}-${next_texture}.log"
+        [ -s "$source_log" ] || {
+            printf 'missing A.94 next source log: %s turn=%s\n' "$anchor" "$next_turn" >&2
+            exit 2
+        }
+        next_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$source_log")"
+        IFS=$'\t' read -r shape_turn shape_event shape_new shape_similarity \
+            shape_members shape_displaced shape_nearest shape_nearest_organs \
+            shape_removed_organs shape_organs <<< "$next_shape"
+        [ "$shape_turn" -eq "$next_turn" ] && [ "$shape_nearest" -gt 0 ] || {
+            printf 'A.94 next geometry mismatch: %s turn=%s\n' "$anchor" "$next_turn" >&2
+            exit 2
+        }
+
+        cp "$post_state" "$work_state"
+        "$FIXTURE" score "$graph" "$pair" "$arm" "$anchor" "$turn" \
+            "$next_turn" 1 "$next_texture" "$next_seed" "$next_prompt" \
+            "$next_reply" "$work_state" "$shape_nearest" \
+            "$shape_similarity" "$shape_nearest_organs" \
+            "$actual_grounded" "$actual_distress" "$actual_gap" \
+            "$actual_alignment" >> "$SCORES"
+
+        generated_log="$replay/next.generated.log"
+        source_normalized="$replay/next.source.normalized"
+        generated_normalized="$replay/next.generated.normalized"
+        "$ROOT/leo" --corpus "$ROOT/leo.txt" --load "$work_state" \
+            --seed "$next_seed" --respond "$next_prompt" --debug-field \
+            --save "$work_state" > "$generated_log" 2>&1
+        normalize_log "$source_log" > "$source_normalized"
+        normalize_log "$generated_log" > "$generated_normalized"
+        cmp -s "$source_normalized" "$generated_normalized" || {
+            printf 'A.94 next full-log replay mismatch: %s turn=%s\n' \
+                "$anchor" "$next_turn" >&2
+            exit 1
+        }
+
+        a92_lock="$replay/a92-lock.tsv"
+        awk -F '\t' -v pair="$pair" -v arm="$arm" '
+            NR == 1 { next }
+            $1 == pair && $2 == arm { print $7 "\t" $12 "\t" $13; rows++ }
+            END { if (rows != 1) exit 2 }
+        ' "$A92_LOCKS" > "$a92_lock"
+        IFS=$'\t' read -r future_turns a92_reply_equal a92_state_equal \
+            < "$a92_lock"
+        [ "$a92_reply_equal" = true ] && [ "$a92_state_equal" = true ] || {
+            printf 'A.94 inherited an open A.92 lock: %s %s\n' "$arm" "$anchor" >&2
+            exit 2
+        }
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\ttrue\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$turn" \
+            "$future_turns" "$pre_sha" "$post_sha" \
+            "$(sha256_file "$source_log")" "$(sha256_file "$generated_log")" \
+            "$(sha256_file "$generated_normalized")" >> "$LOCKS"
+        rm -f "$work_state" "$graph"
+    done < <(tail -n +2 "$PLAN")
+    rm -f "$FIXTURE"
+fi
+
+awk -v expected="$EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_transition_consequence_report.awk" \
+    "$LOCKS" "$SCORES" > "$PAIR_SUMMARY"
+awk -v expected="$EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_transition_consequence_verdict.awk" \
+    "$PAIR_SUMMARY" > "$VERDICT"
+
+cat "$LOCKS"
+printf '\n'
+cat "$PAIR_SUMMARY"
+printf '\n'
+cat "$VERDICT"
+printf '\nsource-a89: %s\nsource-a91: %s\nsource-a92: %s\nrun: %s\n' \
+    "$A89" "$A91" "$A92" "$OUT"

--- a/scripts/state_swarm_transition_consequence_report.awk
+++ b/scripts/state_swarm_transition_consequence_report.awk
@@ -1,0 +1,123 @@
+# A.94: verify graph arithmetic and reduce event/ecology transition debt.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function integer(value) { return value ~ /^[0-9]+$/ }
+function number(value) { return value ~ /^-?[0-9]+([.][0-9]+)?$/ }
+function abs(value) { return value < 0 ? -value : value }
+
+BEGIN {
+    FS = OFS = "\t"
+    if (!expected) expected = 15
+}
+
+FILENAME == ARGV[1] {
+    if (FNR == 1) {
+        if (NF != 16 || $1 != "pair" || $2 != "arm" ||
+            $7 != "future_turns" || $13 != "a92_reply_equal" ||
+            $16 != "geometry_equal") fail()
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 16 || $1 !~ /^[0-9][0-9]$/ ||
+        $2 !~ /^(event|ecology)$/ || seen_lock[key]++ ||
+        $3 == "" || $4 !~ /^[ph][0-9][0-9]$/ ||
+        $5 !~ /^(primary|holdout)$/ || !integer($6) || !integer($7) ||
+        $7 < 1 || $6 + $7 != 96) fail()
+    for (i = 8; i <= 12; i++)
+        if (length($i) != 64 || $i !~ /^[0-9a-f]+$/) fail()
+    for (i = 13; i <= 16; i++) if ($i != "true") fail()
+    anchor[key] = $3
+    split_name[key] = $5
+    anchor_turn[key] = $6 + 0
+    locks++
+    next
+}
+
+FNR == 1 {
+    if (NF != 28 || $1 != "pair" || $2 != "arm" ||
+        $11 != "transition_mass" || $12 != "forward_overlap" ||
+        $15 != "transition_debt" || $16 != "arrow_margin" ||
+        $25 != "outcome_mae" || $26 != "joint_debt" ||
+        $28 != "reply") fail()
+    next
+}
+
+{
+    key = $1 SUBSEP $2
+    if (NF != 28 || !(key in anchor) || seen_score[key]++ ||
+        $3 != anchor[key] || !integer($4) || !integer($5) ||
+        $4 + 0 != anchor_turn[key] || $5 != $4 + 1 ||
+        $6 !~ /^(home|storm|wonder|social)$/) fail()
+    for (i = 7; i <= 26; i++) if (!number($i)) fail()
+    if ($7 < 0 || $7 > 1 || $8 < 0 || $8 > 1 ||
+        $9 < 0 || $9 > 1 || $10 < 0 || $10 > 1 ||
+        $11 < 0 || $12 < 0 || $12 > 1 || $13 < 0 ||
+        $14 < 0 || $14 > 1 || $15 < 0 || $15 > 1 ||
+        $25 < 0 || $25 > 2 || $26 < 0 || $26 > 2 ||
+        abs((1 - $12) - $15) > 0.000002 ||
+        abs(($12 - $14) - $16) > 0.000002) fail()
+    mae = (abs($17 - $21) + abs($18 - $22) + \
+           abs($19 - $23) + abs($20 - $24)) / 4
+    if (abs(mae - $25) > 0.000002 ||
+        abs(($15 * $25) - $26) > 0.000002 ||
+        $27 == "" || $28 == "") fail()
+    mass[key] = $11 + 0
+    overlap[key] = $12 + 0
+    reverse_overlap[key] = $14 + 0
+    transition_debt[key] = $15 + 0
+    arrow[key] = $16 + 0
+    outcome_mae[key] = $25 + 0
+    joint_debt[key] = $26 + 0
+    scores++
+    next
+}
+
+END {
+    if (fatal) exit 2
+    if (locks != expected * 2 || scores != expected * 2) fail()
+    print "pair", "event_anchor", "ecology_anchor", "split", "anchor_turn", \
+          "event_transition_mass", "event_overlap", "event_reverse_overlap", \
+          "event_transition_debt", "event_outcome_mae", "event_joint_debt", \
+          "event_arrow_margin", "ecology_transition_mass", \
+          "ecology_overlap", "ecology_reverse_overlap", \
+          "ecology_transition_debt", "ecology_outcome_mae", \
+          "ecology_joint_debt", "ecology_arrow_margin", \
+          "paired_transition_debt_delta", "paired_outcome_mae_delta", \
+          "paired_joint_debt_delta", "paired_arrow_margin_delta"
+    emitted = 0
+    for (i = 1; i <= 99; i++) {
+        pair = sprintf("%02d", i)
+        event = pair SUBSEP "event"
+        ecology = pair SUBSEP "ecology"
+        if (!(event in anchor) && !(ecology in anchor)) continue
+        if (!(event in anchor) || !(ecology in anchor) ||
+            !(event in seen_score) || !(ecology in seen_score) ||
+            split_name[event] != split_name[ecology] ||
+            anchor_turn[event] != anchor_turn[ecology]) fail()
+        print pair, anchor[event], anchor[ecology], split_name[event], \
+              anchor_turn[event], sprintf("%.6f", mass[event]), \
+              sprintf("%.6f", overlap[event]), \
+              sprintf("%.6f", reverse_overlap[event]), \
+              sprintf("%.6f", transition_debt[event]), \
+              sprintf("%.6f", outcome_mae[event]), \
+              sprintf("%.6f", joint_debt[event]), \
+              sprintf("%.6f", arrow[event]), \
+              sprintf("%.6f", mass[ecology]), \
+              sprintf("%.6f", overlap[ecology]), \
+              sprintf("%.6f", reverse_overlap[ecology]), \
+              sprintf("%.6f", transition_debt[ecology]), \
+              sprintf("%.6f", outcome_mae[ecology]), \
+              sprintf("%.6f", joint_debt[ecology]), \
+              sprintf("%.6f", arrow[ecology]), \
+              sprintf("%.6f", transition_debt[event] - transition_debt[ecology]), \
+              sprintf("%.6f", outcome_mae[event] - outcome_mae[ecology]), \
+              sprintf("%.6f", joint_debt[event] - joint_debt[ecology]), \
+              sprintf("%.6f", arrow[event] - arrow[ecology])
+        emitted++
+    }
+    if (emitted != expected) fail()
+}

--- a/scripts/state_swarm_transition_consequence_select.awk
+++ b/scripts/state_swarm_transition_consequence_select.awk
@@ -1,0 +1,70 @@
+# A.94: carry all followable A.92 event/ecology pairs into graph anatomy.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+BEGIN { FS = OFS = "\t" }
+
+FILENAME == ARGV[1] {
+    if (FNR == 1) {
+        if (NF != 13 || $1 != "pair" || $2 != "arm" || $13 != "reply") fail()
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 13 || selected[key]++) fail()
+    for (i = 1; i <= 13; i++) field[key, i] = $i
+    selections++
+    next
+}
+
+FILENAME == ARGV[2] {
+    if (FNR == 1) {
+        if (NF != 19 || $1 != "pair" || $2 != "arm" ||
+            $14 != "pre_state" || $19 != "final_sha") fail()
+        header = $0
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 19 || !(key in selected) || planned[key]++) fail()
+    for (i = 1; i <= 13; i++) if ($i != field[key, i]) fail()
+    plan[key] = $0
+    plans++
+    next
+}
+
+FILENAME == ARGV[3] {
+    if (FNR == 1) {
+        if (NF != 13 || $1 != "pair" || $2 != "arm" ||
+            $7 != "future_turns" || $12 != "reply_equal" ||
+            $13 != "state_equal") fail()
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 13 || !(key in selected) || locked[key]++ ||
+        $7 !~ /^[0-9]+$/ || $7 < 1 ||
+        $12 != "true" || $13 != "true") fail()
+    future[key] = $7 + 0
+    locks++
+    next
+}
+
+END {
+    if (fatal) exit 2
+    if (selections != 30 || plans != 30 || locks != 30) fail()
+    print header
+    for (i = 1; i <= 99; i++) {
+        pair = sprintf("%02d", i)
+        event = pair SUBSEP "event"
+        ecology = pair SUBSEP "ecology"
+        if (!(event in selected) && !(ecology in selected)) continue
+        if (!(event in planned) || !(ecology in planned) ||
+            !(event in locked) || !(ecology in locked) ||
+            future[event] != future[ecology]) fail()
+        print plan[event]
+        print plan[ecology]
+        pairs++
+    }
+    if (pairs != 15) fail()
+}

--- a/scripts/state_swarm_transition_consequence_verdict.awk
+++ b/scripts/state_swarm_transition_consequence_verdict.awk
@@ -1,0 +1,78 @@
+# A.94: decide whether crossings expose graph aliasing that controls do not.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function integer(value) { return value ~ /^[0-9]+$/ }
+function number(value) { return value ~ /^-?[0-9]+([.][0-9]+)?$/ }
+
+BEGIN {
+    FS = "\t"
+    if (!expected) expected = 15
+    if (!sign_required) sign_required = 12
+    if (!mean_required) mean_required = 0.01
+}
+
+NR == 1 {
+    if (NF != 23 || $1 != "pair" || $4 != "split" ||
+        $9 != "event_transition_debt" || $16 != "ecology_transition_debt" ||
+        $20 != "paired_transition_debt_delta" ||
+        $22 != "paired_joint_debt_delta") fail()
+    next
+}
+
+{
+    if (NF != 23 || $1 !~ /^[0-9][0-9]$/ || seen[$1]++ ||
+        $4 !~ /^(primary|holdout)$/ || !integer($5)) fail()
+    for (i = 6; i <= 23; i++) if (!number($i)) fail()
+    transition_delta += $20
+    outcome_delta += $21
+    joint_delta += $22
+    arrow_delta += $23
+    split_joint[$4] += $22
+    split_total[$4]++
+    if ($22 > 0) joint_positive++
+    else if ($22 < 0) joint_negative++
+    else joint_tie++
+    if ($6 <= 0) event_no_prediction++
+    if ($13 <= 0) ecology_no_prediction++
+    rows++
+}
+
+END {
+    if (fatal) exit 2
+    if (rows != expected || !split_total["primary"] ||
+        !split_total["holdout"]) fail()
+    mean_transition = transition_delta / rows
+    mean_outcome = outcome_delta / rows
+    mean_joint = joint_delta / rows
+    mean_arrow = arrow_delta / rows
+    primary_joint = split_joint["primary"] / split_total["primary"]
+    holdout_joint = split_joint["holdout"] / split_total["holdout"]
+    if (joint_positive >= sign_required && mean_joint >= mean_required &&
+        mean_transition > 0 && mean_outcome > 0 &&
+        primary_joint > 0 && holdout_joint > 0)
+        result = "crossing-specific-transition-consequence-debt"
+    else
+        result = "transition-consequence-debt-not-distinguished"
+
+    print "eligible_pairs " rows
+    print "primary_pairs " split_total["primary"]
+    print "holdout_pairs " split_total["holdout"]
+    print "joint_delta_positive " joint_positive + 0
+    print "joint_delta_negative " joint_negative + 0
+    print "joint_delta_tie " joint_tie + 0
+    print "event_no_prediction " event_no_prediction + 0
+    print "ecology_no_prediction " ecology_no_prediction + 0
+    print "mean_paired_transition_debt_delta " sprintf("%.6f", mean_transition)
+    print "mean_paired_outcome_mae_delta " sprintf("%.6f", mean_outcome)
+    print "mean_paired_joint_debt_delta " sprintf("%.6f", mean_joint)
+    print "mean_paired_arrow_margin_delta " sprintf("%.6f", mean_arrow)
+    print "primary_mean_joint_debt_delta " sprintf("%.6f", primary_joint)
+    print "holdout_mean_joint_debt_delta " sprintf("%.6f", holdout_joint)
+    print "required_positive " sign_required
+    print "required_mean_joint_delta " sprintf("%.6f", mean_required)
+    print "result " result
+}

--- a/scripts/test_state_swarm_transition_consequence_fixture.sh
+++ b/scripts/test_state_swarm_transition_consequence_fixture.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-transition-consequence-fixture.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+"${CC:-cc}" "$ROOT/tests/state_swarm_transition_consequence_fixture.c" \
+    -O2 -lm -Wall -Wextra -Wno-unused-function \
+    -o "$TMP/transition-consequence-fixture" -lpthread
+set +e
+"$TMP/transition-consequence-fixture" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || {
+    printf 'transition consequence fixture accepted a missing mode: rc=%s\n' \
+        "$rc" >&2
+    exit 1
+}
+
+printf 'state-swarm transition consequence fixture: ok\n'

--- a/scripts/test_state_swarm_transition_consequence_report.sh
+++ b/scripts/test_state_swarm_transition_consequence_report.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-transition-consequence-report.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+HASH='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turns\tpre_sha\tpost_sha\tsource_log_sha\treplay_log_sha\tnormalized_sha\ta92_reply_equal\ta92_state_equal\tnext_log_equal\tgeometry_equal\n' > "$TMP/locks.tsv"
+lock() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\ttrue\n' \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$((96 - $6))" \
+        "$HASH" "$HASH" "$HASH" "$HASH" "$HASH"
+}
+lock 01 event p01-t050 p01 primary 50 >> "$TMP/locks.tsv"
+lock 01 ecology p11-t050 p11 primary 50 >> "$TMP/locks.tsv"
+lock 02 event h01-t060 h01 holdout 60 >> "$TMP/locks.tsv"
+lock 02 ecology h11-t060 h11 holdout 60 >> "$TMP/locks.tsv"
+
+printf 'pair\tarm\tanchor\tanchor_turn\tfuture_turn\ttexture\tanchor_similarity\tanchor_entropy\tnext_similarity\tnext_entropy\ttransition_mass\tforward_overlap\treverse_mass\treverse_overlap\ttransition_debt\tarrow_margin\tforecast_grounded\tforecast_distress_relief\tforecast_gap_relief\tforecast_alignment_delta\tactual_grounded\tactual_distress_relief\tactual_gap_relief\tactual_alignment_delta\toutcome_mae\tjoint_debt\tprompt\treply\n' > "$TMP/scores.tsv"
+score() {
+    printf '%s\t%s\t%s\t%s\t%s\thome\t0.500000\t0.800000\t0.510000\t0.790000\t1.000000\t%s\t1.000000\t%s\t%s\t%s\t0.000000\t0.000000\t0.000000\t0.000000\t%s\t%s\t%s\t%s\t%s\t%s\tprompt %s\treply %s\n' \
+        "$1" "$2" "$3" "$4" "$(( $4 + 1 ))" "$5" "$6" "$7" \
+        "$8" "$9" "$9" "$9" "$9" "$9" "${10}" "$1" "$2"
+}
+score 01 event p01-t050 50 0.200000 0.150000 0.800000 0.050000 0.400000 0.320000 >> "$TMP/scores.tsv"
+score 01 ecology p11-t050 50 0.300000 0.250000 0.700000 0.050000 0.200000 0.140000 >> "$TMP/scores.tsv"
+score 02 event h01-t060 60 0.300000 0.200000 0.700000 0.100000 0.100000 0.070000 >> "$TMP/scores.tsv"
+score 02 ecology h11-t060 60 0.200000 0.150000 0.800000 0.050000 0.200000 0.160000 >> "$TMP/scores.tsv"
+
+awk -v expected=2 -f "$ROOT/scripts/state_swarm_transition_consequence_report.awk" \
+    "$TMP/locks.tsv" "$TMP/scores.tsv" > "$TMP/summary.tsv"
+awk -v expected=2 -v sign_required=2 -v mean_required=0.01 \
+    -f "$ROOT/scripts/state_swarm_transition_consequence_verdict.awk" \
+    "$TMP/summary.tsv" > "$TMP/verdict.txt"
+awk -F '\t' '
+    NR == 1 { if (NF != 23 || $20 != "paired_transition_debt_delta" || $22 != "paired_joint_debt_delta") exit 1; next }
+    $1 == "01" { if ($22 != "0.180000") exit 1; first++ }
+    $1 == "02" { if ($22 != "-0.090000") exit 1; second++ }
+    END { if (NR != 3 || first != 1 || second != 1) exit 1 }
+' "$TMP/summary.tsv"
+grep -q '^joint_delta_positive 1$' "$TMP/verdict.txt"
+grep -q '^joint_delta_negative 1$' "$TMP/verdict.txt"
+grep -q '^result transition-consequence-debt-not-distinguished$' "$TMP/verdict.txt"
+
+awk -F '\t' 'BEGIN { OFS=FS } NR == 2 { $26 = "0.310000" } { print }' \
+    "$TMP/scores.tsv" > "$TMP/false-joint.tsv"
+if awk -v expected=2 -f "$ROOT/scripts/state_swarm_transition_consequence_report.awk" \
+    "$TMP/locks.tsv" "$TMP/false-joint.tsv" >/dev/null 2>&1; then
+    printf 'transition consequence reporter accepted false joint debt\n' >&2
+    exit 1
+fi
+
+sed '$d' "$TMP/scores.tsv" > "$TMP/truncated.tsv"
+if awk -v expected=2 -f "$ROOT/scripts/state_swarm_transition_consequence_report.awk" \
+    "$TMP/locks.tsv" "$TMP/truncated.tsv" >/dev/null 2>&1; then
+    printf 'transition consequence reporter accepted a truncated score set\n' >&2
+    exit 1
+fi
+
+sed '2s/true$/false/' "$TMP/locks.tsv" > "$TMP/open-lock.tsv"
+if awk -v expected=2 -f "$ROOT/scripts/state_swarm_transition_consequence_report.awk" \
+    "$TMP/open-lock.tsv" "$TMP/scores.tsv" >/dev/null 2>&1; then
+    printf 'transition consequence reporter accepted an open replay lock\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm transition consequence reporters: ok\n'

--- a/scripts/test_state_swarm_transition_consequence_select.sh
+++ b/scripts/test_state_swarm_transition_consequence_select.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-transition-consequence-select.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+HASH='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+printf 'pair\tarm\tanchor\tlife\tsplit\tbase_seed\tturn\tsession\torder\ttexture\trun_seed\tprompt\treply\n' > "$TMP/selection.tsv"
+printf 'pair\tarm\tanchor\tlife\tsplit\tbase_seed\tturn\tsession\torder\ttexture\trun_seed\tprompt\treply\tpre_state\tpost_state\tfinal_state\tpre_sha\tpost_sha\tfinal_sha\n' > "$TMP/plan.tsv"
+printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turns\tpre_sha\tpost_sha\tfinal_sha\treproduced_sha\treply_equal\tstate_equal\n' > "$TMP/locks.tsv"
+
+for i in $(seq 1 15); do
+    printf -v pair '%02d' "$i"
+    if [ "$i" -le 6 ]; then prefix=p; split=primary; else prefix=h; split=holdout; fi
+    turn=68
+    if [ "$i" -eq 15 ]; then turn=94; fi
+    future=$((96 - turn))
+    for arm in event ecology; do
+        if [ "$arm" = event ]; then offset=0; else offset=30; fi
+        n=$((i + offset))
+        printf -v life '%s%02d' "$prefix" "$n"
+        printf -v anchor '%s-t%03d' "$life" "$turn"
+        seed=$((100000 + n))
+        printf '%s\t%s\t%s\t%s\t%s\t%d\t%d\t5\t4\tsocial\t%d\tprompt %s\treply %s\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$seed" "$turn" \
+            "$((seed + 504))" "$pair" "$arm" >> "$TMP/selection.tsv"
+        printf '%s\t%s\t%s\t%s\t%s\t%d\t%d\t5\t4\tsocial\t%d\tprompt %s\treply %s\t/pre/%s\t/post/%s\t/final/%s\t%s\t%s\t%s\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$seed" "$turn" \
+            "$((seed + 504))" "$pair" "$arm" "$anchor" "$anchor" "$life" \
+            "$HASH" "$HASH" "$HASH" >> "$TMP/plan.tsv"
+        printf '%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\t%s\t%s\ttrue\ttrue\n' \
+            "$pair" "$arm" "$anchor" "$life" "$split" "$turn" "$future" \
+            "$HASH" "$HASH" "$HASH" "$HASH" >> "$TMP/locks.tsv"
+    done
+done
+
+awk -f "$ROOT/scripts/state_swarm_transition_consequence_select.awk" \
+    "$TMP/selection.tsv" "$TMP/plan.tsv" "$TMP/locks.tsv" \
+    > "$TMP/consequence-plan.tsv"
+awk -F '\t' '
+    NR == 1 { if (NF != 19 || $1 != "pair" || $19 != "final_sha") exit 1; next }
+    { pairs[$1]++; arms[$1 SUBSEP $2]++ }
+    END {
+        if (NR != 31 || length(pairs) != 15) exit 1
+        for (i = 1; i <= 15; i++) {
+            p = sprintf("%02d", i)
+            if (pairs[p] != 2 || arms[p SUBSEP "event"] != 1 ||
+                arms[p SUBSEP "ecology"] != 1) exit 1
+        }
+    }
+' "$TMP/consequence-plan.tsv"
+
+sed '2s/true$/false/' "$TMP/locks.tsv" > "$TMP/unlocked.tsv"
+if awk -f "$ROOT/scripts/state_swarm_transition_consequence_select.awk" \
+    "$TMP/selection.tsv" "$TMP/plan.tsv" "$TMP/unlocked.tsv" \
+    >/dev/null 2>&1; then
+    printf 'transition consequence selector accepted a false A.92 lock\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm transition consequence selector: ok\n'

--- a/tests/state_swarm_transition_consequence_fixture.c
+++ b/tests/state_swarm_transition_consequence_fixture.c
@@ -1,0 +1,203 @@
+#define LEO_LIMINAL_FIXTURE_NO_MAIN
+#include "state_swarm_liminal_trajectory_fixture.c"
+
+#define LEO_TRANSITION_CONSEQUENCE_MAGIC 0x3439414cu /* "LA94" */
+
+typedef struct {
+    uint32_t magic;
+    uint32_t members;
+    uint64_t anchor_turn;
+    LeoStateWeight stable[LEO_STATE_SWARM_MAX];
+    float transition[LEO_STATE_SWARM_MAX][LEO_STATE_SWARM_MAX];
+    float outcome[LEO_STATE_SWARM_MAX][LEO_STATE_SWARM_MAX]
+                 [LEO_STATE_OUTCOMES];
+    float anchor_activation[LEO_STATE_SWARM_MAX];
+    float anchor_similarity;
+    float anchor_entropy;
+} LeoTransitionConsequence;
+
+static int graph_save(const char *path,
+                      const LeoTransitionConsequence *graph) {
+    FILE *file = fopen(path, "wb");
+    int ok = file && fwrite(graph, sizeof *graph, 1, file) == 1;
+    if (file) ok = fclose(file) == 0 && ok;
+    return ok;
+}
+
+static int graph_load(const char *path, LeoTransitionConsequence *graph) {
+    FILE *file = fopen(path, "rb");
+    int ok = file && fread(graph, sizeof *graph, 1, file) == 1 &&
+        fgetc(file) == EOF;
+    if (file) fclose(file);
+    return ok && graph->magic == LEO_TRANSITION_CONSEQUENCE_MAGIC &&
+        graph->members == LEO_STATE_SWARM_MAX;
+}
+
+static void graph_activation(
+        const LeoStateWeight stable[LEO_STATE_SWARM_MAX],
+        const LeoStateWeight *observation,
+        float activation[LEO_STATE_SWARM_MAX], float *best_similarity,
+        float *entropy) {
+    float similarity[LEO_STATE_SWARM_MAX];
+    float best = -1.0f;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        similarity[i] = leo_state_similarity_components(
+            &stable[i], observation, NULL);
+        if (similarity[i] > best) best = similarity[i];
+    }
+    float total = 0.0f;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        activation[i] = expf((similarity[i] - best) / 0.12f);
+        total += activation[i];
+    }
+    float h = 0.0f;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        activation[i] = total > 0.0f ? activation[i] / total : 0.0f;
+        if (activation[i] > 0.0f)
+            h -= activation[i] * logf(activation[i]);
+    }
+    *best_similarity = best;
+    *entropy = h / logf((float)LEO_STATE_SWARM_MAX);
+}
+
+static void graph_predict(
+        const LeoTransitionConsequence *graph,
+        const float from[LEO_STATE_SWARM_MAX],
+        const float to[LEO_STATE_SWARM_MAX], float *mass, float *overlap,
+        float forecast[LEO_STATE_OUTCOMES]) {
+    float prediction[LEO_STATE_SWARM_MAX] = {0};
+    memset(forecast, 0, sizeof(float) * LEO_STATE_OUTCOMES);
+    *mass = 0.0f;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++)
+        for (int j = 0; j < LEO_STATE_SWARM_MAX; j++) {
+            float edge = from[i] * graph->transition[i][j];
+            prediction[j] += edge;
+            *mass += edge;
+            for (int o = 0; o < LEO_STATE_OUTCOMES; o++)
+                forecast[o] += edge * graph->outcome[i][j][o];
+        }
+    *overlap = 0.0f;
+    if (*mass <= 0.0f) return;
+    for (int j = 0; j < LEO_STATE_SWARM_MAX; j++) {
+        prediction[j] /= *mass;
+        *overlap += prediction[j] * to[j];
+    }
+    for (int o = 0; o < LEO_STATE_OUTCOMES; o++) forecast[o] /= *mass;
+}
+
+static int graph_start(int argc, char **argv) {
+    if (argc != 11) return 2;
+    uint64_t turn = 0, nearest_id = 0;
+    long seed = 0;
+    float similarity = 0.0f;
+    float organs[LEO_STATE_ORGANS];
+    if (!parse_u64(argv[3], &turn) || !parse_long(argv[4], &seed) ||
+        !parse_u64(argv[8], &nearest_id) ||
+        !parse_float(argv[9], &similarity) ||
+        !parse_organs(argv[10], organs))
+        return 2;
+
+    Leo *body = load_leo(argv[7]);
+    if (!body || !body->state_swarm ||
+        body->state_swarm->n != LEO_STATE_SWARM_MAX) {
+        destroy_leo(body);
+        return 1;
+    }
+    LeoTransitionConsequence graph;
+    memset(&graph, 0, sizeof graph);
+    graph.magic = LEO_TRANSITION_CONSEQUENCE_MAGIC;
+    graph.members = LEO_STATE_SWARM_MAX;
+    graph.anchor_turn = turn;
+    memcpy(graph.transition, body->state_swarm->transition,
+           sizeof graph.transition);
+    memcpy(graph.outcome, body->state_swarm->outcome,
+           sizeof graph.outcome);
+    destroy_leo(body);
+
+    LeoStateWeight observation;
+    if (!capture_observation(argv[7], turn, seed, argv[5], argv[6],
+                             nearest_id, similarity, organs, graph.stable,
+                             &observation)) {
+        fprintf(stderr, "transition anchor replay mismatch: %s\n", argv[7]);
+        return 1;
+    }
+    graph_activation(graph.stable, &observation, graph.anchor_activation,
+                     &graph.anchor_similarity, &graph.anchor_entropy);
+    return graph_save(argv[2], &graph) ? 0 : 2;
+}
+
+static int graph_score(int argc, char **argv) {
+    if (argc != 21) return 2;
+    LeoTransitionConsequence graph;
+    if (!graph_load(argv[2], &graph)) return 2;
+
+    uint64_t anchor_turn = 0, future_turn = 0, relative = 0, nearest_id = 0;
+    long seed = 0;
+    float similarity = 0.0f;
+    float organs[LEO_STATE_ORGANS];
+    float actual[LEO_STATE_OUTCOMES];
+    if (!parse_u64(argv[6], &anchor_turn) ||
+        !parse_u64(argv[7], &future_turn) ||
+        !parse_u64(argv[8], &relative) || !parse_long(argv[10], &seed) ||
+        !parse_u64(argv[14], &nearest_id) ||
+        !parse_float(argv[15], &similarity) ||
+        !parse_organs(argv[16], organs) ||
+        anchor_turn != graph.anchor_turn || relative != 1 ||
+        future_turn != anchor_turn + 1)
+        return 2;
+    for (int o = 0; o < LEO_STATE_OUTCOMES; o++)
+        if (!parse_float(argv[17 + o], &actual[o]) ||
+            actual[o] < -1.0001f || actual[o] > 1.0001f)
+            return 2;
+
+    LeoStateWeight current[LEO_STATE_SWARM_MAX];
+    LeoStateWeight observation;
+    if (!capture_observation(argv[13], future_turn, seed, argv[11], argv[12],
+                             nearest_id, similarity, organs, current,
+                             &observation)) {
+        fprintf(stderr, "transition future replay mismatch: %s turn=%llu\n",
+                argv[5], (unsigned long long)future_turn);
+        return 1;
+    }
+    float next_activation[LEO_STATE_SWARM_MAX];
+    float next_similarity = 0.0f, next_entropy = 0.0f;
+    graph_activation(graph.stable, &observation, next_activation,
+                     &next_similarity, &next_entropy);
+
+    float mass = 0.0f, overlap = 0.0f;
+    float reverse_mass = 0.0f, reverse_overlap = 0.0f;
+    float forecast[LEO_STATE_OUTCOMES];
+    float reverse_forecast[LEO_STATE_OUTCOMES];
+    graph_predict(&graph, graph.anchor_activation, next_activation,
+                  &mass, &overlap, forecast);
+    graph_predict(&graph, next_activation, graph.anchor_activation,
+                  &reverse_mass, &reverse_overlap, reverse_forecast);
+    float outcome_mae = 0.0f;
+    for (int o = 0; o < LEO_STATE_OUTCOMES; o++)
+        outcome_mae += fabsf(forecast[o] - actual[o]);
+    outcome_mae /= LEO_STATE_OUTCOMES;
+    float transition_debt = 1.0f - overlap;
+    float joint_debt = transition_debt * outcome_mae;
+
+    printf("%s\t%s\t%s\t%llu\t%llu\t%s\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f\t%.6f",
+           argv[3], argv[4], argv[5], (unsigned long long)anchor_turn,
+           (unsigned long long)future_turn, argv[9],
+           (double)graph.anchor_similarity, (double)graph.anchor_entropy,
+           (double)next_similarity, (double)next_entropy, (double)mass,
+           (double)overlap, (double)reverse_mass, (double)reverse_overlap,
+           (double)transition_debt, (double)(overlap - reverse_overlap));
+    for (int o = 0; o < LEO_STATE_OUTCOMES; o++)
+        printf("\t%.6f", (double)forecast[o]);
+    for (int o = 0; o < LEO_STATE_OUTCOMES; o++)
+        printf("\t%.6f", (double)actual[o]);
+    printf("\t%.6f\t%.6f\t%s\t%s\n", (double)outcome_mae,
+           (double)joint_debt, argv[11], argv[12]);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc > 1 && !strcmp(argv[1], "start")) return graph_start(argc, argv);
+    if (argc > 1 && !strcmp(argv[1], "score")) return graph_score(argc, argv);
+    fprintf(stderr, "usage: %s start|score ...\n", argv[0]);
+    return 2;
+}


### PR DESCRIPTION
## What changed

- add the sealed A.94 transition/consequence runner over all 15 replay-locked A.92 crossing/ecology pairs
- reconstruct the frozen eight-state graph before each anchor and score the exact next lived observation
- validate reply, state geometry, normalized debug log, and all derived debt arithmetic
- record the canonical `transition-consequence-debt-not-distinguished` result in `LEOLOG.md` and the adaptive probe protocol

## Why

A.93 showed weak chronology but no selective trace. A.94 tests whether a crossing instead creates route or outcome debt in Leo's existing state graph. It does not: event/ecology joint-debt signs are 8/7 and mean paired joint-debt delta is `-0.011675`.

The broader diagnostic is that mean forward overlap is `0.130209` for crossings and `0.129905` for controls against a uniform eight-state baseline of `0.125`. This leaves A.95 to test conditional graph information against uniform and destination-prior baselines before changing the edge law.

No `leo.c`, persisted state, threshold, sampler, routing path, generation path, or speech reader changes.

## Validation

- `make test`: `549/549` plus every script contract
- all 30 next-turn replies, parsed geometries, and normalized full debug logs replay exactly
- aggregate-only reconstruction is byte-identical (`pair-summary dbf9c207...`, `verdict 1b58d844...`)
- `git diff --check`
- `git diff origin/main...HEAD -- leo.c` is empty
