### PR TITLE
Test state-road readout transfer

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -7894,3 +7894,62 @@ unused life population before any reader enters the organism.
 
 The road is not blank. Leo still needs to learn which part of himself is
 walking it.
+
+## Phase A.96 - a louder state is not necessarily a better guide (2026-08-10)
+
+A.95 left two live explanations. The transition matrix might contain only a
+weak road, or a useful road might be blurred because the source activation is
+broad. A.96 gives the second explanation its strongest fair trial without
+letting it touch Leo.
+
+The trial has a one-way boundary. Twelve primary A.95 arms may choose among
+four power sharpenings and four top-k projections. A.95 holdout remains
+unopened. The chosen rule then faces 15 A.91 organism controls whose road
+predictions have never been scored: nine new turns inside primary bodies and
+six turns inside holdout bodies. Their prompts, replies, pre/post bodies, and
+next observations were fixed earlier in the experiment, before A.96 existed.
+
+Two discovery candidates pass. `power-3` wins selection:
+
+```text
+discovery wins                              8/12
+raw CE gain                            +0.007235 nat
+raw Brier gain                         +0.001894
+destination-prior CE gain              +0.017932
+```
+
+It does not survive confirmation:
+
+```text
+validation wins                             3/15
+raw CE gain                            -0.007808 nat
+raw Brier gain                         -0.002482
+primary / holdout raw CE gain          -0.005543 / -0.011206
+formal result                           readout-sharpening-not-confirmed
+```
+
+This is not a single unlucky rule. All eight fixed transformations lose on the
+unused controls. `power-1.25`, the gentlest intervention, wins only four arms
+and loses `0.000619` nat; power `1.5`, `2`, and `3` become progressively more
+harmful. Top-k removal is worse still.
+
+Discovery itself was not merely a crossing label. `power-3` improves the six
+event arms by `0.006641` nat and the six ecology arms by `0.007828`. What fails
+is transport from those selected anchors to other near-gate moments. A broad
+source activation therefore is not a universal defect. Concentrating it makes
+the graph more certain where certainty was not earned.
+
+The canonical evidence is
+`/private/tmp/leo-state-swarm-road-readout-a96-r1-20260810`. Every validation
+anchor and exact next turn is independently regenerated from sealed A.91
+bodies. The scorer sees full matrices and probability vectors, reconstructs
+raw and transformed forecasts, and refuses forged scores or a validation row
+wearing a discovery identity. Reaggregation is byte-identical.
+
+No line of `leo.c`, no persisted state, and no spoken word changed. A.97 should
+not ask how loudly a present state speaks. It should ask what evidence gives a
+particular transition row the right to speak: row mass, departure from the
+destination prior, and realized predictive contribution can be measured
+before any confidence gate is imagined.
+
+Leo's states did not need a sharper mouth. His roads need witnesses.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq ($(wildcard $(AML_SRC)),)   # the ONLY AML source is the vendored copy in 
   AML_FLAGS := -DHAVE_AML -Iariannamethod
 endif
 
-.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls state-swarm-liminal-confirmation state-swarm-liminal-trace state-swarm-transition-consequence state-swarm-road-information visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
+.PHONY: all test asan tsan clean run dialogue-probe life-probe adaptive-probe state-swarm-ecology state-swarm-road-calibration state-swarm-alphabet state-swarm-organs state-swarm-settled-organs state-swarm-displacement-return state-swarm-displacement-anatomy state-swarm-displacement-incidence state-swarm-prospective-incidence state-swarm-balanced-event-reservoir state-swarm-trigger-gate-anatomy state-swarm-near-gate-controls state-swarm-liminal-confirmation state-swarm-liminal-trace state-swarm-transition-consequence state-swarm-road-information state-swarm-road-readout visible-branch-probe visible-branch-matrix visible-resonance-matrix deferred-wonder-matrix deferred-wonder-ecology deferred-wonder-constellation deferred-wonder-semantics deferred-wonder-attribution deferred-wonder-redirection deferred-wonder-appetite deferred-wonder-appetite-calibration deferred-wonder-appetite-reliability deferred-wonder-appetite-drift deferred-wonder-appetite-policy deferred-wonder-appetite-regret deferred-wonder-appetite-readiness deferred-wonder-appetite-holdout deferred-wonder-appetite-admission deferred-wonder-appetite-transport deferred-wonder-appetite-transport-chronology deferred-wonder-appetite-checkpoint deferred-wonder-appetite-checkpoint-life deferred-wonder-appetite-source-ecology-life deferred-wonder-appetite-cadence-life deferred-wonder-appetite-source-cadence-life deferred-wonder-appetite-shift-anatomy deferred-wonder-appetite-visible-signal deferred-wonder-appetite-natural-life deferred-wonder-appetite-temporal-counterfactual deferred-wonder-appetite-exchange-attribution deferred-wonder-appetite-external-life deferred-wonder-appetite-provenance-shadow deferred-wonder-appetite-matched-counterfactual deferred-wonder-appetite-population-causal-lift deferred-wonder-appetite-susceptibility-holdout deferred-wonder-appetite-flom-third-life deferred-wonder-father-path-localization deferred-wonder-capsule-path-factorial deferred-wonder-capsule-interaction-population deferred-wonder-negation-life deferred-wonder-answer-reference-life deferred-wonder-answer-scope-life deferred-wonder-comma-scope-life
 
 all: leo
 
@@ -84,6 +84,9 @@ state-swarm-transition-consequence: leo
 
 state-swarm-road-information: leo
 	./scripts/state_swarm_road_information_matrix.sh
+
+state-swarm-road-readout: leo
+	./scripts/state_swarm_road_readout_matrix.sh
 
 visible-branch-probe: leo
 	LEO_VISIBLE_BRANCH_POLICY=local-v1 ./scripts/adaptive_life_probe.sh scripts/visible_branch_phases.txt
@@ -261,6 +264,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_state_swarm_transition_consequence_fixture.sh
 	./scripts/test_state_swarm_road_information_report.sh
 	./scripts/test_state_swarm_road_information_fixture.sh
+	./scripts/test_state_swarm_road_readout_report.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_report.sh
 	./scripts/test_state_swarm_trigger_gate_anatomy_matrix.sh
 	./scripts/test_state_swarm_near_gate_controls_select.sh

--- a/scripts/ADAPTIVE_PROBE.md
+++ b/scripts/ADAPTIVE_PROBE.md
@@ -1711,3 +1711,76 @@ from this result. A.96 should shadow several source-activation readouts,
 select any sharpening or sparsification rule on primary arms only, then test
 it on a genuinely unused same-life control population before proposing a
 reader.
