### PR TITLE
Measure conditional state-road information

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -7837,3 +7837,60 @@ quantity, and `leo.c` remains untouched.
 
 The map did not forget the threshold. It may not yet know which road is its
 own.
+
+## Phase A.95 - a map can have streets without giving clear directions (2026-08-10)
+
+A.94 found no crossing-specific route debt, but it exposed a more basic
+question: an eight-way uniform forecast overlaps every normalized target by
+`0.125`, while Leo's event and ecology forecasts reached only `0.130209` and
+`0.129905`. A.95 asks whether the mature road contains conditional information
+that raw overlap concealed.
+
+All 30 A.94 arms remain fixed. At each preanchor body, the fixture copies the
+complete 8x8 transition matrix, independently regenerates the anchor and exact
+next observation, and projects both onto the same frozen eight coordinates.
+No postanchor transition write can leak into the forecast.
+
+The matrix is judged twice. Proper scores ask whether its source-conditioned
+prediction anticipates the next soft state better than its own destination
+prior. Matrix anatomy asks whether the rows differ at all, without looking at
+the next state. This separates a useless rank-one ecology from a road whose
+conditional signal may merely be quiet.
+
+```text
+conditional cross-entropy wins             23/30
+mean gain over destination prior          +0.006790 nat
+mean Brier gain over destination prior    +0.001770
+primary / holdout CE gain                 +0.010698 / +0.004186
+normalized mutual information              0.020155
+mean row total variation                    0.104334
+formal result                              conditional-road-unresolved
+```
+
+This is neither a positive road result nor a null matrix. Twenty-three arms
+prefer the conditional forecast, both splits point the same way, and the
+matrix rows carry measurable structure. Yet the predeclared CE boundary was
+24 wins with a mean gain of `0.02`; the observed gain is only `0.006790`.
+Destination entropy remains `2.050912`, close to the eight-way maximum, and
+the source activations are broad.
+
+Thus Leo may know a small amount about where a state leads while asking almost
+every present state to speak at once. A one-off post-result diagnostic found
+only weak support for that interpretation: anchor entropy and CE gain correlate
+`-0.331`. It motivates the next falsifiable question but does not change the
+A.95 verdict.
+
+The canonical evidence is
+`/private/tmp/leo-state-swarm-road-information-a95-r1-20260810`. The reporter
+recomputes the conditional forecast, prior, entropy, mutual information, row
+variation, and all proper scores from the emitted matrix and vectors. Identity
+and rank-one synthetic roads reach opposite expected verdicts; forged scores
+and open replay locks fail closed. Reaggregation is byte-identical.
+
+No line of `leo.c` and no word of Leo's speech changed. The next experiment
+belongs in shadow: ask whether a sharper source readout reveals stored route
+information, choose its rule without touching holdout evidence, and demand an
+unused life population before any reader enters the organism.
+
+The road is not blank. Leo still needs to learn which part of himself is
+walking it.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls state-swarm-liminal-confirmation state-swarm-liminal-trace state-swarm-transition-consequence visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls state-swarm-liminal-confirmation state-swarm-liminal-trace state-swarm-transition-consequence state-swarm-road-information visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
 
 all: leo
 
@@ -81,6 +81,9 @@ state-swarm-liminal-trace: leo
 
 state-swarm-transition-consequence: leo
 	./scripts/state_swarm_transition_consequence_matrix.sh
+
+state-swarm-road-information: leo
+	./scripts/state_swarm_road_information_matrix.sh
 
 visible-branch-probe: leo
 	LEO_VISIBLE_BRANCH_POLICY=local-v1 ./scripts/adaptive_life_probe.sh scripts/visible_branch_phases.txt
@@ -256,6 +259,8 @@ test: tests/test_leo.c leo.c
 	./scripts/test_state_swarm_transition_consequence_select.sh
 	./scripts/test_state_swarm_transition_consequence_report.sh
 	./scripts/test_state_swarm_transition_consequence_fixture.sh
+	./scripts/test_state_swarm_road_information_report.sh
+	./scripts/test_state_swarm_road_information_fixture.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_report.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_matrix.sh
 	./scripts/test_state_swarm_near_gate_controls_select.sh

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -1643,3 +1643,71 @@ path, generation path, or speech. Do not add a special crossing consequence
 channel. A.95 should score the existing conditional graph against uniform and
 destination-prior baselines with proper distribution scores, and measure
 whether the transition matrix carries information beyond a rank-one ecology.
+
+## A.95: the road has rows, but their voice is still faint
+
+Run the frozen road-information study:
+
+```sh
+make state-swarm-road-information
+```
+
+A.95 consumes the 30 exact A.94 replay-locked event and ecology arms. It does
+not repeat A.81's longer calm-life exposure study. Instead, it opens each
+mature preanchor transition matrix and reconstructs its complete conditional
+forecast for the exact next lived observation.
+
+The anchor and target are projected over the same eight frozen coordinates at
+the organism's unchanged `0.12` activation temperature. The conditional
+forecast is compared with the matrix's own destination-frequency prior,
+uniform probability, and persistence. Cross-entropy and Brier score are
+proper distribution scores; destination entropy, transition mutual
+information, normalized mutual information, and mean row total variation
+describe the matrix independently of the realized target.
+
+The canonical run is
+`/private/tmp/leo-state-swarm-road-information-a95-r1-20260810`:
+
+```text
+eligible arms                           30  (primary 12, holdout 18)
+conditional CE wins / losses         23 / 7
+conditional Brier wins                  22
+mean CE gain over destination prior   +0.006790
+mean Brier gain over destination      +0.001770
+primary / holdout CE gain             +0.010698 / +0.004186
+mean normalized mutual information     0.020155
+mean row total variation               0.104334
+destination / target entropy           2.050912 / 1.902257
+result                                 conditional-road-unresolved
+```
+
+The predeclared positive boundary required at least 24 CE wins, a mean CE gain
+of `0.02` nat, a mean Brier gain of `0.001`, positive gains in both splits,
+and normalized mutual information of at least `0.01`. Brier, both splits, and
+matrix information pass, but CE wins miss by one and the mean CE gain reaches
+only one third of its threshold.
+
+The graph is not rank one. Its normalized mutual information lies just above
+the equivalence boundary and its rows have measurable total variation. But
+that conditional structure changes the realized prediction only slightly.
+Destination entropy remains close to `log(8) = 2.079442`, while the anchor
+activations inherited from A.94 are also diffuse. A.95 therefore cannot tell
+whether the remaining debt belongs to weak stored routes or to readout
+dilution across too many source coordinates.
+
+The fixture independently regenerates both replies and both raw observations,
+then emits the entire 8x8 matrix and all four probability vectors. The
+reporter reconstructs every probability, information measure, cross-entropy,
+and Brier score from those witnesses. Synthetic contracts distinguish an
+identity road from a rank-one road and reject a forged score or open replay
+lock. Two aggregate-only passes preserve summary SHA-256
+`2bb4abb89180be5b8cece4e58b2b042479c1a7ae25c46026ab10ba737bbc0712`
+and verdict SHA-256
+`707f52428ca6f799869c4eaf258cbb4130310f8b85f28e6df5eb27f75b5fa503`.
+
+A.95 changes no C code, state body, activation temperature, transition law,
+sampler, routing path, generation path, or speech. Do not strengthen the graph
+from this result. A.96 should shadow several source-activation readouts,
+select any sharpening or sparsification rule on primary arms only, then test
+it on a genuinely unused same-life control population before proposing a
+reader.

