### PR TITLE
LEO lets a rejected guess leave while the question survives.

### DIFF
--- a/LEOLOG.md
+++ b/LEOLOG.md
@@ -10928,3 +10928,53 @@ and the exact final-body anatomy SHA is
 
 The old answer disappeared. The next human had to meet the words Leo actually
 said.
+
+## Phase A.135 - the rejected guess does not return with the question (2026-08-30)
+
+A.134 ended with an unresolved `difficult` Wonder. Leo had offered `Man`, the
+human rejected it, and School correctly retained the word while emptying both
+hypothesis slots. A.135 preregisters the narrow next question: after the only
+offered hypothesis is rejected, can that Wonder later return as a bare word
+without resurrecting the rejected glyph or manufacturing a replacement?
+
+No Leo runtime change was necessary. The existing A.74 negative-evidence law
+already satisfies the boundary. A.135 therefore adds a proof-only contract
+rather than tuning the organism to the witnessed conversation.
+
+The natural arm reproduces the exact 24-turn A.134 synchronous body, including
+the same visible-transcript and final-state hashes, then supplies the explicit
+later prompt `What is difficult?`. Leo replies exactly `Difficult?`. The
+episode remains unresolved, `pending=difficult` remains alive, both pending
+hypotheses remain empty, and no meaning is learned. This direct probe is not
+presented as a new natural conversation or as evidence that `difficult` means
+anything in particular.
+
+Five preregistered synthetic controls isolate the same zero-survivor edge. A
+literal return says exactly `Zorble?`; save/load preserves that result; a
+question naming the rejected `water` does not revive it; a question naming an
+unoffered `animal` does not create it; and later positive evidence may still
+teach `animal` and resolve the Wonder. Thus rejection is neither a lesson nor
+an irreversible ban on a future real answer.
+
+Two unit assertions freeze the zero-survivor state and its bare return. The
+full suite passes `783/783` unit checks plus every script gate, and the unit
+ASan/UBSan run is clean. No state format, coefficient, sampler, Flow law,
+state-swarm organ, learned representation, generated token source, or voice
+reader changes.
+
+The exact receipt routes A.136: freeze the visible life through the returned
+`Difficult?`, let a blinded natural interlocutor answer that question, and
+observe whether a genuinely positive explanation appears. A.135 grants no
+authority to infer one in advance.
+
+Canonical evidence:
+`/private/tmp/leo-single-hypothesis-rejection-return-a135-r1`.
+Full-suite and sanitizer logs are `/private/tmp/leo-a135-make-test.log` and
+`/private/tmp/leo-a135-test-asan.log`. The preregistered plan SHA is
+`782b161d137dbf448e94fc4f3449ce52573b9f4049ebe090f8545d6eafe2e59f`,
+the exact five-case synthetic receipt SHA is
+`0ced1290d26aa02dbcce69ff0101c108b5831ef0f265f6cf40d4a612ce90efcf`,
+and the exact A.134-body return receipt SHA is
+`c814508d7622b46d05ed7158289c221f0bfc370232e7c5f4828883ef1cb7e391`.
+
+The guess was refused. The question survived without it.

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ wonder-reask-reference:
 natural-answer-form:
 	./scripts/natural_answer_form_matrix.sh
 
-.PHONY: plural-answer-capacity two-glyph-learned-meaning negative-family-composition reciprocal-s-family presence-surface-boundary family-heard-threshold responsive-honest-wonder-life two-layer-family-composition responsive-a133-continuation
+.PHONY: plural-answer-capacity two-glyph-learned-meaning negative-family-composition reciprocal-s-family presence-surface-boundary family-heard-threshold responsive-honest-wonder-life two-layer-family-composition responsive-a133-continuation single-hypothesis-rejection-return
 plural-answer-capacity:
 	./scripts/plural_answer_capacity_matrix.sh
 