+
+## A.96: sharpening finds the selected anchors, not a general road
+
+Run the frozen readout study:
+
+```sh
+make state-swarm-road-readout
+```
+
+A.96 never inspects A.95 holdout. Discovery consists only of the 12 A.95
+primary event/ecology arms. Confirmation uses the 15 followable organism
+controls selected and replay-locked in A.91 but never scored for road
+information: nine different turns in primary bodies and six different turns
+in holdout bodies. Four final-turn controls are censored before outcomes.
+
+Eight readouts are fixed before scoring. Four raise the source activation to
+powers `1.25`, `1.5`, `2`, and `3`; four retain only its largest `4`, `3`, `2`,
+or `1` coordinates. Each transformed source is normalized, multiplied through
+the unchanged frozen 8x8 transition matrix, and scored against the exact next
+lived observation. No matrix edge, coordinate, temperature, or body changes.
+
+Discovery nominates a candidate only with at least `8/12` CE wins, mean CE
+gain over raw of `0.005` nat, positive Brier gain, and mean CE gain over the
+destination prior of `0.015` nat. Confirmation requires at least `10/15` CE
+wins, raw CE/Brier gains of `0.005`/`0.001`, a destination-prior gain of
+`0.015`, and positive raw CE gain in both validation splits.
+
+The canonical run is
+`/private/tmp/leo-state-swarm-road-readout-a96-r1-20260810`:
+
+```text
+discovery candidates passing                 2
+selected readout                       power-3
+discovery CE wins                          8/12
+discovery raw CE / Brier gain       +0.007235 / +0.001894
+discovery destination CE gain          +0.017932
+
+validation arms                       15 (9 primary, 6 holdout)
+validation CE wins                           3/15
+validation raw CE / Brier gain       -0.007808 / -0.002482
+validation destination CE gain          -0.008331
+validation primary / holdout gain       -0.005543 / -0.011206
+result                              readout-sharpening-not-confirmed
+```
+
+The discovery effect is not carried by one family: `power-3` gains
+`+0.006641` nat on events and `+0.007828` on ecology arms. But every fixed
+candidate harms the unused validation population on average. Even the mild
+`power-1.25` readout wins only `4/15` controls and loses `0.000619` nat.
+Increasing sharpness makes the validation loss monotonically worse.
+
+Thus A.95 did not reveal a universally correct source signal diluted across
+too many active coordinates. Its small advantage belongs to the selected
+anchor ecology and cannot justify a lower activation temperature, a power
+transform, or a top-k reader. The road's rows may differ in evidential
+authority; source concentration alone cannot identify which rows deserve to
+predict.
+
+Every validation anchor and next observation is regenerated through the A.95
+C witness from its sealed A.91 pre/post body. The reporter reconstructs the
+raw forecast and all eight candidates from the full matrix and vectors.
+Identity-road and rank-one contracts prove nomination and refusal; forged
+scores and cohort leakage fail closed. Aggregate-only reconstruction preserves
+candidate-summary SHA-256
+`ea02391667f990026695925d2c09c9a6593dddaafacd70219c71fa8f3586ceeb`
+and verdict SHA-256
+`f8ae9b99d2db6817b2f7d7507c7958546e7fb0ebeb980a0807d4795262394f56`.
+
+A.96 changes no C code, state body, activation temperature, transition law,
+sampler, routing path, generation path, or speech. Do not sharpen the source
+readout. A.97 should remain anatomical: measure active row mass, row divergence
+from the destination prior, and each row's realized contribution before asking
+whether evidence-aware route authority is separable from anchor selection.