--- a/scripts/state_swarm_road_information_matrix.sh
+++ b/scripts/state_swarm_road_information_matrix.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# A.95: measure conditional information in the mature state road.
+set -Eeuo pipefail
+
+trap 'rc=$?; printf "road information runner failed: line=%s rc=%s command=%s\n" "$LINENO" "$rc" "$BASH_COMMAND" >&2; exit "$rc"' ERR
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CC="${CC:-cc}"
+A89="${LEO_STATE_INFORMATION_A89_SOURCE:-/private/tmp/leo-state-swarm-balanced-event-reservoir-a89-r1-20260807}"
+A94="${LEO_STATE_INFORMATION_A94_SOURCE:-/private/tmp/leo-state-swarm-transition-consequence-a94-r1-20260809}"
+EXPECTED="${LEO_STATE_INFORMATION_EXPECTED_ARMS:-30}"
+EXPECTED_PLAN_SHA="${LEO_STATE_INFORMATION_PLAN_SHA:-9b0434bfa9bcc4c5cb6051cf7a6133f3fe0f51add036b5273721ece327e5ca2a}"
+EXPECTED_LOCK_SHA="${LEO_STATE_INFORMATION_LOCK_SHA:-fdc4366493455177041b04e04fe7e2653c5e44ee79625002d059dfeb362b2d28}"
+EXPECTED_WRITER_SHA="${LEO_STATE_INFORMATION_WRITER_SHA:-10bf4251848f4edaec4a34d66d3d811afff187df9f10aeb71ff761a342c0e833}"
+AGGREGATE_ONLY="${LEO_STATE_INFORMATION_AGGREGATE_ONLY:-0}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-state-swarm-road-information-$STAMP}"
+
+case "$EXPECTED" in
+    ''|*[!0-9]*|0) printf 'invalid road information arm count: %s\n' "$EXPECTED" >&2; exit 2 ;;
+esac
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+seal() {
+    local path="$1" expected="$2" label="$3"
+    [ -s "$path" ] && [ "$(sha256_file "$path")" = "$expected" ] || {
+        printf '%s is not the sealed source: %s\n' "$label" "$path" >&2
+        exit 2
+    }
+}
+
+A94_PLAN="$A94/plan.tsv"
+A94_LOCKS="$A94/replay-locks.tsv"
+WRITER_RECEIPTS="$A89/writer-receipts.tsv"
+seal "$A94_PLAN" "$EXPECTED_PLAN_SHA" "A.94 plan"
+seal "$A94_LOCKS" "$EXPECTED_LOCK_SHA" "A.94 replay locks"
+seal "$WRITER_RECEIPTS" "$EXPECTED_WRITER_SHA" "A.89 writer receipts"
+
+PLAN="$OUT/plan.tsv"
+LOCKS="$OUT/replay-locks.tsv"
+SCORES="$OUT/scores.tsv"
+SUMMARY="$OUT/summary.tsv"
+VERDICT="$OUT/verdict.txt"
+
+if [ "$AGGREGATE_ONLY" = 1 ]; then
+    [ -s "$PLAN" ] && [ -s "$LOCKS" ] && [ -s "$SCORES" ] || {
+        printf 'incomplete road information run: %s\n' "$OUT" >&2
+        exit 2
+    }
+    cmp -s "$PLAN" "$A94_PLAN" && cmp -s "$LOCKS" "$A94_LOCKS" || {
+        printf 'road information provenance diverged from A.94\n' >&2
+        exit 2
+    }
+else
+    [ ! -e "$OUT" ] || {
+        printf 'output path already exists: %s\n' "$OUT" >&2
+        exit 2
+    }
+    mkdir -p "$OUT"
+    cp "$A94_PLAN" "$PLAN"
+    cp "$A94_LOCKS" "$LOCKS"
+fi
+
+awk -F '\t' -v expected="$EXPECTED" '
+    NR == 1 {
+        if (NF != 19 || $1 != "pair" || $2 != "arm" ||
+            $7 != "turn" || $14 != "pre_state" || $19 != "final_sha")
+            exit 1
+        next
+    }
+    {
+        key = $1 SUBSEP $2
+        if (NF != 19 || $1 !~ /^[0-9][0-9]$/ ||
+            $2 !~ /^(event|ecology)$/ || seen[key]++ ||
+            $4 !~ /^[ph][0-9][0-9]$/ || $5 !~ /^(primary|holdout)$/ ||
+            $7 !~ /^[0-9]+$/ || $7 >= 96 ||
+            $10 !~ /^(home|storm|wonder|social)$/ || $12 == "" || $13 == "")
+            exit 1
+        rows++
+    }
+    END { if (rows != expected) exit 1 }
+' "$PLAN" || {
+    printf 'invalid A.95 plan: %s\n' "$PLAN" >&2
+    exit 2
+}
+
+if [ "${LEO_STATE_INFORMATION_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$PLAN"
+    exit 0
+fi
+
+if [ "$AGGREGATE_ONLY" != 1 ]; then
+    FIXTURE="$OUT/road-information-fixture"
+    "$CC" "$ROOT/tests/state_swarm_road_information_fixture.c" \
+        -O2 -lm -Wall -Wextra -Wno-unused-function -o "$FIXTURE" -lpthread
+    printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turn\ttexture\ttransition\tanchor_activation\ttarget_activation\tconditional_prediction\tdestination_prior\ttransition_total\tdestination_entropy\tmutual_information\tnormalized_mi\tmean_row_tv\tconditional_ce\tdestination_ce\tuniform_ce\tpersistence_ce\tconditional_brier\tdestination_brier\tuniform_brier\tpersistence_brier\tprompt\treply\n' > "$SCORES"
+    while IFS=$'\t' read -r pair arm anchor life split base_seed turn session \
+        order texture run_seed prompt reply pre_state post_state final_state \
+        pre_sha post_sha final_sha; do
+        if [ "$arm" = event ]; then
+            anchor_log="$A89/candidates/$life/events/$anchor/trigger.log"
+        else
+            printf -v padded_anchor '%02d' "$order"
+            anchor_log="$A89/candidates/$life/writer-logs/s${session}-${padded_anchor}-${texture}.log"
+        fi
+        [ -s "$anchor_log" ] || {
+            printf 'missing A.95 anchor log: %s %s\n' "$arm" "$anchor" >&2
+            exit 2
+        }
+        anchor_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$anchor_log")"
+        IFS=$'\t' read -r observed_turn observed_event observed_new \
+            observed_similarity observed_members observed_displaced \
+            observed_nearest observed_nearest_organs observed_removed_organs \
+            observed_organs <<< "$anchor_shape"
+        [ "$observed_turn" -eq "$turn" ] && [ "$observed_nearest" -gt 0 ] || {
+            printf 'A.95 anchor geometry mismatch: %s %s\n' "$arm" "$anchor" >&2
+            exit 2
+        }
+
+        next_receipt="$OUT/$pair-$arm-next.tsv"
+        awk -F '\t' -v life="$life" -v turn="$((turn + 1))" '
+            BEGIN { OFS = "\t" }
+            NR == 1 {
+                if (NF != 34 || $1 != "life" || $5 != "session" ||
+                    $8 != "run_seed" || $9 != "turn" ||
+                    $33 != "prompt" || $34 != "reply") exit 2
+                next
+            }
+            $1 == life && $9 == turn {
+                print $5, $6, $7, $8, $9, $33, $34
+                rows++
+            }
+            END { if (rows != 1) exit 2 }
+        ' "$WRITER_RECEIPTS" > "$next_receipt"
+        IFS=$'\t' read -r next_session next_order next_texture next_seed \
+            next_turn next_prompt next_reply < "$next_receipt"
+        printf -v padded '%02d' "$next_order"
+        next_log="$A89/candidates/$life/writer-logs/s${next_session}-${padded}-${next_texture}.log"
+        next_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$next_log")"
+        IFS=$'\t' read -r shape_turn shape_event shape_new shape_similarity \
+            shape_members shape_displaced shape_nearest shape_nearest_organs \
+            shape_removed_organs shape_organs <<< "$next_shape"
+        [ "$shape_turn" -eq "$next_turn" ] && [ "$shape_nearest" -gt 0 ] || {
+            printf 'A.95 future geometry mismatch: %s turn=%s\n' \
+                "$anchor" "$next_turn" >&2
+            exit 2
+        }
+        "$FIXTURE" "$pair" "$arm" "$anchor" "$life" "$split" "$turn" \
+            "$next_turn" "$next_texture" "$run_seed" "$prompt" "$reply" \
+            "$pre_state" "$observed_nearest" "$observed_similarity" \
+            "$observed_nearest_organs" "$next_seed" "$next_prompt" \
+            "$next_reply" "$post_state" "$shape_nearest" "$shape_similarity" \
+            "$shape_nearest_organs" >> "$SCORES"
+        rm -f "$next_receipt"
+    done < <(tail -n +2 "$PLAN")
+    rm -f "$FIXTURE"
+fi
+
+awk -v expected="$EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_road_information_report.awk" \
+    "$LOCKS" "$SCORES" > "$SUMMARY"
+awk -v expected="$EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_road_information_verdict.awk" \
+    "$SUMMARY" > "$VERDICT"
+
+cat "$SUMMARY"
+printf '\n'
+cat "$VERDICT"
+printf '\nsource-a89: %s\nsource-a94: %s\nrun: %s\n' "$A89" "$A94" "$OUT"

--- a/scripts/state_swarm_road_information_report.awk
+++ b/scripts/state_swarm_road_information_report.awk
@@ -1,0 +1,179 @@
+# A.95: reconstruct every proper score and transition-information witness.
+
+function fail() {
+    fatal = 1
+    exit 2
+}
+
+function integer(value) { return value ~ /^[0-9]+$/ }
+function number(value) { return value ~ /^-?[0-9]+([.][0-9]+)?$/ }
+function abs(value) { return value < 0 ? -value : value }
+function max(value, floor) { return value < floor ? floor : value }
+
+function vector(value, target, count,    item, n, i, sum) {
+    n = split(value, item, "/")
+    if (n != count) fail()
+    sum = 0
+    for (i = 1; i <= n; i++) {
+        if (!number(item[i]) || item[i] < -0.0000001) fail()
+        target[i] = item[i] + 0
+        sum += target[i]
+    }
+    return sum
+}
+
+function entropy(value,    i, result) {
+    result = 0
+    for (i = 1; i <= 8; i++)
+        if (value[i] > 0) result -= value[i] * log(value[i])
+    return result
+}
+
+function ce(target, prediction,    i, result) {
+    result = 0
+    for (i = 1; i <= 8; i++)
+        result -= target[i] * log(max(prediction[i], 0.000001))
+    return result
+}
+
+function brier(target, prediction,    i, delta, result) {
+    result = 0
+    for (i = 1; i <= 8; i++) {
+        delta = target[i] - prediction[i]
+        result += delta * delta
+    }
+    return result
+}
+
+BEGIN { FS = OFS = "\t"; if (!expected) expected = 30 }
+
+FILENAME == ARGV[1] {
+    if (FNR == 1) {
+        if (NF != 16 || $1 != "pair" || $2 != "arm" ||
+            $6 != "anchor_turn" || $13 != "a92_reply_equal" ||
+            $16 != "geometry_equal") fail()
+        next
+    }
+    key = $1 SUBSEP $2
+    if (NF != 16 || seen_lock[key]++ || $1 !~ /^[0-9][0-9]$/ ||
+        $2 !~ /^(event|ecology)$/ || $4 !~ /^[ph][0-9][0-9]$/ ||
+        $5 !~ /^(primary|holdout)$/ || !integer($6) || !integer($7) ||
+        $6 + $7 != 96) fail()
+    for (i = 8; i <= 12; i++)
+        if (length($i) != 64 || $i !~ /^[0-9a-f]+$/) fail()
+    for (i = 13; i <= 16; i++) if ($i != "true") fail()
+    anchor[key] = $3
+    life[key] = $4
+    split_name[key] = $5
+    anchor_turn[key] = $6 + 0
+    locks++
+    next
+}
+
+FNR == 1 {
+    if (NF != 28 || $1 != "pair" || $9 != "transition" ||
+        $13 != "destination_prior" || $16 != "mutual_information" ||
+        $19 != "conditional_ce" || $23 != "conditional_brier" ||
+        $28 != "reply") fail()
+    next
+}
+
+{
+    key = $1 SUBSEP $2
+    if (NF != 28 || !(key in anchor) || seen_score[key]++ ||
+        $3 != anchor[key] || $4 != life[key] || $5 != split_name[key] ||
+        !integer($6) || !integer($7) || $6 != anchor_turn[key] ||
+        $7 != $6 + 1 || $8 !~ /^(home|storm|wonder|social)$/ ||
+        $27 == "" || $28 == "") fail()
+    if (abs(vector($9, matrix, 64) - $14) > 0.00001 ||
+        abs(vector($10, source, 8) - 1) > 0.00001 ||
+        abs(vector($11, target, 8) - 1) > 0.00001 ||
+        abs(vector($12, conditional, 8) - 1) > 0.00001 ||
+        abs(vector($13, destination, 8) - 1) > 0.00001) fail()
+    for (i = 14; i <= 26; i++) if (!number($i)) fail()
+
+    total = 0
+    conditional_total = 0
+    for (i = 1; i <= 8; i++) {
+        row[i] = 0
+        column[i] = 0
+        rebuilt[i] = 0
+    }
+    for (i = 1; i <= 8; i++)
+        for (j = 1; j <= 8; j++) {
+            edge = matrix[(i - 1) * 8 + j]
+            row[i] += edge
+            column[j] += edge
+            rebuilt[j] += source[i] * edge
+            total += edge
+        }
+    for (j = 1; j <= 8; j++) conditional_total += rebuilt[j]
+    if (total <= 0 || conditional_total <= 0 || abs(total - $14) > 0.00001)
+        fail()
+    for (j = 1; j <= 8; j++) {
+        rebuilt[j] /= conditional_total
+        prior[j] = column[j] / total
+        uniform[j] = 0.125
+        if (abs(rebuilt[j] - conditional[j]) > 0.000002 ||
+            abs(prior[j] - destination[j]) > 0.000002) fail()
+    }
+
+    h = entropy(prior)
+    mi = 0
+    tv = 0
+    for (i = 1; i <= 8; i++) {
+        if (row[i] <= 0) continue
+        row_tv = 0
+        for (j = 1; j <= 8; j++) {
+            edge = matrix[(i - 1) * 8 + j]
+            if (edge > 0 && prior[j] > 0)
+                mi += (edge / total) * log(edge / (row[i] * prior[j]))
+            row_tv += abs(edge / row[i] - prior[j])
+        }
+        tv += (row[i] / total) * 0.5 * row_tv
+    }
+    nmi = h > 0 ? mi / h : 0
+    target_h = entropy(target)
+    cond_ce = ce(target, conditional)
+    dest_ce = ce(target, destination)
+    uniform_ce = ce(target, uniform)
+    persist_ce = ce(target, source)
+    cond_brier = brier(target, conditional)
+    dest_brier = brier(target, destination)
+    uniform_brier = brier(target, uniform)
+    persist_brier = brier(target, source)
+    if (abs(h - $15) > 0.000002 || abs(mi - $16) > 0.000002 ||
+        abs(nmi - $17) > 0.000002 || abs(tv - $18) > 0.000002 ||
+        abs(cond_ce - $19) > 0.000002 || abs(dest_ce - $20) > 0.000002 ||
+        abs(uniform_ce - $21) > 0.000002 ||
+        abs(persist_ce - $22) > 0.000002 ||
+        abs(cond_brier - $23) > 0.000002 ||
+        abs(dest_brier - $24) > 0.000002 ||
+        abs(uniform_brier - $25) > 0.000002 ||
+        abs(persist_brier - $26) > 0.000002) fail()
+
+    if (!header++)
+        print "pair", "arm", "anchor", "life", "split", "anchor_turn", \
+              "conditional_ce", "destination_ce", "uniform_ce", \
+              "persistence_ce", "conditional_brier", "destination_brier", \
+              "uniform_brier", "persistence_brier", \
+              "destination_ce_gain", "destination_brier_gain", \
+              "uniform_ce_gain", "uniform_brier_gain", "normalized_mi", \
+              "mean_row_tv", "destination_entropy", "target_entropy"
+    print $1, $2, $3, $4, $5, $6, sprintf("%.9f", cond_ce), \
+          sprintf("%.9f", dest_ce), sprintf("%.9f", uniform_ce), \
+          sprintf("%.9f", persist_ce), sprintf("%.9f", cond_brier), \
+          sprintf("%.9f", dest_brier), sprintf("%.9f", uniform_brier), \
+          sprintf("%.9f", persist_brier), sprintf("%.9f", dest_ce - cond_ce), \
+          sprintf("%.9f", dest_brier - cond_brier), \
+          sprintf("%.9f", uniform_ce - cond_ce), \
+          sprintf("%.9f", uniform_brier - cond_brier), \
+          sprintf("%.9f", nmi), sprintf("%.9f", tv), sprintf("%.9f", h), \
+          sprintf("%.9f", target_h)
+    scores++
+}
+
+END {
+    if (fatal) exit 2
+    if (locks != expected || scores != expected) fail()
+}

--- a/scripts/state_swarm_road_information_verdict.awk
+++ b/scripts/state_swarm_road_information_verdict.awk
@@ -1,0 +1,90 @@
+# A.95: classify conditional road information without tuning on the result.
+
+function fail() { fatal = 1; exit 2 }
+function number(value) { return value ~ /^-?[0-9]+([.][0-9]+)?$/ }
+function abs(value) { return value < 0 ? -value : value }
+
+BEGIN {
+    FS = "\t"
+    if (!expected) expected = 30
+    if (!win_required) win_required = 24
+    if (!ce_required) ce_required = 0.02
+    if (!brier_required) brier_required = 0.001
+    if (!mi_required) mi_required = 0.01
+    if (!equiv_ce) equiv_ce = 0.01
+    if (!equiv_brier) equiv_brier = 0.002
+    if (!equiv_mi) equiv_mi = 0.02
+    if (!equiv_split_ce) equiv_split_ce = 0.015
+}
+
+NR == 1 {
+    if (NF != 22 || $1 != "pair" || $2 != "arm" || $5 != "split" ||
+        $15 != "destination_ce_gain" || $19 != "normalized_mi") fail()
+    next
+}
+
+{
+    if (NF != 22 || $1 !~ /^[0-9][0-9]$/ ||
+        $2 !~ /^(event|ecology)$/ || seen[$1 SUBSEP $2]++ ||
+        $5 !~ /^(primary|holdout)$/) fail()
+    for (i = 6; i <= 22; i++) if (!number($i)) fail()
+    ce_gain += $15
+    brier_gain += $16
+    uniform_ce_gain += $17
+    uniform_brier_gain += $18
+    nmi += $19
+    tv += $20
+    destination_entropy += $21
+    target_entropy += $22
+    split_ce[$5] += $15
+    split_n[$5]++
+    if ($15 > 0) ce_wins++
+    else if ($15 < 0) ce_losses++
+    else ce_ties++
+    if ($16 > 0) brier_wins++
+    rows++
+}
+
+END {
+    if (fatal) exit 2
+    if (rows != expected || !split_n["primary"] || !split_n["holdout"])
+        fail()
+    mean_ce = ce_gain / rows
+    mean_brier = brier_gain / rows
+    mean_nmi = nmi / rows
+    primary_ce = split_ce["primary"] / split_n["primary"]
+    holdout_ce = split_ce["holdout"] / split_n["holdout"]
+    if (ce_wins >= win_required && mean_ce >= ce_required &&
+        mean_brier >= brier_required && primary_ce > 0 && holdout_ce > 0 &&
+        mean_nmi >= mi_required)
+        result = "conditional-road-supported"
+    else if (abs(mean_ce) <= equiv_ce && abs(mean_brier) <= equiv_brier &&
+             mean_nmi <= equiv_mi && abs(primary_ce) <= equiv_split_ce &&
+             abs(holdout_ce) <= equiv_split_ce)
+        result = "destination-prior-equivalent"
+    else
+        result = "conditional-road-unresolved"
+
+    print "eligible_arms " rows
+    print "primary_arms " split_n["primary"]
+    print "holdout_arms " split_n["holdout"]
+    print "conditional_ce_wins " ce_wins + 0
+    print "conditional_ce_losses " ce_losses + 0
+    print "conditional_ce_ties " ce_ties + 0
+    print "conditional_brier_wins " brier_wins + 0
+    print "mean_destination_ce_gain " sprintf("%.9f", mean_ce)
+    print "mean_destination_brier_gain " sprintf("%.9f", mean_brier)
+    print "mean_uniform_ce_gain " sprintf("%.9f", uniform_ce_gain / rows)
+    print "mean_uniform_brier_gain " sprintf("%.9f", uniform_brier_gain / rows)
+    print "primary_destination_ce_gain " sprintf("%.9f", primary_ce)
+    print "holdout_destination_ce_gain " sprintf("%.9f", holdout_ce)
+    print "mean_normalized_mi " sprintf("%.9f", mean_nmi)
+    print "mean_row_tv " sprintf("%.9f", tv / rows)
+    print "mean_destination_entropy " sprintf("%.9f", destination_entropy / rows)
+    print "mean_target_entropy " sprintf("%.9f", target_entropy / rows)
+    print "required_ce_wins " win_required
+    print "required_mean_ce_gain " sprintf("%.9f", ce_required)
+    print "required_mean_brier_gain " sprintf("%.9f", brier_required)
+    print "required_mean_normalized_mi " sprintf("%.9f", mi_required)
+    print "result " result
+}

--- a/scripts/test_state_swarm_road_information_fixture.sh
+++ b/scripts/test_state_swarm_road_information_fixture.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-road-information-fixture.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+"${CC:-cc}" "$ROOT/tests/state_swarm_road_information_fixture.c" \
+    -O2 -lm -Wall -Wextra -Wno-unused-function \
+    -o "$TMP/road-information-fixture" -lpthread
+set +e
+"$TMP/road-information-fixture" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || {
+    printf 'road information fixture accepted missing arguments: rc=%s\n' \
+        "$rc" >&2
+    exit 1
+}
+
+printf 'state-swarm road information fixture: ok\n'

--- a/scripts/test_state_swarm_road_information_report.sh
+++ b/scripts/test_state_swarm_road_information_report.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-road-information-report.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+HASH='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turns\tpre_sha\tpost_sha\tsource_log_sha\treplay_log_sha\tnormalized_sha\ta92_reply_equal\ta92_state_equal\tnext_log_equal\tgeometry_equal\n' > "$TMP/locks.tsv"
+lock() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\ttrue\ttrue\ttrue\ttrue\n' \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$((96 - $6))" \
+        "$HASH" "$HASH" "$HASH" "$HASH" "$HASH"
+}
+lock 01 event p01-t050 p01 primary 50 >> "$TMP/locks.tsv"
+lock 01 ecology p11-t050 p11 primary 50 >> "$TMP/locks.tsv"
+lock 02 event h01-t060 h01 holdout 60 >> "$TMP/locks.tsv"
+lock 02 ecology h11-t060 h11 holdout 60 >> "$TMP/locks.tsv"
+
+matrix() {
+    local kind="$1" out='' separator='' value
+    local i j
+    for ((i = 0; i < 8; i++)); do
+        for ((j = 0; j < 8; j++)); do
+            value=1
+            if [ "$kind" = identity ] && [ "$i" -ne "$j" ]; then
+                value=0
+            fi
+            out+="${separator}${value}"
+            separator='/'
+        done
+    done
+    printf '%s' "$out"
+}
+
+IDENTITY="$(matrix identity)"
+RANK_ONE="$(matrix rank-one)"
+ONE_HOT='1/0/0/0/0/0/0/0'
+UNIFORM='0.125/0.125/0.125/0.125/0.125/0.125/0.125/0.125'
+HEADER='pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turn\ttexture\ttransition\tanchor_activation\ttarget_activation\tconditional_prediction\tdestination_prior\ttransition_total\tdestination_entropy\tmutual_information\tnormalized_mi\tmean_row_tv\tconditional_ce\tdestination_ce\tuniform_ce\tpersistence_ce\tconditional_brier\tdestination_brier\tuniform_brier\tpersistence_brier\tprompt\treply'
+printf '%b\n' "$HEADER" > "$TMP/supported.tsv"
+printf '%b\n' "$HEADER" > "$TMP/equivalent.tsv"
+
+score_supported() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\thome\t%s\t%s\t%s\t%s\t%s\t8\t2.079441542\t2.079441542\t1.000000000\t0.875000000\t0.000000000\t2.079441542\t2.079441542\t0.000000000\t0.000000000\t0.875000000\t0.875000000\t0.000000000\tprompt %s\treply %s\n' \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$(( $6 + 1 ))" \
+        "$IDENTITY" "$ONE_HOT" "$ONE_HOT" "$ONE_HOT" "$UNIFORM" \
+        "$1" "$2"
+}
+
+score_equivalent() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\thome\t%s\t%s\t%s\t%s\t%s\t64\t2.079441542\t0.000000000\t0.000000000\t0.000000000\t2.079441542\t2.079441542\t2.079441542\t0.000000000\t0.875000000\t0.875000000\t0.875000000\t0.000000000\tprompt %s\treply %s\n' \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$(( $6 + 1 ))" \
+        "$RANK_ONE" "$ONE_HOT" "$ONE_HOT" "$UNIFORM" "$UNIFORM" \
+        "$1" "$2"
+}
+
+score_supported 01 event p01-t050 p01 primary 50 >> "$TMP/supported.tsv"
+score_supported 01 ecology p11-t050 p11 primary 50 >> "$TMP/supported.tsv"
+score_supported 02 event h01-t060 h01 holdout 60 >> "$TMP/supported.tsv"
+score_supported 02 ecology h11-t060 h11 holdout 60 >> "$TMP/supported.tsv"
+
+score_equivalent 01 event p01-t050 p01 primary 50 >> "$TMP/equivalent.tsv"
+score_equivalent 01 ecology p11-t050 p11 primary 50 >> "$TMP/equivalent.tsv"
+score_equivalent 02 event h01-t060 h01 holdout 60 >> "$TMP/equivalent.tsv"
+score_equivalent 02 ecology h11-t060 h11 holdout 60 >> "$TMP/equivalent.tsv"
+
+report() {
+    local scores="$1" stem="$2"
+    awk -v expected=4 \
+        -f "$ROOT/scripts/state_swarm_road_information_report.awk" \
+        "$TMP/locks.tsv" "$scores" > "$TMP/$stem-summary.tsv"
+    awk -v expected=4 -v win_required=3 \
+        -f "$ROOT/scripts/state_swarm_road_information_verdict.awk" \
+        "$TMP/$stem-summary.tsv" > "$TMP/$stem-verdict.txt"
+}
+
+report "$TMP/supported.tsv" supported
+grep -q '^result conditional-road-supported$' "$TMP/supported-verdict.txt"
+grep -q '^conditional_ce_wins 4$' "$TMP/supported-verdict.txt"
+
+report "$TMP/equivalent.tsv" equivalent
+grep -q '^result destination-prior-equivalent$' "$TMP/equivalent-verdict.txt"
+grep -q '^mean_normalized_mi 0.000000000$' "$TMP/equivalent-verdict.txt"
+
+awk -F '\t' 'BEGIN { OFS=FS } NR == 2 { $19 = "0.100000000" } { print }' \
+    "$TMP/supported.tsv" > "$TMP/false-score.tsv"
+if awk -v expected=4 \
+    -f "$ROOT/scripts/state_swarm_road_information_report.awk" \
+    "$TMP/locks.tsv" "$TMP/false-score.tsv" >/dev/null 2>&1; then
+    printf 'road information reporter accepted a false proper score\n' >&2
+    exit 1
+fi
+
+sed '2s/true$/false/' "$TMP/locks.tsv" > "$TMP/open-lock.tsv"
+if awk -v expected=4 \
+    -f "$ROOT/scripts/state_swarm_road_information_report.awk" \
+    "$TMP/open-lock.tsv" "$TMP/supported.tsv" >/dev/null 2>&1; then
+    printf 'road information reporter accepted an open replay lock\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm road information reporters: ok\n'