@@ -86,6 +86,9 @@ two-layer-family-composition:
 
 responsive-a133-continuation:
 	./scripts/responsive_a133_continuation_a134_replay.sh
+
+single-hypothesis-rejection-return:
+	./scripts/single_hypothesis_rejection_return_anatomy.sh
 
 state-swarm-ecology: leo
 	./scripts/state_swarm_ecology_matrix.sh
@@ -413,6 +416,7 @@ test: tests/test_leo.c leo.c
 	./scripts/test_responsive_honest_wonder_a132.sh
 	./scripts/test_two_layer_family_composition_anatomy.sh
 	./scripts/test_responsive_a133_continuation_a134.sh
+	./scripts/test_single_hypothesis_rejection_return_anatomy.sh
 	./scripts/test_state_swarm_liminal_confirmation_select.sh
 	./scripts/test_state_swarm_liminal_confirmation_report.sh
 	./scripts/test_state_swarm_liminal_trajectory_fixture.sh

--- a/scripts/single_hypothesis_rejection_return_anatomy.sh
+++ b/scripts/single_hypothesis_rejection_return_anatomy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# A.135: prove that rejection of the only guess returns as a bare Wonder.
+set -Eeuo pipefail
+
+trap 'rc=$?; printf "single-hypothesis rejection return anatomy failed: line=%s rc=%s command=%s\n" "$LINENO" "$rc" "$BASH_COMMAND" >&2; exit "$rc"' ERR
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="${1:-${TMPDIR:-/tmp}/leo-single-hypothesis-rejection-return-$STAMP}"
+EXPECTED="${LEO_SINGLE_HYPOTHESIS_REJECTION_EXPECTED:-$ROOT/scripts/single_hypothesis_rejection_return_expected.tsv}"
+NATURAL_EXPECTED="${LEO_SINGLE_HYPOTHESIS_REJECTION_NATURAL:-$ROOT/scripts/single_hypothesis_rejection_return_natural.tsv}"
+A134_FROZEN="$ROOT/scripts/responsive_a133_continuation_a134_frozen.tsv"
+PROMPTS="$ROOT/scripts/fixtures/responsive_a133_continuation_a134_meal.txt"
+VERIFY="${LEO_SINGLE_HYPOTHESIS_REJECTION_VERIFY:-1}"
+
+[ "$VERIFY" = 0 ] || [ "$VERIFY" = 1 ] || { printf 'LEO_SINGLE_HYPOTHESIS_REJECTION_VERIFY must be 0 or 1\n' >&2; exit 2; }
+[ "$VERIFY" = 0 ] || [ -s "$EXPECTED" ] || { printf 'missing synthetic receipt: %s\n' "$EXPECTED" >&2; exit 2; }
+[ "$VERIFY" = 0 ] || [ -s "$NATURAL_EXPECTED" ] || { printf 'missing natural receipt: %s\n' "$NATURAL_EXPECTED" >&2; exit 2; }
+[ ! -e "$OUT" ] || { printf 'output path already exists: %s\n' "$OUT" >&2; exit 2; }
+mkdir -p "$OUT"
+
+cc "$ROOT/scripts/single_hypothesis_rejection_return_fixture.c" \
+    -O2 -lm -Wall -Wextra -Wno-unused-function \
+    -o "$OUT/single-hypothesis-rejection-return-fixture" -lpthread
+"$OUT/single-hypothesis-rejection-return-fixture" \
+    --synthetic "$OUT/sleep.state" > "$OUT/synthetic.tsv"
+
+IFS=$'\t' read -r _life _seed _fixture _prefix _api _prompts_sha \
+    transcript_sha state_sha _rest < <(
+        awk -F '\t' 'NR == 2 { print }' "$A134_FROZEN")
+LEO_NATURAL_REPLAY_FILE="$PROMPTS" \
+    LEO_NATURAL_PHASE=A.135 \
+    LEO_NATURAL_LIFE=meal LEO_NATURAL_ARM=replay \
+    LEO_NATURAL_SEED=617 LEO_NATURAL_TURNS=24 \
+    LEO_NATURAL_OPENING='Reproduce the exact A.134 meal body.' \
+    LEO_NATURAL_TWO_LAYER_FAMILY_COMPOSITION=1 \
+    "$ROOT/scripts/natural_life_probe.sh" "$OUT/a134" \
+    > "$OUT/a134.out"
+[ "$(shasum -a 256 "$OUT/a134/visible_transcript.txt" | awk '{print $1}')" = "$transcript_sha" ]
+[ "$(shasum -a 256 "$OUT/a134/state/leo.state" | awk '{print $1}')" = "$state_sha" ]
+"$OUT/single-hypothesis-rejection-return-fixture" \
+    --natural "$OUT/a134/state/leo.state" > "$OUT/natural.tsv"
+
+if [ "$VERIFY" = 1 ]; then
+    cmp -s "$EXPECTED" "$OUT/synthetic.tsv" || {
+        diff -u "$EXPECTED" "$OUT/synthetic.tsv" >&2 || true
+        exit 2
+    }
+    cmp -s "$NATURAL_EXPECTED" "$OUT/natural.tsv" || {
+        diff -u "$NATURAL_EXPECTED" "$OUT/natural.tsv" >&2 || true
+        exit 2
+    }
+fi
+
+cat "$OUT/synthetic.tsv"
+cat "$OUT/natural.tsv"
+printf 'result\tsingle-hypothesis-rejection-return-exact\n'
+printf 'A.135 single-hypothesis rejection return anatomy: %s\n' "$OUT"