--- a/scripts/state_swarm_road_readout_matrix.sh
+++ b/scripts/state_swarm_road_readout_matrix.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# A.96: test source-readout dilution without changing Leo's road or voice.
+set -Eeuo pipefail
+
+trap 'rc=$?; printf "road readout runner failed: line=%s rc=%s command=%s\n" "$LINENO" "$rc" "$BASH_COMMAND" >&2; exit "$rc"' ERR
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CC="${CC:-cc}"
+A89="${LEO_STATE_READOUT_A89_SOURCE:-/private/tmp/leo-state-swarm-balanced-event-reservoir-a89-r1-20260807}"
+A91="${LEO_STATE_READOUT_A91_SOURCE:-/private/tmp/leo-state-swarm-near-gate-controls-a91-r2-20260807}"
+A95="${LEO_STATE_READOUT_A95_SOURCE:-/private/tmp/leo-state-swarm-road-information-a95-r1-20260810}"
+DISCOVERY_EXPECTED="${LEO_STATE_READOUT_DISCOVERY_EXPECTED:-12}"
+VALIDATION_EXPECTED="${LEO_STATE_READOUT_VALIDATION_EXPECTED:-15}"
+AGGREGATE_ONLY="${LEO_STATE_READOUT_AGGREGATE_ONLY:-0}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-state-swarm-road-readout-$STAMP}"
+
+A95_SCORES="$A95/scores.tsv"
+A91_CONTROLS="$A91/controls.tsv"
+A91_LOCKS="$A91/control-replay-locks.tsv"
+WRITER_RECEIPTS="$A89/writer-receipts.tsv"
+EXPECTED_A95_SCORES_SHA="${LEO_STATE_READOUT_A95_SCORES_SHA:-1406b654ef7fdf21b8d2511c55f90d24a4181abda6572a788a04a54249be3ae0}"
+EXPECTED_A91_CONTROLS_SHA="${LEO_STATE_READOUT_A91_CONTROLS_SHA:-50e4b6f513a6ddfe375b69c0246005fd4f9990542d2d15790cc64fb9e871bab5}"
+EXPECTED_A91_LOCKS_SHA="${LEO_STATE_READOUT_A91_LOCKS_SHA:-1d28607ea891338403f8ed2c94c3f935752afe7680dedf42b70a8106cfb07321}"
+EXPECTED_WRITER_SHA="${LEO_STATE_READOUT_WRITER_SHA:-10bf4251848f4edaec4a34d66d3d811afff187df9f10aeb71ff761a342c0e833}"
+
+case "$DISCOVERY_EXPECTED:$VALIDATION_EXPECTED" in
+    *[!0-9:]*|0:*|*:0) printf 'invalid road readout dimensions\n' >&2; exit 2 ;;
+esac
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+seal() {
+    local path="$1" expected="$2" label="$3"
+    [ -s "$path" ] && [ "$(sha256_file "$path")" = "$expected" ] || {
+        printf '%s is not the sealed source: %s\n' "$label" "$path" >&2
+        exit 2
+    }
+}
+
+seal "$A95_SCORES" "$EXPECTED_A95_SCORES_SHA" "A.95 scores"
+seal "$A91_CONTROLS" "$EXPECTED_A91_CONTROLS_SHA" "A.91 controls"
+seal "$A91_LOCKS" "$EXPECTED_A91_LOCKS_SHA" "A.91 control locks"
+seal "$WRITER_RECEIPTS" "$EXPECTED_WRITER_SHA" "A.89 writer receipts"
+
+CANDIDATES="$OUT/candidates.tsv"
+DISCOVERY="$OUT/discovery-witnesses.tsv"
+PLAN="$OUT/validation-plan.tsv"
+LOCKS="$OUT/validation-locks.tsv"
+VALIDATION="$OUT/validation-witnesses.tsv"
+SCORES="$OUT/readout-scores.tsv"
+SUMMARY="$OUT/candidate-summary.tsv"
+SELECTION="$OUT/selection.tsv"
+VERDICT="$OUT/verdict.txt"
+
+write_candidates() {
+    printf 'candidate\tkind\tparameter\trank\n'
+    printf 'power-1p25\tpower\t1.25\t1\n'
+    printf 'power-1p50\tpower\t1.50\t2\n'
+    printf 'power-2p00\tpower\t2.00\t3\n'
+    printf 'power-3p00\tpower\t3.00\t4\n'
+    printf 'top-4\ttopk\t4\t5\n'
+    printf 'top-3\ttopk\t3\t6\n'
+    printf 'top-2\ttopk\t2\t7\n'
+    printf 'top-1\ttopk\t1\t8\n'
+}
+
+write_plan() {
+    awk -F '\t' -v OFS='\t' -v a91="$A91" \
+        -v expected="$VALIDATION_EXPECTED" '
+        FILENAME == ARGV[1] {
+            if (FNR == 1) {
+                if (NF != 21 || $1 != "control" || $3 != "family" ||
+                    $12 != "precontrol_sha" || $21 != "reply_equal") exit 2
+                next
+            }
+            if ($3 != "organism" || $7 >= 96) next
+            key = $1
+            if (seen_lock[key]++ || $5 !~ /^(primary|holdout)$/) exit 2
+            for (i = 17; i <= 21; i++) if ($i != "true") exit 2
+            pair[key] = $2; life[key] = $4; split_name[key] = $5
+            base[key] = $6; turn[key] = $7; session[key] = $8
+            order[key] = $9; texture[key] = $10; seed[key] = $11
+            pre_sha[key] = $12; post_sha[key] = $13
+            log_sha[key] = $14
+            locks++
+            next
+        }
+        FNR == 1 {
+            if (NF != 16 || $1 != "control" || $3 != "family" ||
+                $13 != "prompt" || $16 != "source_log_sha") exit 2
+            print "control", "pair", "life", "split", "base_seed", \
+                "turn", "session", "order", "texture", "run_seed", \
+                "prompt", "reply", "pre_state", "post_state", \
+                "pre_sha", "post_sha", "source_log", "source_log_sha"
+            next
+        }
+        $1 in pair {
+            key = $1
+            if ($2 != pair[key] || $3 != "organism" || $4 != life[key] ||
+                $5 != split_name[key] || $6 != base[key] || $7 != turn[key] ||
+                $8 != session[key] || $9 != order[key] ||
+                $10 != texture[key] || $11 != seed[key] ||
+                $16 != log_sha[key] || emitted[key]++) exit 2
+            print key, pair[key], life[key], split_name[key], base[key], turn[key], \
+                session[key], order[key], texture[key], seed[key], $13, $14, \
+                a91 "/controls/" key "/precontrol.state", \
+                a91 "/controls/" key "/updated.state", pre_sha[key], \
+                post_sha[key], $15, log_sha[key]
+            rows++
+        }
+        END { if (locks != expected || rows != expected) exit 2 }
+    ' "$A91_LOCKS" "$A91_CONTROLS"
+}
+
+write_locks() {
+    awk -F '\t' -v expected="$VALIDATION_EXPECTED" '
+        NR == 1 { print; next }
+        $3 == "organism" && $7 < 96 {
+            for (i = 17; i <= 21; i++) if ($i != "true") exit 2
+            print
+            rows++
+        }
+        END { if (rows != expected) exit 2 }
+    ' "$A91_LOCKS"
+}
+
+write_discovery() {
+    awk -F '\t' -v expected="$DISCOVERY_EXPECTED" '
+        NR == 1 { print; next }
+        $5 == "primary" {
+            if ($2 !~ /^(event|ecology)$/) exit 2
+            print
+            rows++
+        }
+        END { if (rows != expected) exit 2 }
+    ' "$A95_SCORES"
+}
+
+if [ "$AGGREGATE_ONLY" = 1 ]; then
+    for path in "$CANDIDATES" "$DISCOVERY" "$PLAN" "$LOCKS" "$VALIDATION"; do
+        [ -s "$path" ] || {
+            printf 'incomplete road readout run: %s\n' "$OUT" >&2
+            exit 2
+        }
+    done
+    write_candidates | cmp -s - "$CANDIDATES" || {
+        printf 'A.96 candidate ledger diverged\n' >&2
+        exit 2
+    }
+    write_discovery | cmp -s - "$DISCOVERY" || {
+        printf 'A.96 discovery population diverged\n' >&2
+        exit 2
+    }
+    write_plan | cmp -s - "$PLAN" || {
+        printf 'A.96 validation plan diverged\n' >&2
+        exit 2
+    }
+    write_locks | cmp -s - "$LOCKS" || {
+        printf 'A.96 validation locks diverged\n' >&2
+        exit 2
+    }
+else
+    [ ! -e "$OUT" ] || {
+        printf 'output path already exists: %s\n' "$OUT" >&2
+        exit 2
+    }
+    mkdir -p "$OUT"
+    write_candidates > "$CANDIDATES"
+    write_discovery > "$DISCOVERY"
+    write_plan > "$PLAN"
+    write_locks > "$LOCKS"
+fi
+
+if [ "${LEO_STATE_READOUT_PLAN_ONLY:-0}" = 1 ]; then
+    cat "$CANDIDATES"
+    printf '\n'
+    cat "$PLAN"
+    exit 0
+fi
+
+if [ "$AGGREGATE_ONLY" != 1 ]; then
+    FIXTURE="$OUT/road-readout-fixture"
+    "$CC" "$ROOT/tests/state_swarm_road_information_fixture.c" \
+        -O2 -lm -Wall -Wextra -Wno-unused-function -o "$FIXTURE" -lpthread
+    printf 'pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turn\ttexture\ttransition\tanchor_activation\ttarget_activation\tconditional_prediction\tdestination_prior\ttransition_total\tdestination_entropy\tmutual_information\tnormalized_mi\tmean_row_tv\tconditional_ce\tdestination_ce\tuniform_ce\tpersistence_ce\tconditional_brier\tdestination_brier\tuniform_brier\tpersistence_brier\tprompt\treply\n' > "$VALIDATION"
+    while IFS=$'\t' read -r control pair life split base_seed turn session \
+        order texture run_seed prompt reply pre_state post_state pre_sha \
+        post_sha source_log source_log_sha; do
+        [ "$(sha256_file "$pre_state")" = "$pre_sha" ] && \
+            [ "$(sha256_file "$post_state")" = "$post_sha" ] && \
+            [ "$(sha256_file "$source_log")" = "$source_log_sha" ] || {
+            printf 'A.96 validation source drift: %s\n' "$control" >&2
+            exit 2
+        }
+        anchor_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$source_log")"
+        IFS=$'\t' read -r observed_turn observed_event observed_new \
+            observed_similarity observed_members observed_displaced \
+            observed_nearest observed_nearest_organs observed_removed_organs \
+            observed_organs <<< "$anchor_shape"
+        [ "$observed_turn" -eq "$turn" ] && [ "$observed_nearest" -gt 0 ] || {
+            printf 'A.96 anchor geometry mismatch: %s\n' "$control" >&2
+            exit 2
+        }
+
+        next_receipt="$OUT/$control-next.tsv"
+        awk -F '\t' -v life="$life" -v turn="$((turn + 1))" '
+            BEGIN { OFS = "\t" }
+            NR == 1 {
+                if (NF != 34 || $1 != "life" || $5 != "session" ||
+                    $8 != "run_seed" || $9 != "turn" ||
+                    $33 != "prompt" || $34 != "reply") exit 2
+                next
+            }
+            $1 == life && $9 == turn {
+                print $5, $6, $7, $8, $9, $33, $34
+                rows++
+            }
+            END { if (rows != 1) exit 2 }
+        ' "$WRITER_RECEIPTS" > "$next_receipt"
+        IFS=$'\t' read -r next_session next_order next_texture next_seed \
+            next_turn next_prompt next_reply < "$next_receipt"
+        printf -v padded '%02d' "$next_order"
+        next_log="$A89/candidates/$life/writer-logs/s${next_session}-${padded}-${next_texture}.log"
+        next_shape="$(awk -f "$ROOT/scripts/state_swarm_displacement_anatomy_log.awk" "$next_log")"
+        IFS=$'\t' read -r shape_turn shape_event shape_new shape_similarity \
+            shape_members shape_displaced shape_nearest shape_nearest_organs \
+            shape_removed_organs shape_organs <<< "$next_shape"
+        [ "$shape_turn" -eq "$next_turn" ] && [ "$shape_nearest" -gt 0 ] || {
+            printf 'A.96 future geometry mismatch: %s turn=%s\n' \
+                "$control" "$next_turn" >&2
+            exit 2
+        }
+        "$FIXTURE" "$pair" organism "$control" "$life" "$split" "$turn" \
+            "$next_turn" "$next_texture" "$run_seed" "$prompt" "$reply" \
+            "$pre_state" "$observed_nearest" "$observed_similarity" \
+            "$observed_nearest_organs" "$next_seed" "$next_prompt" \
+            "$next_reply" "$post_state" "$shape_nearest" "$shape_similarity" \
+            "$shape_nearest_organs" >> "$VALIDATION"
+        rm -f "$next_receipt"
+    done < <(tail -n +2 "$PLAN")
+    rm -f "$FIXTURE"
+fi
+
+awk -v discovery_expected="$DISCOVERY_EXPECTED" \
+    -v validation_expected="$VALIDATION_EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_road_readout_report.awk" \
+    "$CANDIDATES" "$DISCOVERY" "$VALIDATION" > "$SCORES"
+awk -v discovery_expected="$DISCOVERY_EXPECTED" \
+    -v validation_expected="$VALIDATION_EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_road_readout_summary.awk" \
+    "$SCORES" > "$SUMMARY"
+awk -v expected="$DISCOVERY_EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_road_readout_select.awk" \
+    "$SUMMARY" > "$SELECTION"
+awk -v expected="$VALIDATION_EXPECTED" \
+    -f "$ROOT/scripts/state_swarm_road_readout_verdict.awk" \
+    "$SELECTION" "$SUMMARY" > "$VERDICT"
+
+cat "$SUMMARY"
+printf '\n'
+cat "$SELECTION"
+printf '\n'
+cat "$VERDICT"
+printf '\nsource-a91: %s\nsource-a95: %s\nrun: %s\n' "$A91" "$A95" "$OUT"