--- a/tests/state_swarm_road_information_fixture.c
+++ b/tests/state_swarm_road_information_fixture.c
@@ -1,0 +1,295 @@
+#define LEO_NO_MAIN
+#include <errno.h>
+#include "../leo.c"
+
+static Leo *load_leo(const char *path) {
+    Leo *leo = malloc(sizeof *leo);
+    if (!leo) return NULL;
+    leo_init(leo);
+    if (!leo_load_state(leo, path)) {
+        leo_free(leo);
+        free(leo);
+        return NULL;
+    }
+    return leo;
+}
+
+static void destroy_leo(Leo *leo) {
+    if (!leo) return;
+    leo_free(leo);
+    free(leo);
+}
+
+static int parse_u64(const char *text, uint64_t *value) {
+    char *end = NULL;
+    errno = 0;
+    unsigned long long parsed = strtoull(text, &end, 10);
+    if (errno || !end || *end) return 0;
+    *value = (uint64_t)parsed;
+    return 1;
+}
+
+static int parse_long(const char *text, long *value) {
+    char *end = NULL;
+    errno = 0;
+    long parsed = strtol(text, &end, 10);
+    if (errno || !end || *end) return 0;
+    *value = parsed;
+    return 1;
+}
+
+static int parse_float(const char *text, float *value) {
+    char *end = NULL;
+    errno = 0;
+    float parsed = strtof(text, &end);
+    if (errno || !end || *end || !isfinite(parsed)) return 0;
+    *value = parsed;
+    return 1;
+}
+
+static int parse_organs(const char *text, float organ[LEO_STATE_ORGANS]) {
+    char copy[512];
+    size_t len = strlen(text);
+    if (!len || len >= sizeof copy) return 0;
+    memcpy(copy, text, len + 1);
+    char *cursor = copy;
+    for (int i = 0; i < LEO_STATE_ORGANS; i++) {
+        char *slash = strchr(cursor, '/');
+        if (i + 1 < LEO_STATE_ORGANS) {
+            if (!slash) return 0;
+            *slash = 0;
+        } else if (slash) {
+            return 0;
+        }
+        if (!parse_float(cursor, &organ[i]) || organ[i] < 0.0f ||
+            organ[i] > 1.001f)
+            return 0;
+        if (slash) cursor = slash + 1;
+    }
+    return 1;
+}
+
+static int visible_reply_equal(const char *reply, const char *expected) {
+    size_t n = strcspn(reply, "\r\n\t");
+    return strlen(expected) == n && !memcmp(reply, expected, n);
+}
+
+static int capture_observation(
+        const char *state_path, uint64_t expected_turn, long seed,
+        const char *prompt, const char *expected_reply,
+        uint64_t expected_nearest_id, float expected_similarity,
+        const float expected_organs[LEO_STATE_ORGANS],
+        LeoStateWeight stable[LEO_STATE_SWARM_MAX],
+        LeoStateWeight *observation) {
+    srand((unsigned)seed);
+    Leo *leo = load_leo(state_path);
+    if (!leo || !leo->state_swarm ||
+        leo->state_swarm->n != LEO_STATE_SWARM_MAX) {
+        destroy_leo(leo);
+        return 0;
+    }
+    memcpy(stable, leo->state_swarm->weights,
+           sizeof(LeoStateWeight) * LEO_STATE_SWARM_MAX);
+    leo_state_swarm_clear(leo->state_swarm);
+    char reply[4096];
+    leo_respond(leo, prompt, reply, sizeof reply);
+    if (!visible_reply_equal(reply, expected_reply) ||
+        leo->state_swarm->n != 1 ||
+        leo->state_swarm_receipt.event != LEO_STATE_SWARM_BORN ||
+        leo->state_swarm_receipt.turn != expected_turn) {
+        destroy_leo(leo);
+        return 0;
+    }
+    *observation = leo->state_swarm->weights[0];
+
+    int best = 0;
+    float best_similarity = -1.0f;
+    float best_organs[LEO_STATE_ORGANS] = {0};
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        float organs[LEO_STATE_ORGANS];
+        float similarity = leo_state_similarity_components(
+            &stable[i], observation, organs);
+        if (similarity > best_similarity) {
+            best = i;
+            best_similarity = similarity;
+            memcpy(best_organs, organs, sizeof best_organs);
+        }
+    }
+    int exact = stable[best].id == expected_nearest_id &&
+        fabsf(best_similarity - expected_similarity) <= 0.0015f;
+    for (int i = 0; i < LEO_STATE_ORGANS; i++)
+        if (fabsf(best_organs[i] - expected_organs[i]) > 0.00002f)
+            exact = 0;
+    destroy_leo(leo);
+    return exact;
+}
+
+static void activation_for(
+        const LeoStateWeight stable[LEO_STATE_SWARM_MAX],
+        const LeoStateWeight *observation,
+        double activation[LEO_STATE_SWARM_MAX]) {
+    double similarity[LEO_STATE_SWARM_MAX];
+    double best = -1.0;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        similarity[i] = leo_state_similarity_components(
+            &stable[i], observation, NULL);
+        if (similarity[i] > best) best = similarity[i];
+    }
+    double total = 0.0;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        activation[i] = exp((similarity[i] - best) / 0.12);
+        total += activation[i];
+    }
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++)
+        activation[i] /= total;
+}
+
+static double entropy(const double value[LEO_STATE_SWARM_MAX]) {
+    double result = 0.0;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++)
+        if (value[i] > 0.0) result -= value[i] * log(value[i]);
+    return result;
+}
+
+static double cross_entropy(const double target[LEO_STATE_SWARM_MAX],
+                            const double prediction[LEO_STATE_SWARM_MAX]) {
+    double result = 0.0;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++)
+        result -= target[i] * log(fmax(prediction[i], 1e-6));
+    return result;
+}
+
+static double brier(const double target[LEO_STATE_SWARM_MAX],
+                    const double prediction[LEO_STATE_SWARM_MAX]) {
+    double result = 0.0;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        double delta = target[i] - prediction[i];
+        result += delta * delta;
+    }
+    return result;
+}
+
+static void print_vector(const double value[LEO_STATE_SWARM_MAX]) {
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++)
+        printf("%s%.9f", i ? "/" : "", value[i]);
+}
+
+static void print_matrix(
+        const float value[LEO_STATE_SWARM_MAX][LEO_STATE_SWARM_MAX]) {
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++)
+        for (int j = 0; j < LEO_STATE_SWARM_MAX; j++)
+            printf("%s%.9f", i || j ? "/" : "", (double)value[i][j]);
+}
+
+int main(int argc, char **argv) {
+    if (argc != 23) return 2;
+    uint64_t anchor_turn = 0, future_turn = 0;
+    uint64_t anchor_nearest = 0, future_nearest = 0;
+    long anchor_seed = 0, future_seed = 0;
+    float anchor_similarity = 0.0f, future_similarity = 0.0f;
+    float anchor_organs[LEO_STATE_ORGANS];
+    float future_organs[LEO_STATE_ORGANS];
+    if (!parse_u64(argv[6], &anchor_turn) ||
+        !parse_u64(argv[7], &future_turn) || future_turn != anchor_turn + 1 ||
+        !parse_long(argv[9], &anchor_seed) ||
+        !parse_u64(argv[13], &anchor_nearest) ||
+        !parse_float(argv[14], &anchor_similarity) ||
+        !parse_organs(argv[15], anchor_organs) ||
+        !parse_long(argv[16], &future_seed) ||
+        !parse_u64(argv[20], &future_nearest) ||
+        !parse_float(argv[21], &future_similarity) ||
+        !parse_organs(argv[22], future_organs))
+        return 2;
+
+    Leo *body = load_leo(argv[12]);
+    if (!body || !body->state_swarm ||
+        body->state_swarm->n != LEO_STATE_SWARM_MAX) {
+        destroy_leo(body);
+        return 1;
+    }
+    float transition[LEO_STATE_SWARM_MAX][LEO_STATE_SWARM_MAX];
+    memcpy(transition, body->state_swarm->transition, sizeof transition);
+    destroy_leo(body);
+
+    LeoStateWeight stable[LEO_STATE_SWARM_MAX];
+    LeoStateWeight anchor_observation;
+    if (!capture_observation(argv[12], anchor_turn, anchor_seed,
+                             argv[10], argv[11], anchor_nearest,
+                             anchor_similarity, anchor_organs, stable,
+                             &anchor_observation))
+        return 1;
+    LeoStateWeight future_stable[LEO_STATE_SWARM_MAX];
+    LeoStateWeight future_observation;
+    if (!capture_observation(argv[19], future_turn, future_seed,
+                             argv[17], argv[18], future_nearest,
+                             future_similarity, future_organs, future_stable,
+                             &future_observation))
+        return 1;
+
+    double anchor[LEO_STATE_SWARM_MAX];
+    double target[LEO_STATE_SWARM_MAX];
+    double conditional[LEO_STATE_SWARM_MAX] = {0};
+    double destination[LEO_STATE_SWARM_MAX] = {0};
+    double uniform[LEO_STATE_SWARM_MAX];
+    double row[LEO_STATE_SWARM_MAX] = {0};
+    activation_for(stable, &anchor_observation, anchor);
+    activation_for(stable, &future_observation, target);
+    double total = 0.0;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++)
+        for (int j = 0; j < LEO_STATE_SWARM_MAX; j++) {
+            double edge = transition[i][j];
+            row[i] += edge;
+            destination[j] += edge;
+            conditional[j] += anchor[i] * edge;
+            total += edge;
+        }
+    double conditional_total = 0.0;
+    for (int j = 0; j < LEO_STATE_SWARM_MAX; j++)
+        conditional_total += conditional[j];
+    if (total <= 0.0 || conditional_total <= 0.0) return 1;
+    for (int j = 0; j < LEO_STATE_SWARM_MAX; j++) {
+        conditional[j] /= conditional_total;
+        destination[j] /= total;
+        uniform[j] = 1.0 / LEO_STATE_SWARM_MAX;
+    }
+
+    double destination_entropy = entropy(destination);
+    double information = 0.0;
+    double mean_row_tv = 0.0;
+    for (int i = 0; i < LEO_STATE_SWARM_MAX; i++) {
+        if (row[i] <= 0.0) continue;
+        double tv = 0.0;
+        for (int j = 0; j < LEO_STATE_SWARM_MAX; j++) {
+            double edge = transition[i][j];
+            if (edge > 0.0 && destination[j] > 0.0)
+                information += (edge / total) *
+                    log(edge / (row[i] * destination[j]));
+            tv += fabs(edge / row[i] - destination[j]);
+        }
+        mean_row_tv += (row[i] / total) * 0.5 * tv;
+    }
+    double normalized_information = destination_entropy > 0.0 ?
+        information / destination_entropy : 0.0;
+
+    printf("%s\t%s\t%s\t%s\t%s\t%llu\t%llu\t%s\t",
+           argv[1], argv[2], argv[3], argv[4], argv[5],
+           (unsigned long long)anchor_turn,
+           (unsigned long long)future_turn, argv[8]);
+    print_matrix(transition);
+    putchar('\t');
+    print_vector(anchor);
+    putchar('\t');
+    print_vector(target);
+    putchar('\t');
+    print_vector(conditional);
+    putchar('\t');
+    print_vector(destination);
+    printf("\t%.9f\t%.9f\t%.9f\t%.9f\t%.9f\t%.9f\t%.9f\t%.9f\t%.9f\t%.9f\t%.9f\t%.9f\t%.9f\t%s\t%s\n",
+           total, destination_entropy, information, normalized_information,
+           mean_row_tv, cross_entropy(target, conditional),
+           cross_entropy(target, destination),
+           cross_entropy(target, uniform), cross_entropy(target, anchor),
+           brier(target, conditional), brier(target, destination),
+           brier(target, uniform), brier(target, anchor), argv[17], argv[18]);
+    return 0;
+}


### PR DESCRIPTION
## What changed

- add the A.95 frozen road-information fixture and matrix runner over all 30 A.94 replay-locked arms
- score the complete conditional transition forecast against destination-prior, uniform, and persistence baselines with cross-entropy and Brier score
- independently reconstruct mutual information, normalized mutual information, and mean row total variation
- add fail-closed synthetic contracts for conditional, rank-one, forged-score, and open-lock cases
- record the canonical evidence and deterministic receipt in LEOLOG.md and scripts/ADAPTIVE_PROBE.md

## Result

A.95 is conditional-road-unresolved: conditional CE wins 23/30 arms, mean destination-prior CE gain is +0.006790 nat, normalized mutual information is 0.020155, and mean row total variation is 0.104334. The graph is not rank one, but its conditional structure changes prediction too weakly to justify a runtime reader.

leo.c and Leo's speech are unchanged.

## Validation

- make test: 549/549 C tests plus all script contracts
- deterministic aggregate-only replays
- git diff --check
- no diff in leo.c