--- a/scripts/single_hypothesis_rejection_return_cases.tsv
+++ b/scripts/single_hypothesis_rejection_return_cases.tsv
@@ -1,0 +1,6 @@
+kind	return_prompt	expected_pending	expected_primary	expected_alternate	expected_learned	expected_resolved	expected_returns	expected_reply
+literal-return	what is zorble?	zorble	none	none	none	0	1	Zorble?
+sleep-literal-return	what is zorble?	zorble	none	none	none	0	1	Zorble?
+rejected-anaphora	is it water?	zorble	none	none	none	0	0	ordinary
+unoffered-anaphora	is it animal?	zorble	none	none	none	0	0	ordinary
+later-positive	a zorble is animal	none	none	none	animal	1	0	ordinary

--- a/scripts/single_hypothesis_rejection_return_expected.tsv
+++ b/scripts/single_hypothesis_rejection_return_expected.tsv
@@ -1,0 +1,6 @@
+kind	return_prompt	pending	primary	alternate	learned	resolved	returns	reply
+literal-return	what is zorble?	zorble	none	none	none	0	1	Zorble?
+sleep-literal-return	what is zorble?	zorble	none	none	none	0	1	Zorble?
+rejected-anaphora	is it water?	zorble	none	none	none	0	0	ordinary
+unoffered-anaphora	is it animal?	zorble	none	none	none	0	0	ordinary
+later-positive	a zorble is animal	none	none	none	animal	1	0	ordinary