--- a/scripts/state_swarm_road_readout_report.awk
+++ b/scripts/state_swarm_road_readout_report.awk
@@ -1,0 +1,226 @@
+# A.96: reconstruct each transformed source readout from full witnesses.
+
+function fail() { fatal = 1; exit 2 }
+function integer(value) { return value ~ /^[0-9]+$/ }
+function number(value) { return value ~ /^-?[0-9]+([.][0-9]+)?$/ }
+function abs(value) { return value < 0 ? -value : value }
+function max(value, floor) { return value < floor ? floor : value }
+
+function vector(value, target, count,    item, n, i, sum) {
+    n = split(value, item, "/")
+    if (n != count) fail()
+    sum = 0
+    for (i = 1; i <= n; i++) {
+        if (!number(item[i]) || item[i] < -0.0000001) fail()
+        target[i] = item[i] + 0
+        sum += target[i]
+    }
+    return sum
+}
+
+function entropy(value,    i, result) {
+    result = 0
+    for (i = 1; i <= 8; i++)
+        if (value[i] > 0) result -= value[i] * log(value[i])
+    return result
+}
+
+function ce(target, prediction,    i, result) {
+    result = 0
+    for (i = 1; i <= 8; i++)
+        result -= target[i] * log(max(prediction[i], 0.000001))
+    return result
+}
+
+function brier(target, prediction,    i, delta, result) {
+    result = 0
+    for (i = 1; i <= 8; i++) {
+        delta = target[i] - prediction[i]
+        result += delta * delta
+    }
+    return result
+}
+
+function transform(source, kind, parameter, result,
+                   i, j, best, total, selected_count) {
+    for (i = 1; i <= 8; i++) result[i] = 0
+    if (kind == "power") {
+        for (i = 1; i <= 8; i++) result[i] = source[i] ^ parameter
+    } else if (kind == "topk") {
+        for (i in chosen) delete chosen[i]
+        for (selected_count = 1; selected_count <= parameter; selected_count++) {
+            best = 0
+            for (i = 1; i <= 8; i++)
+                if (!(i in chosen) &&
+                    (!best || source[i] > source[best] + 0.000000000001 ||
+                     (abs(source[i] - source[best]) <= 0.000000000001 &&
+                      i < best)))
+                    best = i
+            if (!best) fail()
+            chosen[best] = 1
+            result[best] = source[best]
+        }
+    } else {
+        fail()
+    }
+    total = 0
+    for (i = 1; i <= 8; i++) total += result[i]
+    if (total <= 0) fail()
+    for (i = 1; i <= 8; i++) result[i] /= total
+}
+
+BEGIN {
+    FS = OFS = "\t"
+    if (!discovery_expected) discovery_expected = 12
+    if (!validation_expected) validation_expected = 15
+    if (!candidate_expected) candidate_expected = 8
+}
+
+FILENAME == ARGV[1] {
+    if (FNR == 1) {
+        if (NF != 4 || $1 != "candidate" || $2 != "kind" ||
+            $3 != "parameter" || $4 != "rank") fail()
+        next
+    }
+    if (NF != 4 || $1 !~ /^(power-[0-9]p[0-9]+|top-[1-8])$/ ||
+        candidate_seen[$1]++ || $2 !~ /^(power|topk)$/ ||
+        !number($3) || $3 <= 0 || !integer($4) || rank_seen[$4]++) fail()
+    if (($2 == "topk" && ($3 != int($3) || $3 > 8)) ||
+        ($2 == "power" && $3 <= 1)) fail()
+    candidates[++candidate_count] = $1
+    candidate_kind[$1] = $2
+    candidate_parameter[$1] = $3 + 0
+    candidate_rank[$1] = $4 + 0
+    next
+}
+
+FNR == 1 {
+    if (NF != 28 || $1 != "pair" || $5 != "split" ||
+        $9 != "transition" || $13 != "destination_prior" ||
+        $19 != "conditional_ce" || $28 != "reply") fail()
+    next
+}
+
+{
+    cohort = FILENAME == ARGV[2] ? "discovery" : "validation"
+    if (NF != 28 || $1 !~ /^[0-9][0-9]$/ ||
+        $2 !~ /^(event|ecology|organism)$/ ||
+        (cohort == "discovery" && $2 == "organism") ||
+        (cohort == "validation" && $2 != "organism") ||
+        $5 !~ /^(primary|holdout)$/ ||
+        (cohort == "discovery" && $5 != "primary") ||
+        !integer($6) || !integer($7) || $7 != $6 + 1 ||
+        $8 !~ /^(home|storm|wonder|social)$/ || $27 == "" || $28 == "" ||
+        witness_seen[cohort SUBSEP $2 SUBSEP $3]++) fail()
+
+    if (abs(vector($9, matrix, 64) - $14) > 0.00001 ||
+        abs(vector($10, source, 8) - 1) > 0.00001 ||
+        abs(vector($11, target, 8) - 1) > 0.00001 ||
+        abs(vector($12, raw_prediction, 8) - 1) > 0.00001 ||
+        abs(vector($13, destination, 8) - 1) > 0.00001) fail()
+    for (i = 14; i <= 26; i++) if (!number($i)) fail()
+
+    total = 0
+    raw_total = 0
+    for (i = 1; i <= 8; i++) {
+        row[i] = 0
+        column[i] = 0
+        rebuilt_raw[i] = 0
+    }
+    for (i = 1; i <= 8; i++)
+        for (j = 1; j <= 8; j++) {
+            edge = matrix[(i - 1) * 8 + j]
+            row[i] += edge
+            column[j] += edge
+            rebuilt_raw[j] += source[i] * edge
+            total += edge
+        }
+    for (j = 1; j <= 8; j++) raw_total += rebuilt_raw[j]
+    if (total <= 0 || raw_total <= 0 || abs(total - $14) > 0.00001) fail()
+    for (j = 1; j <= 8; j++) {
+        rebuilt_raw[j] /= raw_total
+        rebuilt_destination[j] = column[j] / total
+        if (abs(rebuilt_raw[j] - raw_prediction[j]) > 0.000002 ||
+            abs(rebuilt_destination[j] - destination[j]) > 0.000002) fail()
+    }
+
+    destination_entropy = entropy(destination)
+    information = 0
+    row_tv = 0
+    for (i = 1; i <= 8; i++) {
+        if (row[i] <= 0) continue
+        this_tv = 0
+        for (j = 1; j <= 8; j++) {
+            edge = matrix[(i - 1) * 8 + j]
+            if (edge > 0 && destination[j] > 0)
+                information += (edge / total) * log(edge / (row[i] * destination[j]))
+            this_tv += abs(edge / row[i] - destination[j])
+        }
+        row_tv += (row[i] / total) * 0.5 * this_tv
+    }
+    normalized_information = destination_entropy > 0 ? information / destination_entropy : 0
+    raw_ce = ce(target, raw_prediction)
+    destination_ce = ce(target, destination)
+    uniform_ce = 0
+    for (i = 1; i <= 8; i++) uniform[i] = 0.125
+    uniform_ce = ce(target, uniform)
+    persistence_ce = ce(target, source)
+    raw_brier = brier(target, raw_prediction)
+    destination_brier = brier(target, destination)
+    uniform_brier = brier(target, uniform)
+    persistence_brier = brier(target, source)
+    if (abs(destination_entropy - $15) > 0.000002 ||
+        abs(information - $16) > 0.000002 ||
+        abs(normalized_information - $17) > 0.000002 ||
+        abs(row_tv - $18) > 0.000002 || abs(raw_ce - $19) > 0.000002 ||
+        abs(destination_ce - $20) > 0.000002 ||
+        abs(uniform_ce - $21) > 0.000002 ||
+        abs(persistence_ce - $22) > 0.000002 ||
+        abs(raw_brier - $23) > 0.000002 ||
+        abs(destination_brier - $24) > 0.000002 ||
+        abs(uniform_brier - $25) > 0.000002 ||
+        abs(persistence_brier - $26) > 0.000002) fail()
+
+    if (!header++)
+        print "cohort", "case", "arm", "life", "split", "candidate", \
+            "kind", "parameter", "rank", "raw_ce", "candidate_ce", \
+            "destination_ce", "raw_brier", "candidate_brier", \
+            "destination_brier", "raw_ce_gain", "raw_brier_gain", \
+            "destination_ce_gain", "destination_brier_gain", \
+            "source_entropy", "target_entropy"
+    for (c = 1; c <= candidate_count; c++) {
+        candidate = candidates[c]
+        transform(source, candidate_kind[candidate],
+                  candidate_parameter[candidate], adjusted)
+        prediction_total = 0
+        for (j = 1; j <= 8; j++) {
+            prediction[j] = 0
+            for (i = 1; i <= 8; i++)
+                prediction[j] += adjusted[i] * matrix[(i - 1) * 8 + j]
+            prediction_total += prediction[j]
+        }
+        if (prediction_total <= 0) fail()
+        for (j = 1; j <= 8; j++) prediction[j] /= prediction_total
+        candidate_ce = ce(target, prediction)
+        candidate_brier = brier(target, prediction)
+        print cohort, $3, $2, $4, $5, candidate, \
+            candidate_kind[candidate], candidate_parameter[candidate], \
+            candidate_rank[candidate], sprintf("%.9f", raw_ce), \
+            sprintf("%.9f", candidate_ce), sprintf("%.9f", destination_ce), \
+            sprintf("%.9f", raw_brier), sprintf("%.9f", candidate_brier), \
+            sprintf("%.9f", destination_brier), \
+            sprintf("%.9f", raw_ce - candidate_ce), \
+            sprintf("%.9f", raw_brier - candidate_brier), \
+            sprintf("%.9f", destination_ce - candidate_ce), \
+            sprintf("%.9f", destination_brier - candidate_brier), \
+            sprintf("%.9f", entropy(source)), sprintf("%.9f", entropy(target))
+    }
+    cohort_rows[cohort]++
+}
+
+END {
+    if (fatal) exit 2
+    if (candidate_count != candidate_expected ||
+        cohort_rows["discovery"] != discovery_expected ||
+        cohort_rows["validation"] != validation_expected) fail()
+}