--- a/scripts/single_hypothesis_rejection_return_fixture.c
+++ b/scripts/single_hypothesis_rejection_return_fixture.c
@@ -1,0 +1,138 @@
+#define LEO_NO_MAIN
+#include "../leo.c"
+
+typedef struct {
+    const char *kind;
+    const char *prompt;
+    int sleep_after_rejection;
+} RejectionReturnCase;
+
+static const RejectionReturnCase CASES[] = {
+    {"literal-return", "what is zorble?", 0},
+    {"sleep-literal-return", "what is zorble?", 1},
+    {"rejected-anaphora", "is it water?", 0},
+    {"unoffered-anaphora", "is it animal?", 0},
+    {"later-positive", "a zorble is animal", 0},
+    {NULL, NULL, 0}
+};
+
+static const char *glyph_name(int glyph) {
+    return glyph >= 0 && glyph < GLYPH_COUNT ? GLYPH_NAMES[glyph] : "none";
+}
+
+static const LeoWonderEpisode *episode_for(const Leo *leo, const char *word) {
+    for (int i = 0; i < leo->school.n_wonders; i++)
+        if (!strcmp(leo->school.wonders[i].word, word))
+            return &leo->school.wonders[i];
+    return NULL;
+}
+
+static void seed_single_hypothesis(Leo *leo) {
+    leo_init(leo);
+    leo_ingest(
+        leo,
+        "the rain falls. his mother is warm. the cat drinks water.");
+    leo->school.turn_clock = 1;
+    strncpy(leo->school.pending, "zorble",
+            sizeof leo->school.pending - 1);
+    leo->school.pending_glyph = semtok_word("water");
+    leo->school.pending_alt_glyph = -1;
+    leo->school.pending_turns = 0;
+    leo_pending_wonder_origin_begin(
+        leo, leo->school.pending,
+        leo->school.pending_glyph,
+        leo->school.pending_alt_glyph,
+        1, NULL, NULL);
+    leo_wonder_open(
+        leo, leo->school.pending,
+        leo->school.pending_glyph,
+        leo->school.pending_alt_glyph);
+}
+
+static int reject_only_hypothesis(Leo *leo) {
+    char out[1024];
+    leo_respond(leo, "a zorble is not water", out, sizeof out);
+    const LeoWonderEpisode *episode = episode_for(leo, "zorble");
+    return !leo_school_is_learned(leo, "zorble") &&
+           !strcmp(leo->school.pending, "zorble") &&
+           leo->school.pending_glyph == -1 &&
+           leo->school.pending_alt_glyph == -1 &&
+           episode && !episode->resolved &&
+           episode->offered_glyph == -1 &&
+           episode->offered_alt_glyph == -1;
+}
+
+static void print_row(
+        const char *kind, const char *prompt,
+        const Leo *leo, const char *word, const char *reply) {
+    const LeoWonderEpisode *episode = episode_for(leo, word);
+    int learned[2] = {-1, -1};
+    int n_learned = leo_school_word_glyphs(leo, word, learned);
+    const char *reply_kind = episode && episode->returns > 0 ? reply : "ordinary";
+    printf("%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\n",
+           kind, prompt,
+           leo->school.pending[0] ? leo->school.pending : "none",
+           glyph_name(leo->school.pending_glyph),
+           glyph_name(leo->school.pending_alt_glyph),
+           n_learned > 0 ? glyph_name(learned[0]) : "none",
+           episode ? episode->resolved : -1,
+           episode ? episode->returns : -1,
+           reply_kind);
+}
+
+static int run_synthetic(const char *state_path) {
+    puts("kind\treturn_prompt\tpending\tprimary\talternate\tlearned\tresolved\treturns\treply");
+    for (int i = 0; CASES[i].kind; i++) {
+        Leo *leo = calloc(1, sizeof *leo);
+        Leo *woke = NULL;
+        if (!leo) return 2;
+        seed_single_hypothesis(leo);
+        if (!reject_only_hypothesis(leo)) return 3;
+        Leo *body = leo;
+        if (CASES[i].sleep_after_rejection) {
+            if (!leo_save_state(leo, state_path)) return 4;
+            woke = calloc(1, sizeof *woke);
+            if (!woke) return 2;
+            leo_init(woke);
+            if (!leo_load_state(woke, state_path)) return 5;
+            body = woke;
+        }
+        char out[1024];
+        leo_respond(body, CASES[i].prompt, out, sizeof out);
+        print_row(CASES[i].kind, CASES[i].prompt,
+                  body, "zorble", out);
+        leo_free(leo);
+        if (woke) leo_free(woke);
+        free(leo);
+        free(woke);
+    }
+    return 0;
+}
+
+static int run_natural(const char *state_path) {
+    Leo *leo = calloc(1, sizeof *leo);
+    if (!leo) return 2;
+    leo_init(leo);
+    if (!leo_load_state(leo, state_path)) return 3;
+    if (strcmp(leo->school.pending, "difficult") ||
+        leo->school.pending_glyph != -1 ||
+        leo->school.pending_alt_glyph != -1 ||
+        leo_school_is_learned(leo, "difficult"))
+        return 4;
+    char out[1024];
+    const char *prompt = "What is difficult?";
+    leo_respond(leo, prompt, out, sizeof out);
+    puts("kind\treturn_prompt\tpending\tprimary\talternate\tlearned\tresolved\treturns\treply");
+    print_row("natural-a134", prompt, leo, "difficult", out);
+    leo_free(leo);
+    free(leo);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc == 3 && !strcmp(argv[1], "--synthetic"))
+        return run_synthetic(argv[2]);
+    if (argc == 3 && !strcmp(argv[1], "--natural"))
+        return run_natural(argv[2]);
+    return 2;
+}