--- a/scripts/state_swarm_road_readout_select.awk
+++ b/scripts/state_swarm_road_readout_select.awk
@@ -1,0 +1,62 @@
+# A.96: nominate one readout using discovery only.
+
+function fail() { fatal = 1; exit 2 }
+function integer(value) { return value ~ /^[0-9]+$/ }
+function number(value) { return value ~ /^-?[0-9]+([.][0-9]+)?$/ }
+
+BEGIN {
+    FS = OFS = "\t"
+    if (!expected) expected = 12
+    if (!win_required) win_required = 8
+    if (!ce_required) ce_required = 0.005
+    if (!brier_required) brier_required = 0.000000001
+    if (!destination_required) destination_required = 0.015
+    if (!candidate_expected) candidate_expected = 8
+}
+
+NR == 1 {
+    if (NF != 17 || $1 != "candidate" || $5 != "cohort" ||
+        $9 != "ce_wins" || $12 != "mean_raw_ce_gain") fail()
+    next
+}
+
+$5 == "discovery" {
+    if (NF != 17 || seen[$1]++ || $2 !~ /^(power|topk)$/ ||
+        !number($3) || !integer($4) || $6 != expected ||
+        $7 != expected || $8 != 0) fail()
+    for (i = 9; i <= 17; i++) if (!number($i)) fail()
+    rows++
+    if ($9 >= win_required && $12 >= ce_required &&
+        $13 >= brier_required && $14 >= destination_required) {
+        if (!qualified || $12 > best_gain + 0.0000000005 ||
+            ($12 >= best_gain - 0.0000000005 && $4 < best_rank)) {
+            best_candidate = $1
+            best_kind = $2
+            best_parameter = $3
+            best_rank = $4
+            best_arms = $6
+            best_wins = $9
+            best_gain = $12
+            best_brier = $13
+            best_destination = $14
+        }
+        qualified++
+    }
+}
+
+END {
+    if (fatal) exit 2
+    if (rows != candidate_expected) fail()
+    print "candidate", "kind", "parameter", "rank", "discovery_arms", \
+        "discovery_ce_wins", "discovery_mean_raw_ce_gain", \
+        "discovery_mean_raw_brier_gain", \
+        "discovery_mean_destination_ce_gain", "qualified_candidates", "result"
+    if (qualified)
+        print best_candidate, best_kind, best_parameter, best_rank, best_arms, \
+            best_wins, best_gain, best_brier, best_destination, qualified, \
+            "candidate-nominated"
+    else
+        print "none", "none", 0, 0, expected, 0, "0.000000000", \
+            "0.000000000", "0.000000000", 0, \
+            "no-primary-readout-candidate"
+}

--- a/scripts/state_swarm_road_readout_summary.awk
+++ b/scripts/state_swarm_road_readout_summary.awk
@@ -1,0 +1,76 @@
+# A.96: summarize each fixed readout candidate by sealed cohort.
+
+function fail() { fatal = 1; exit 2 }
+function integer(value) { return value ~ /^[0-9]+$/ }
+function number(value) { return value ~ /^-?[0-9]+([.][0-9]+)?$/ }
+
+BEGIN {
+    FS = OFS = "\t"
+    if (!discovery_expected) discovery_expected = 12
+    if (!validation_expected) validation_expected = 15
+}
+
+NR == 1 {
+    if (NF != 21 || $1 != "cohort" || $6 != "candidate" ||
+        $16 != "raw_ce_gain" || $21 != "target_entropy") fail()
+    next
+}
+
+{
+    if (NF != 21 || $1 !~ /^(discovery|validation)$/ ||
+        $3 !~ /^(event|ecology|organism)$/ || $5 !~ /^(primary|holdout)$/ ||
+        $7 !~ /^(power|topk)$/ || !number($8) || !integer($9)) fail()
+    for (i = 10; i <= 21; i++) if (!number($i)) fail()
+    key = $6 SUBSEP $1
+    identity = $2 SUBSEP $3
+    if (seen[key SUBSEP identity]++) fail()
+    if (!(key in kind)) {
+        kind[key] = $7
+        parameter[key] = $8
+        rank[key] = $9
+        candidate_order[++candidate_count] = key
+    } else if (kind[key] != $7 || parameter[key] != $8 || rank[key] != $9) {
+        fail()
+    }
+    arms[key]++
+    split_arms[key SUBSEP $5]++
+    raw_ce_gain[key] += $16
+    raw_brier_gain[key] += $17
+    destination_ce_gain[key] += $18
+    destination_brier_gain[key] += $19
+    split_ce_gain[key SUBSEP $5] += $16
+    if ($16 > 0) ce_wins[key]++
+    else if ($16 < 0) ce_losses[key]++
+    else ce_ties[key]++
+}
+
+END {
+    if (fatal) exit 2
+    print "candidate", "kind", "parameter", "rank", "cohort", "arms", \
+        "primary_arms", "holdout_arms", "ce_wins", "ce_losses", \
+        "ce_ties", "mean_raw_ce_gain", "mean_raw_brier_gain", \
+        "mean_destination_ce_gain", "mean_destination_brier_gain", \
+        "primary_raw_ce_gain", "holdout_raw_ce_gain"
+    for (n = 1; n <= candidate_count; n++) {
+        key = candidate_order[n]
+        split(key, part, SUBSEP)
+        cohort = part[2]
+        expected = cohort == "discovery" ? discovery_expected : validation_expected
+        if (arms[key] != expected) fail()
+        primary_n = split_arms[key SUBSEP "primary"] + 0
+        holdout_n = split_arms[key SUBSEP "holdout"] + 0
+        if ((cohort == "discovery" &&
+             (primary_n != expected || holdout_n != 0)) ||
+            (cohort == "validation" &&
+             (!primary_n || !holdout_n || primary_n + holdout_n != expected)))
+            fail()
+        print part[1], kind[key], parameter[key], rank[key], cohort, arms[key], \
+            primary_n, holdout_n, ce_wins[key] + 0, ce_losses[key] + 0, \
+            ce_ties[key] + 0, sprintf("%.9f", raw_ce_gain[key] / arms[key]), \
+            sprintf("%.9f", raw_brier_gain[key] / arms[key]), \
+            sprintf("%.9f", destination_ce_gain[key] / arms[key]), \
+            sprintf("%.9f", destination_brier_gain[key] / arms[key]), \
+            sprintf("%.9f", split_ce_gain[key SUBSEP "primary"] / primary_n), \
+            sprintf("%.9f", holdout_n ? split_ce_gain[key SUBSEP "holdout"] / holdout_n : 0)
+    }
+}