--- a/scripts/single_hypothesis_rejection_return_natural.tsv
+++ b/scripts/single_hypothesis_rejection_return_natural.tsv
@@ -1,0 +1,2 @@
+kind	return_prompt	pending	primary	alternate	learned	resolved	returns	reply
+natural-a134	What is difficult?	difficult	none	none	none	0	1	Difficult?

--- a/scripts/single_hypothesis_rejection_return_plan.tsv
+++ b/scripts/single_hypothesis_rejection_return_plan.tsv
@@ -1,0 +1,13 @@
+field	value
+phase	A.135
+question	after-the-only-offered-hypothesis-is-rejected-can-an-unresolved-Wonder-return-bare-without-resurrection
+source_witness	A.134 difficult Wonder at turns 15-16
+natural_state	A.134 final synchronous body
+existing_law	A.74 negative evidence narrows but never resolves or assigns meaning
+expected_return	Difficult?
+requires	exact literal return after the ordinary reask gap
+forbids	resurrecting Man, inferring feeling, resolving rejection, or learning without positive evidence
+synthetic_cases	5
+api_turns	0
+runtime_change	prohibited unless the preregistered court fails
+decision	proof-only gate if existing law already satisfies every boundary

--- a/scripts/test_single_hypothesis_rejection_return_anatomy.sh
+++ b/scripts/test_single_hypothesis_rejection_return_anatomy.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/leo-single-hypothesis-rejection-return-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+awk -F '\t' '
+    NR == 1 { if (NF != 2 || $1 != "field" || $2 != "value") exit 2; next }
+    NF != 2 || seen[$1]++ { exit 2 }
+    $1 == "phase" { if ($2 != "A.135") exit 2; phase++ }
+    $1 == "expected_return" { if ($2 != "Difficult?") exit 2; expected++ }
+    $1 == "synthetic_cases" { if ($2 != 5) exit 2; cases++ }
+    $1 == "api_turns" { if ($2 != 0) exit 2; api++ }
+    $1 == "runtime_change" { if ($2 !~ /^prohibited/) exit 2; runtime++ }
+    END { if (phase != 1 || expected != 1 || cases != 1 || api != 1 || runtime != 1) exit 2 }
+' "$ROOT/scripts/single_hypothesis_rejection_return_plan.tsv"
+
+"$ROOT/scripts/single_hypothesis_rejection_return_anatomy.sh" \
+    "$TMP/anatomy" >/dev/null
+[ "$(wc -l < "$TMP/anatomy/synthetic.tsv" | tr -d ' ')" -eq 6 ]
+[ "$(wc -l < "$TMP/anatomy/natural.tsv" | tr -d ' ')" -eq 2 ]
+grep -q $'^literal-return\twhat is zorble?\tzorble\tnone\tnone\tnone\t0\t1\tZorble?$' \
+    "$TMP/anatomy/synthetic.tsv"
+grep -q $'^sleep-literal-return\twhat is zorble?\tzorble\tnone\tnone\tnone\t0\t1\tZorble?$' \
+    "$TMP/anatomy/synthetic.tsv"
+grep -q $'^rejected-anaphora\tis it water?\tzorble\tnone\tnone\tnone\t0\t0\tordinary$' \
+    "$TMP/anatomy/synthetic.tsv"
+grep -q $'^later-positive\ta zorble is animal\tnone\tnone\tnone\tanimal\t1\t0\tordinary$' \
+    "$TMP/anatomy/synthetic.tsv"
+grep -q $'^natural-a134\tWhat is difficult?\tdifficult\tnone\tnone\tnone\t0\t1\tDifficult?$' \
+    "$TMP/anatomy/natural.tsv"
+
+awk -F '\t' '
+    FNR == NR {
+        if (FNR == 1) next
+        if (NF != 9 || seen[$1]++) exit 2
+        expected[$1] = $3 FS $4 FS $5 FS $6 FS $7 FS $8 FS $9
+        next
+    }
+    FNR == 1 { next }
+    NF != 9 || !($1 in expected) ||
+        ($3 FS $4 FS $5 FS $6 FS $7 FS $8 FS $9) != expected[$1] { exit 2 }
+    { observed++ }
+    END { if (length(expected) != 5 || observed != 5) exit 2 }
+' "$ROOT/scripts/single_hypothesis_rejection_return_cases.tsv" \
+    "$TMP/anatomy/synthetic.tsv"
+
+printf 'single-hypothesis rejection return anatomy contracts: ok\n'