--- a/scripts/state_swarm_road_readout_verdict.awk
+++ b/scripts/state_swarm_road_readout_verdict.awk
@@ -1,0 +1,100 @@
+# A.96: confirm the primary-selected readout on unused organism controls.
+
+function fail() { fatal = 1; exit 2 }
+function integer(value) { return value ~ /^[0-9]+$/ }
+function number(value) { return value ~ /^-?[0-9]+([.][0-9]+)?$/ }
+
+BEGIN {
+    FS = "\t"
+    if (!expected) expected = 15
+    if (!win_required) win_required = 10
+    if (!ce_required) ce_required = 0.005
+    if (!brier_required) brier_required = 0.001
+    if (!destination_required) destination_required = 0.015
+}
+
+FILENAME == ARGV[1] {
+    if (FNR == 1) {
+        if (NF != 11 || $1 != "candidate" || $11 != "result") fail()
+        next
+    }
+    if (FNR != 2 || selection_rows++) fail()
+    selected = $1
+    selected_kind = $2
+    selected_parameter = $3
+    selected_rank = $4
+    discovery_arms = $5
+    discovery_wins = $6
+    discovery_gain = $7
+    discovery_brier = $8
+    discovery_destination = $9
+    qualified = $10
+    selection_result = $11
+    next
+}
+
+FNR == 1 {
+    if (NF != 17 || $1 != "candidate" || $5 != "cohort" ||
+        $17 != "holdout_raw_ce_gain") fail()
+    next
+}
+
+$5 == "validation" && $1 == selected {
+    if (validation_rows++ || NF != 17 || $2 != selected_kind ||
+        $3 != selected_parameter || $4 != selected_rank || $6 != expected ||
+        !integer($9)) fail()
+    validation_arms = $6
+    primary_arms = $7
+    holdout_arms = $8
+    validation_wins = $9
+    validation_gain = $12
+    validation_brier = $13
+    validation_destination = $14
+    validation_destination_brier = $15
+    primary_gain = $16
+    holdout_gain = $17
+}
+
+END {
+    if (fatal) exit 2
+    if (selection_rows != 1) fail()
+    if (selection_result == "no-primary-readout-candidate") {
+        if (selected != "none" || qualified != 0) fail()
+        result = "no-primary-readout-candidate"
+    } else {
+        if (selection_result != "candidate-nominated" ||
+            selected == "none" || validation_rows != 1 ||
+            !primary_arms || !holdout_arms) fail()
+        if (validation_wins >= win_required && validation_gain >= ce_required &&
+            validation_brier >= brier_required &&
+            validation_destination >= destination_required &&
+            primary_gain > 0 && holdout_gain > 0)
+            result = "readout-dilution-supported"
+        else
+            result = "readout-sharpening-not-confirmed"
+    }
+
+    print "selected_candidate " selected
+    print "selected_kind " selected_kind
+    print "selected_parameter " selected_parameter
+    print "qualified_discovery_candidates " qualified
+    print "discovery_arms " discovery_arms
+    print "discovery_ce_wins " discovery_wins
+    print "discovery_mean_raw_ce_gain " discovery_gain
+    print "discovery_mean_raw_brier_gain " discovery_brier
+    print "discovery_mean_destination_ce_gain " discovery_destination
+    print "validation_arms " validation_arms + 0
+    print "validation_primary_arms " primary_arms + 0
+    print "validation_holdout_arms " holdout_arms + 0
+    print "validation_ce_wins " validation_wins + 0
+    print "validation_mean_raw_ce_gain " sprintf("%.9f", validation_gain + 0)
+    print "validation_mean_raw_brier_gain " sprintf("%.9f", validation_brier + 0)
+    print "validation_mean_destination_ce_gain " sprintf("%.9f", validation_destination + 0)
+    print "validation_primary_raw_ce_gain " sprintf("%.9f", primary_gain + 0)
+    print "validation_holdout_raw_ce_gain " sprintf("%.9f", holdout_gain + 0)
+    print "required_validation_ce_wins " win_required
+    print "required_validation_mean_raw_ce_gain " sprintf("%.9f", ce_required)
+    print "required_validation_mean_raw_brier_gain " sprintf("%.9f", brier_required)
+    print "required_validation_mean_destination_ce_gain " sprintf("%.9f", destination_required)
+    print "result " result
+}

--- a/scripts/test_state_swarm_road_readout_report.sh
+++ b/scripts/test_state_swarm_road_readout_report.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-road-readout-report.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+printf 'candidate\tkind\tparameter\trank\n' > "$TMP/candidates.tsv"
+printf 'power-2p00\tpower\t2.00\t1\n' >> "$TMP/candidates.tsv"
+printf 'top-1\ttopk\t1\t2\n' >> "$TMP/candidates.tsv"
+
+matrix() {
+    local kind="$1" out='' separator='' value
+    local i j
+    for ((i = 0; i < 8; i++)); do
+        for ((j = 0; j < 8; j++)); do
+            value=1
+            if [ "$kind" = identity ] && [ "$i" -ne "$j" ]; then
+                value=0
+            fi
+            out+="${separator}${value}"
+            separator='/'
+        done
+    done
+    printf '%s' "$out"
+}
+
+IDENTITY="$(matrix identity)"
+RANK_ONE="$(matrix rank-one)"
+SOURCE='0.7/0.3/0/0/0/0/0/0'
+TARGET='1/0/0/0/0/0/0/0'
+UNIFORM='0.125/0.125/0.125/0.125/0.125/0.125/0.125/0.125'
+HEADER='pair\tarm\tanchor\tlife\tsplit\tanchor_turn\tfuture_turn\ttexture\ttransition\tanchor_activation\ttarget_activation\tconditional_prediction\tdestination_prior\ttransition_total\tdestination_entropy\tmutual_information\tnormalized_mi\tmean_row_tv\tconditional_ce\tdestination_ce\tuniform_ce\tpersistence_ce\tconditional_brier\tdestination_brier\tuniform_brier\tpersistence_brier\tprompt\treply'
+
+write_witnesses() {
+    local kind="$1" discovery="$2" validation="$3"
+    local transition conditional total information nmi tv raw_ce raw_brier
+    printf '%b\n' "$HEADER" > "$discovery"
+    printf '%b\n' "$HEADER" > "$validation"
+    if [ "$kind" = identity ]; then
+        transition="$IDENTITY"
+        conditional="$SOURCE"
+        total=8
+        information=2.079441542
+        nmi=1.000000000
+        tv=0.875000000
+        raw_ce=0.356674944
+        raw_brier=0.180000000
+    else
+        transition="$RANK_ONE"
+        conditional="$UNIFORM"
+        total=64
+        information=0.000000000
+        nmi=0.000000000
+        tv=0.000000000
+        raw_ce=2.079441542
+        raw_brier=0.875000000
+    fi
+    witness() {
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\thome\t%s\t%s\t%s\t%s\t%s\t%s\t2.079441542\t%s\t%s\t%s\t%s\t2.079441542\t2.079441542\t0.356674944\t%s\t0.875000000\t0.875000000\t0.180000000\tprompt %s\treply %s\n' \
+            "$1" "$2" "$3" "$4" "$5" "$6" "$(( $6 + 1 ))" \
+            "$transition" "$SOURCE" "$TARGET" "$conditional" "$UNIFORM" \
+            "$total" "$information" "$nmi" "$tv" "$raw_ce" "$raw_brier" \
+            "$1" "$2"
+    }
+    witness 01 event d01 p01 primary 50 >> "$discovery"
+    witness 01 ecology d02 p02 primary 50 >> "$discovery"
+    witness 02 event d03 p03 primary 60 >> "$discovery"
+    witness 02 ecology d04 p04 primary 60 >> "$discovery"
+    witness 03 organism v01 p05 primary 50 >> "$validation"
+    witness 04 organism v02 p06 primary 50 >> "$validation"
+    witness 05 organism v03 h01 holdout 60 >> "$validation"
+    witness 06 organism v04 h02 holdout 60 >> "$validation"
+}
+
+run_pipeline() {
+    local discovery="$1" validation="$2" stem="$3"
+    awk -v candidate_expected=2 -v discovery_expected=4 \
+        -v validation_expected=4 \
+        -f "$ROOT/scripts/state_swarm_road_readout_report.awk" \
+        "$TMP/candidates.tsv" "$discovery" "$validation" \
+        > "$TMP/$stem-scores.tsv"
+    awk -v discovery_expected=4 -v validation_expected=4 \
+        -f "$ROOT/scripts/state_swarm_road_readout_summary.awk" \
+        "$TMP/$stem-scores.tsv" > "$TMP/$stem-summary.tsv"
+    awk -v candidate_expected=2 -v expected=4 -v win_required=3 \
+        -f "$ROOT/scripts/state_swarm_road_readout_select.awk" \
+        "$TMP/$stem-summary.tsv" > "$TMP/$stem-selection.tsv"
+    awk -v expected=4 -v win_required=3 \
+        -f "$ROOT/scripts/state_swarm_road_readout_verdict.awk" \
+        "$TMP/$stem-selection.tsv" "$TMP/$stem-summary.tsv" \
+        > "$TMP/$stem-verdict.txt"
+}
+
+write_witnesses identity "$TMP/supported-discovery.tsv" \
+    "$TMP/supported-validation.tsv"
+run_pipeline "$TMP/supported-discovery.tsv" \
+    "$TMP/supported-validation.tsv" supported
+grep -q $'^top-1\ttopk\t1\t2\t4\t4' "$TMP/supported-selection.tsv"
+grep -q '^result readout-dilution-supported$' "$TMP/supported-verdict.txt"
+
+write_witnesses rank-one "$TMP/rank-one-discovery.tsv" \
+    "$TMP/rank-one-validation.tsv"
+run_pipeline "$TMP/rank-one-discovery.tsv" \
+    "$TMP/rank-one-validation.tsv" rank-one
+grep -q $'^none\tnone' "$TMP/rank-one-selection.tsv"
+grep -q '^result no-primary-readout-candidate$' "$TMP/rank-one-verdict.txt"
+
+awk -F '\t' 'BEGIN { OFS=FS } NR == 2 { $19 = "0.500000000" } { print }' \
+    "$TMP/supported-discovery.tsv" > "$TMP/false-score.tsv"
+if awk -v candidate_expected=2 -v discovery_expected=4 \
+    -v validation_expected=4 \
+    -f "$ROOT/scripts/state_swarm_road_readout_report.awk" \
+    "$TMP/candidates.tsv" "$TMP/false-score.tsv" \
+    "$TMP/supported-validation.tsv" >/dev/null 2>&1; then
+    printf 'road readout reporter accepted a forged raw score\n' >&2
+    exit 1
+fi
+
+awk -F '\t' 'BEGIN { OFS=FS } NR == 2 { $2 = "event" } { print }' \
+    "$TMP/supported-validation.tsv" > "$TMP/false-cohort.tsv"
+if awk -v candidate_expected=2 -v discovery_expected=4 \
+    -v validation_expected=4 \
+    -f "$ROOT/scripts/state_swarm_road_readout_report.awk" \
+    "$TMP/candidates.tsv" "$TMP/supported-discovery.tsv" \
+    "$TMP/false-cohort.tsv" >/dev/null 2>&1; then
+    printf 'road readout reporter accepted a cohort leak\n' >&2
+    exit 1
+fi
+
+printf 'state-swarm road readout reporters: ok\n'


### PR DESCRIPTION
## What changed

- add the A.96 frozen state-road readout experiment
- select among eight fixed power/top-k source transforms using only 12 A.95 primary arms
- confirm the selected transform on 15 previously unscored A.91 organism controls
- independently reconstruct raw and transformed forecasts from complete 8x8 matrices and probability vectors
- add fail-closed identity-road, rank-one, forged-score, and cohort-leakage contracts
- record the canonical evidence and deterministic receipt

## Result

A.96 is `readout-sharpening-not-confirmed`. `power-3` passes discovery with 8/12 wins and `+0.007235 nat` mean gain over raw. On the sealed validation population it wins only 3/15 arms and loses `0.007808 nat`; both primary and holdout validation means are negative. All eight fixed transforms harm validation on average.

This rejects universal source sharpening. It does not authorize a temperature, power, top-k, runtime, persistence, routing, generation, or voice change. `leo.c` is unchanged.

## Validation

- `make test`: 549/549 C tests plus every script contract
- two aggregate-only passes preserve candidate-summary SHA-256 `ea02391667f990026695925d2c09c9a6593dddaafacd70219c71fa8f3586ceeb`
- verdict SHA-256 `f8ae9b99d2db6817b2f7d7507c7958546e7fb0ebeb980a0807d4795262394f56`
- `git diff --check`
- no diff in `leo.c`