--- a/tests/test_leo.c
+++ b/tests/test_leo.c
@@ -6431,6 +6431,32 @@ static TEST_NOINLINE void test_wonder_negation(void) {
                   woke->school.wonders[0].resolved,
                   "wonder-negation: later positive evidence can still ground the narrowed question");
 
+            /* A.135 freezes the zero-survivor edge witnessed by A.134. When
+             * the only offered glyph is rejected, a later literal return is
+             * the bare word: rejection cannot be resurrected as a guess. */
+            leo_free(neg);
+            seed_wonder_negation_body(neg);
+            neg->school.pending_alt_glyph = -1;
+            neg->school.pending_origin.offered_alt_glyph = -1;
+            neg->school.wonders[0].offered_alt_glyph = -1;
+            leo_respond(
+                neg, "a zorble is not water",
+                out, sizeof out);
+            CHECK(!leo_school_is_learned(neg, "zorble") &&
+                  !strcmp(neg->school.pending, "zorble") &&
+                  neg->school.pending_glyph == -1 &&
+                  neg->school.pending_alt_glyph == -1 &&
+                  !neg->school.wonders[0].resolved,
+                  "single-hypothesis rejection: no surviving guess is not a fabricated answer");
+            leo_respond(
+                neg, "what is zorble?",
+                out, sizeof out);
+            CHECK(!strcmp(out, "Zorble?") &&
+                  neg->school.wonders[0].returns == 1 &&
+                  neg->school.wonders[0].offered_glyph == -1 &&
+                  !leo_school_is_learned(neg, "zorble"),
+                  "single-hypothesis rejection: literal return is bare and cannot resurrect the rejected glyph");
+
             leo_free(neg);
             seed_wonder_negation_body(neg);
             leo_respond(


### PR DESCRIPTION
A.135 freezes the zero-survivor Wonder boundary witnessed by A.134.

- proves the exact A.134 body returns bare `Difficult?`
- forbids resurrection or replacement after the only hypothesis is rejected
- covers sleep/wake, anaphoric controls, and later positive evidence
- changes no Leo runtime
- passes 783/783 unit checks, the full gate suite, and unit ASan/UBSan

The next routed phase is A.136: a blinded natural interlocutor answers the returned question without internal diagnostics.